### PR TITLE
Improve skill damage detection

### DIFF
--- a/generate_stats.py
+++ b/generate_stats.py
@@ -1,0 +1,208 @@
+import yaml
+import os
+import re
+from collections import defaultdict
+
+# Directory containing mob YAML files
+mobs_dir = 'mobs'
+skills_dir = 'skills'
+
+# Get all q1-q10 files for difficulties inf, hell, blood
+files = {}
+for q in range(1, 11):
+    for diff in ['inf', 'hell', 'blood']:
+        fname = f"q{q}_{diff}.yml"
+        path = os.path.join(mobs_dir, fname)
+        if os.path.exists(path):
+            files.setdefault(q, {})[diff] = path
+
+# Rarity detection
+
+def get_rarity(display):
+    if display is None:
+        return 'Unknown'
+    if '&4<&skull>' in display or '&4 <&skull>' in display:
+        return 'Boss'
+    if '&5&l' in display:
+        return 'Mini Boss'
+    if '&e&l' in display:
+        return 'Elite'
+    if '&l' in display:
+        return 'Normal'
+    return 'Unknown'
+
+rarity_order = ['Boss', 'Mini Boss', 'Elite', 'Normal', 'Unknown']
+
+# regex helpers for cleaning display names
+COLOR_CODE = re.compile(r'&[0-9a-fk-or]')
+BRACKET_HP = re.compile(r'\[[^\]]*caster\.hp[^\]]*\]')
+ANGLE = re.compile(r'<[^>]+>')
+
+def clean_name(display: str) -> str:
+    if not display:
+        return ''
+    name = COLOR_CODE.sub('', display)
+    name = BRACKET_HP.sub('', name)
+    name = ANGLE.sub('', name)
+    name = ' '.join(name.split())
+    return name.strip()
+
+# Collect data
+quests = defaultdict(lambda: defaultdict(list))
+mob_skill_map = defaultdict(list)
+
+# Load skills information
+skill_defs = {}
+for fname in os.listdir(skills_dir):
+    if not fname.endswith('.yml'):
+        continue
+    path = os.path.join(skills_dir, fname)
+    with open(path, 'r') as f:
+        try:
+            data = yaml.safe_load(f) or {}
+        except Exception:
+            # Fallback simple parser for non-standard YAML
+            f.seek(0)
+            data = {}
+            current = None
+            cooldown = None
+            actions = []
+            for line in f:
+                if not line.strip() or line.lstrip().startswith('#'):
+                    continue
+                if not line.startswith(' '):
+                    if current:
+                        data[current] = {'Cooldown': cooldown, 'Skills': actions}
+                    current = line.strip().rstrip(':')
+                    cooldown = None
+                    actions = []
+                else:
+                    l = line.strip()
+                    if l.startswith('Cooldown:'):
+                        try:
+                            cooldown = int(l.split(':',1)[1].strip())
+                        except ValueError:
+                            cooldown = None
+                    elif l.startswith('-'):
+                        actions.append(l[1:].strip())
+            if current:
+                data[current] = {'Cooldown': cooldown, 'Skills': actions}
+    for sname, sinfo in data.items():
+        if not isinstance(sinfo, dict):
+            continue
+        cd = sinfo.get('Cooldown')
+        lines = sinfo.get('Skills', [])
+        if isinstance(lines, str):
+            lines = [lines]
+        skill_defs[sname] = {'cooldown': cd, 'actions': lines}
+
+# Recursively compute damage of a skill, following references to other skills
+def compute_damage(name, visited=None):
+    if visited is None:
+        visited = set()
+    if name in visited:
+        return None
+    visited.add(name)
+    info = skill_defs.get(name)
+    if not info:
+        return None
+    dmg_pattern = re.compile(r'damage[^0-9{=]*[=\{][^0-9]*([0-9]+)')
+    max_dmg = None
+    for line in info.get('actions', []):
+        for m in dmg_pattern.finditer(str(line)):
+            val = int(m.group(1))
+            if max_dmg is None or val > max_dmg:
+                max_dmg = val
+        for ref in re.findall(r'(?:onHit|onTick|skill|skills?|s)[=:]([A-Za-z0-9_#-]+)', str(line)):
+            sub = ref.strip()
+            sub_dmg = compute_damage(sub, visited)
+            if sub_dmg is not None and (max_dmg is None or sub_dmg > max_dmg):
+                max_dmg = sub_dmg
+    return max_dmg
+
+# Final mapping of skills to cooldown and damage
+skill_info = {}
+for sname, sinfo in skill_defs.items():
+    skill_info[sname] = {
+        'cooldown': sinfo.get('cooldown'),
+        'damage': compute_damage(sname)
+    }
+
+for q, diffs in files.items():
+    for diff, path in diffs.items():
+        with open(path, 'r') as f:
+            data = yaml.safe_load(f)
+        for mob_id, info in data.items():
+            display = info.get('Display', '')
+            rarity = get_rarity(display)
+            clean = clean_name(display)
+            mob_entry = {
+                'name': clean,
+                'type': info.get('Type', ''),
+                'health': info.get('Health', ''),
+                'damage': info.get('Damage', ''),
+                'rarity': rarity
+            }
+            quests[q][diff].append(mob_entry)
+
+            skills_field = info.get('Skills')
+            if isinstance(skills_field, list):
+                for line in skills_field:
+                    for m in re.finditer(r's=([A-Za-z0-9_#-]+)', str(line)):
+                        mob_skill_map[(q, diff, clean)].append(m.group(1))
+        # Sort mobs by rarity order
+        quests[q][diff].sort(key=lambda m: rarity_order.index(m['rarity']))
+
+# Generate markdown
+lines = []
+lines.append('# Statystyki mobów dla Q1-Q10\n')
+lines.append('Plik automatycznie wygenerowany z konfiguracji MythicMobs.\n')
+for q in range(1, 11):
+    lines.append(f'\n## Q{q}\n')
+    for diff in ['inf', 'hell', 'blood']:
+        mobs = quests.get(q, {}).get(diff)
+        if not mobs:
+            continue
+        lines.append(f'\n### Poziom trudności: {diff}\n')
+        lines.append('| Nazwa | Typ | HP | DMG | Rzadkość |')
+        lines.append('|-------|-----|----|-----|----------|')
+        for m in mobs:
+            name = m['name'].replace('|', '\\|') if m['name'] else ''
+            lines.append(f"| {name} | {m['type']} | {m['health']} | {m['damage']} | {m['rarity']} |")
+
+# Write to file
+with open('mob_stats.md', 'w') as f:
+    f.write('\n'.join(lines))
+
+# Generate markdown for mob skills
+skills_lines = []
+skills_lines.append('# Umiejętności mobów dla Q1-Q10\n')
+skills_lines.append('Plik automatycznie wygenerowany z konfiguracji MythicMobs.\n')
+for q in range(1, 11):
+    skills_lines.append(f'\n## Q{q}\n')
+    for diff in ['inf', 'hell', 'blood']:
+        mobs = quests.get(q, {}).get(diff)
+        if not mobs:
+            continue
+        skills_lines.append(f'\n### Poziom trudności: {diff}\n')
+        skills_lines.append('| Mob | Skill | DMG | Cooldown |')
+        skills_lines.append('|-----|-------|-----|----------|')
+        for m in mobs:
+            key = (q, diff, m['name'])
+            mob_skills = mob_skill_map.get(key)
+            if not mob_skills:
+                skills_lines.append(f"| {m['name']} | - | - | - |")
+                continue
+            first = True
+            for s in mob_skills:
+                info = skill_info.get(s, {})
+                dmg = info.get('damage', '')
+                cd = info.get('cooldown', '')
+                if first:
+                    skills_lines.append(f"| {m['name']} | {s} | {dmg} | {cd} |")
+                    first = False
+                else:
+                    skills_lines.append(f"|  | {s} | {dmg} | {cd} |")
+
+with open('mob_skills.md', 'w') as f:
+    f.write('\n'.join(skills_lines))

--- a/mob_skills.md
+++ b/mob_skills.md
@@ -1,0 +1,674 @@
+# Umiejętności mobów dla Q1-Q10
+
+Plik automatycznie wygenerowany z konfiguracji MythicMobs.
+
+
+## Q1
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Grimmag the Risen | TeleportToPlayer | None | 15 |
+|  | BurningShotElite | 300 | 30 |
+|  | SummonFlamecultServants | None | 60 |
+| Perral World Dragonknight | CatapultProjectile | 200 | 15 |
+| Raazghul the Corruptor | SummonServants | None | 30 |
+|  | ExplosiveFireball | 300 | 15 |
+| Flamecult Worshipper | SummonServants | None | 30 |
+|  | PowerfulProjectile | 100 | 10 |
+| Flamecult Servant | - | - | - |
+| Flamecult Archer | - | - | - |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Grimmag the Risen | TeleportToPlayer | None | 15 |
+|  | BurningShotElite | 300 | 30 |
+|  | SummonFlamecultServants_hell | None | 60 |
+| Perral World Dragonknight | CatapultProjectile | 200 | 15 |
+| Raazghul the Corruptor | SummonServants_hell | None | 30 |
+|  | ExplosiveFireball | 300 | 15 |
+| Flamecult Worshipper | SummonServants_hell | None | 30 |
+|  | PowerfulProjectile | 100 | 10 |
+| Flamecult Servant | - | - | - |
+| Flamecult Archer | - | - | - |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Grimmag the Risen | TeleportToPlayer | None | 15 |
+|  | BurningShotElite | 300 | 30 |
+|  | SummonFlamecultServants_blood | None | 60 |
+| Perral World Dragonknight | CatapultProjectile | 200 | 15 |
+| Raazghul the Corruptor | SummonServants_blood | None | 30 |
+|  | ExplosiveFireball | 300 | 15 |
+| Flamecult Worshipper | SummonServants_blood | None | 30 |
+|  | PowerfulProjectile | 100 | 10 |
+| Flamecult Servant | - | - | - |
+| Flamecult Archer | - | - | - |
+
+## Q2
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Arachna, Scourge of Duria | WebShot_inf | 100 | 10 |
+|  | VenomSpit_inf | 150 | 15 |
+|  | FallingPoisonSphere_inf | 0 | 15 |
+|  | SummonPoisonousSpiders_inf | None | 25 |
+| Xerib the Hunchback | SummoningSphereXerib_inf | None | 20 |
+|  | PoisonMagicProjectile_inf | 60 | 10 |
+|  | FallingPoisonSphere_inf | 0 | 15 |
+| Archus the Mad | ThrowStone_inf | 150 | 12 |
+| Corrupted Root Creature | VineChase_inf | 100 | 15 |
+| Gremlin Marauder | - | - | - |
+| Death Witch | MagicProjectile_inf | 40 | 5 |
+|  | SummonSphere_inf | None | 15 |
+| Poisonous Spider | - | - | - |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Arachna, Scourge of Duria | WebShot_hell | 200 | 8 |
+|  | VenomSpit_hell | 300 | 12 |
+|  | FallingPoisonSphere_hell | 0 | 12 |
+|  | SummonPoisonousSpiders_hell | None | 22 |
+| Xerib the Hunchback | SummoningSphereXerib_hell | None | 18 |
+|  | PoisonMagicProjectile_hell | 120 | 8 |
+|  | FallingPoisonSphere_hell | 0 | 12 |
+| Archus the Mad | ThrowStone_hell | 300 | 10 |
+| Corrupted Root Creature | VineChase_hell | 200 | 12 |
+| Gremlin Marauder | - | - | - |
+| Death Witch | MagicProjectile_hell | 80 | 4 |
+|  | SummonSphere_hell | None | 12 |
+| Poisonous Spider | - | - | - |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Arachna, Scourge of Duria | WebShot_blood | 500 | 6 |
+|  | VenomSpit_blood | 750 | 10 |
+|  | FallingPoisonSphere_blood | 0 | 10 |
+|  | SummonPoisonousSpiders_blood | None | 18 |
+| Xerib the Hunchback | SummoningSphereXerib_blood | None | 15 |
+|  | PoisonMagicProjectile_blood | 300 | 6 |
+|  | FallingPoisonSphere_blood | 0 | 10 |
+| Archus the Mad | ThrowStone_blood | 750 | 8 |
+| Corrupted Root Creature | VineChase_blood | 500 | 10 |
+| Gremlin Marauder | - | - | - |
+| Death Witch | MagicProjectile_blood | 200 | 3 |
+|  | SummonSphere_blood | None | 10 |
+| Poisonous Spider | - | - | - |
+
+## Q3
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Undead King Heredur | FrostExplosion | 200 | 15 |
+|  | SummonUndead | None | 25 |
+|  | DeathBeam | 500 | 20 |
+| Parallel World Evil Miller | SummonVillagers | None | 30 |
+|  | IceBall | 150 | 8 |
+|  | FrostExplosion | 200 | 15 |
+| The Bloody Arrow | BlindingShot | 150 | 12 |
+|  | SlowingTrap | None | 15 |
+| Cursed Troll | ThrowBoulder | 200 | 10 |
+| Slain Assassin | - | - | - |
+| Cursed Farmer | - | - | - |
+| Cursed Archer | - | - | - |
+| Slain Warrior | - | - | - |
+| Slain Archer | - | - | - |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Undead King Heredur | FrostExplosion_hell | 400 | 15 |
+|  | SummonUndead_hell | None | 25 |
+|  | DeathBeam_hell | 1000 | 20 |
+| Parallel World Evil Miller | SummonVillagers_hell | None | 30 |
+|  | IceBall_hell | 300 | 8 |
+|  | FrostExplosion_hell | 400 | 15 |
+| The Bloody Arrow | BlindingShot_hell | 300 | 12 |
+|  | SlowingTrap_hell | None | 15 |
+| Cursed Troll | ThrowBoulder_hell | 400 | 10 |
+| Slain Assassin | - | - | - |
+| Cursed Farmer | - | - | - |
+| Cursed Archer | - | - | - |
+| Slain Warrior | - | - | - |
+| Slain Archer | - | - | - |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Undead King Heredur | FrostExplosion_blood | 1000 | 15 |
+|  | SummonUndead_blood | None | 25 |
+|  | DeathBeam_blood | 2500 | 20 |
+| Parallel World Evil Miller | SummonVillagers_blood | None | 30 |
+|  | IceBall_blood | 750 | 8 |
+|  | FrostExplosion_blood | 1000 | 15 |
+| The Bloody Arrow | BlindingShot_blood | 750 | 12 |
+|  | SlowingTrap_blood | None | 15 |
+| Cursed Troll | ThrowBoulder_blood | 1000 | 10 |
+| Slain Assassin | - | - | - |
+| Cursed Farmer | - | - | - |
+| Cursed Archer | - | - | - |
+| Slain Warrior | - | - | - |
+| Slain Archer | - | - | - |
+
+## Q4
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Bearach, Champion of the Wilds | BearachRotation_inf | 200 | None |
+| Parallel World Ancient Stag | SummonHoundPack | None | 45 |
+|  | PowerShot | 200 | 15 |
+| Ulgar the Master Butcher | TransformPhase2_inf | None | None |
+|  | TransformPhase3_inf | None | None |
+|  | DeathExplosion_inf | 300 | None |
+| Ulgar the Master Butcher | TransformPhase2_inf | None | None |
+|  | TransformPhase3_inf | None | None |
+|  | DeathExplosion_inf | 300 | None |
+| Ulgar the Master Butcher | TransformPhase2_inf | None | None |
+|  | TransformPhase3_inf | None | None |
+|  | DeathExplosion_inf | 300 | None |
+| Sanguine Clan`s Raging Snooper | - | - | - |
+| Sanguine Clan`s Raging Hunter | SummonHounds | None | 30 |
+| Eternal Root Creature | - | - | - |
+| Eternal Hunter | SummonEternalHounds_inf | None | 30 |
+| Sanguine Clan`s Raging Guardian | - | - | - |
+| Raging Hunting-Hound | - | - | - |
+| Eternal Satyr Warrior | - | - | - |
+| Eternal Hunting-Hound | - | - | - |
+| Lightning Wolf | ShootLightning_inf | 150 | 10 |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Bearach, Champion of the Wilds | BearachRotation_hell | 350 | None |
+| Parallel World Ancient Stag | SummonHoundPack_hell | None | 45 |
+|  | PowerShot_hell | 400 | 15 |
+| Ulgar the Master Butcher | TransformPhase2_hell | None | None |
+|  | TransformPhase3_hell | None | None |
+|  | DeathExplosion_hell | 600 | 1 |
+| Ulgar the Master Butcher | TransformPhase2_hell | None | None |
+|  | TransformPhase3_hell | None | None |
+|  | DeathExplosion_hell | 600 | 1 |
+| Ulgar the Master Butcher | TransformPhase2_hell | None | None |
+|  | TransformPhase3_hell | None | None |
+|  | DeathExplosion_hell | 600 | 1 |
+| Sanguine Clan`s Raging Snooper | - | - | - |
+| Sanguine Clan`s Raging Hunter | SummonHounds_hell | None | 30 |
+| Eternal Root Creature | - | - | - |
+| Eternal Hunter | SummonEternalHounds_hell | None | 30 |
+| Sanguine Clan`s Raging Guardian | - | - | - |
+| Raging Hunting-Hound | - | - | - |
+| Eternal Satyr Warrior | - | - | - |
+| Eternal Hunting-Hound | - | - | - |
+| Lightning Wolf | ShootLightning_hell | 300 | 10 |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Bearach, Champion of the Wilds | BearachRotation_blood | 600 | None |
+| Parallel World Ancient Stag | SummonHoundPack_blood | None | 45 |
+|  | PowerShot_blood | 1000 | 15 |
+| Ulgar the Master Butcher | TransformPhase2_blood | None | None |
+|  | TransformPhase3_blood | None | None |
+|  | DeathExplosion_blood | 1500 | 1 |
+| Ulgar the Master Butcher | TransformPhase2_blood | None | None |
+|  | TransformPhase3_blood | None | None |
+|  | DeathExplosion_blood | 1500 | 1 |
+| Ulgar the Master Butcher | TransformPhase2_blood | None | None |
+|  | TransformPhase3_blood | None | None |
+|  | DeathExplosion_blood | 1500 | 1 |
+| Sanguine Clan`s Raging Snooper | - | - | - |
+| Sanguine Clan`s Raging Hunter | SummonHounds_blood | None | 30 |
+| Eternal Root Creature | - | - | - |
+| Eternal Hunter | SummonEternalHounds_blood | None | 30 |
+| Sanguine Clan`s Raging Guardian | - | - | - |
+| Raging Hunting-Hound | - | - | - |
+| Eternal Satyr Warrior | - | - | - |
+| Eternal Hunting-Hound | - | - | - |
+| Lightning Wolf | ShootLightning_blood | 750 | 10 |
+
+## Q5
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Khalys, Leader of the Cultists | SummonCopy_inf | None | 45 |
+|  | MagicMissile_inf | 200 | 10 |
+|  | Teleport_inf | None | 30 |
+|  | DeathBeam_inf | 0 | 20 |
+| Parallel World Old Jabbax Shaman | SummonMaggots_inf | None | 30 |
+|  | MeteorStrike_inf | 250 | 15 |
+| Wandering Experiment | RunFromPlayer_inf | None | 5 |
+| Furious Andermagic | FireballAttack_inf | 150 | 10 |
+| Wailing Andermagic Ghost | SlowAura_inf | None | 5 |
+|  | DamageAura_inf | 50 | 10 |
+| Andermagic Scoropitl | - | - | - |
+| Furious Maggot | - | - | - |
+| Furious Flagrancy | - | - | - |
+| Andermagic Guardian | - | - | - |
+| Living Andermagic | FireballAttack_inf | 150 | 10 |
+| Khalys Clone | MagicMissile_inf | 200 | 10 |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Khalys, Leader of the Cultists | SummonCopy_hell | None | 45 |
+|  | MagicMissile_hell | 400 | 10 |
+|  | Teleport_hell | None | 30 |
+|  | DeathBeam_hell | 1000 | 20 |
+| Parallel World Old Jabbax Shaman | SummonMaggots_hell | None | 30 |
+|  | MeteorStrike_hell | 600 | 15 |
+| Wandering Experiment | RunFromPlayer_hell | None | 5 |
+| Furious Andermagic | FireballAttack_hell | 300 | 10 |
+| Wailing Andermagic Ghost | SlowAura_hell | None | 5 |
+|  | DamageAura_hell | 100 | 10 |
+| Andermagic Scoropitl | - | - | - |
+| Furious Maggot | - | - | - |
+| Furious Flagrancy | - | - | - |
+| Andermagic Guardian | - | - | - |
+| Living Andermagic | FireballAttack_hell | 300 | 10 |
+| Khalys Clone | MagicMissile_hell | 400 | 10 |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Khalys, Leader of the Cultists | SummonCopy_blood | None | 45 |
+|  | MagicMissile_blood | 1000 | 10 |
+|  | Teleport_blood | None | 30 |
+|  | DeathBeam_blood | 2500 | 20 |
+| Parallel World Old Jabbax Shaman | SummonMaggots_blood | None | 30 |
+|  | MeteorStrike_blood | 1500 | 15 |
+| Wandering Experiment | RunFromPlayer_blood | None | 5 |
+| Furious Andermagic | FireballAttack_blood | 750 | 10 |
+| Wailing Andermagic Ghost | SlowAura_blood | None | 5 |
+|  | DamageAura_blood | 250 | 10 |
+| Andermagic Scoropitl | - | - | - |
+| Furious Maggot | - | - | - |
+| Furious Flagrancy | - | - | - |
+| Andermagic Guardian | - | - | - |
+| Living Andermagic | FireballAttack_blood | 750 | 10 |
+| Khalys Clone | MagicMissile_blood | 1000 | 10 |
+
+## Q6
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Skeledragon | DragonBreath | 200 | 15 |
+|  | SummonPhase2 | None | None |
+| Mortis & Skeledragon | DragonBreath | 200 | 15 |
+|  | ScytheWhirlwind | 400 | 20 |
+|  | SummonPhase3 | None | None |
+| Mortis, Unchained God of Death | ScytheWhirlwind | 400 | 20 |
+|  | DeathDash | 500 | 10 |
+|  | HealingPulse | None | 15 |
+|  | DeathZone | 99999 | 25 |
+|  | SummonDragon | None | 60 |
+| Mortis Death Knight | DeathExplosion | 300 | 1 |
+| Murot, High Priest of Mortis | MeteorStrike | 300 | 15 |
+|  | HomingOrb | 150 | 10 |
+| Death Knight | DeathExplosion | 300 | 1 |
+| Death Archer | WitheringShot | 200 | 10 |
+| Fallen Warrior | - | - | - |
+| Fallen Archer | - | - | - |
+| Elite Skeleton Archer | - | - | - |
+| Raging Soul | - | - | - |
+| Elite Skeleton Warrior | - | - | - |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Skeledragon | DragonBreath_hell | 400 | 15 |
+|  | SummonPhase2_hell | None | None |
+| Mortis & Skeledragon | DragonBreath_hell | 400 | 15 |
+|  | ScytheWhirlwind_hell | 800 | 20 |
+|  | SummonPhase3_hell | None | None |
+| Mortis, Unchained God of Death | ScytheWhirlwind_hell | 800 | 20 |
+|  | DeathDash_hell | 1000 | 10 |
+|  | HealingPulse_hell | None | 15 |
+|  | DeathZone_hell | 99999 | 25 |
+|  | SummonDragon_hell | None | 60 |
+| Mortis Death Knight | DeathExplosion_hell | 600 | 1 |
+| Murot, High Priest of Mortis | MeteorStrike_hell | 600 | 15 |
+|  | HomingOrb_hell | 300 | 10 |
+| Death Knight | DeathExplosion_hell | 600 | 1 |
+| Death Archer | WitheringShot_hell | 400 | 10 |
+| Fallen Warrior | - | - | - |
+| Fallen Archer | - | - | - |
+| Elite Skeleton Archer | - | - | - |
+| Raging Soul | - | - | - |
+| Elite Skeleton Warrior | - | - | - |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Skeledragon | DragonBreath_blood | 1000 | 15 |
+|  | SummonPhase2_blood | None | None |
+| Mortis & Skeledragon | DragonBreath_blood | 1000 | 15 |
+|  | ScytheWhirlwind_blood | 2000 | 20 |
+|  | SummonPhase3_blood | None | None |
+| Mortis, Unchained God of Death | ScytheWhirlwind_blood | 2000 | 20 |
+|  | DeathDash_blood | 2500 | 10 |
+|  | HealingPulse_blood | None | 15 |
+|  | HealingPulse_blood | None | 15 |
+|  | DeathZone_blood | 99999 | 25 |
+|  | SummonDragon_blood | None | 60 |
+| Mortis Death Knight | DeathExplosion_blood | 1500 | 1 |
+| Murot, High Priest of Mortis | MeteorStrike_blood | 1500 | 15 |
+|  | HomingOrb_blood | 750 | 10 |
+| Death Knight | DeathExplosion_blood | 1500 | 1 |
+| Death Archer | WitheringShot_blood | 1000 | 10 |
+| Fallen Warrior | - | - | - |
+| Fallen Archer | - | - | - |
+| Elite Skeleton Archer | - | - | - |
+| Raging Soul | - | - | - |
+| Elite Skeleton Warrior | - | - | - |
+
+## Q7
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Herald of the Anderworld | FlameStrike | 200 | 5 |
+|  | MeteorShower | 300 | 15 |
+|  | SummonFlamespawnsLarge | None | 30 |
+| Iron Creeper Gate Guard | LaserBeam | 100 | 10 |
+| Commander Embersword | SummonFlamespawns | None | 30 |
+|  | 60 |  |  |
+| Thundering Cyclops | ThunderStrike | 200 | 12 |
+| Dark Sentinel | DeathExplosion | 300 | 1 |
+| Fireclaw Mercenary | 60 |  |  |
+| Bone Warder | - | - | - |
+| B-1000 Combat Mechanoid | FlameAttack | 150 | 15 |
+| Wild Razorclaw | - | - | - |
+| Flamescale Defender | - | - | - |
+| Angry Flamespawn | - | - | - |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Herald of the Anderworld | FlameStrike_hell | 400 | 5 |
+|  | MeteorShower_hell | 600 | 15 |
+|  | SummonFlamespawnsLarge_hell | None | 30 |
+| Iron Creeper Gate Guard | LaserBeam_hell | 200 | 10 |
+| Commander Embersword | SummonFlamespawns_hell | None | 30 |
+|  | 80 |  |  |
+| Thundering Cyclops | ThunderStrike_hell | 400 | 12 |
+| Dark Sentinel | DeathExplosion_hell | 600 | 1 |
+| Fireclaw Mercenary | 80 |  |  |
+| Bone Warder | - | - | - |
+| B-1000 Combat Mechanoid | FlameAttack_hell | 300 | 15 |
+| Wild Razorclaw | - | - | - |
+| Flamescale Defender | - | - | - |
+| Angry Flamespawn | - | - | - |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Herald of the Anderworld | FlameStrike_blood | 1000 | 5 |
+|  | MeteorShower_blood | 1500 | 15 |
+|  | SummonFlamespawnsLarge_blood | None | 30 |
+| Iron Creeper Gate Guard | LaserBeam_blood | 500 | 10 |
+| Commander Embersword | SummonFlamespawns_blood | None | 30 |
+|  | 100 |  |  |
+| Thundering Cyclops | ThunderStrike_blood | 1000 | 12 |
+| Dark Sentinel | DeathExplosion_blood | 1500 | 1 |
+| Fireclaw Mercenary | 100 |  |  |
+| Bone Warder | - | - | - |
+| B-1000 Combat Mechanoid | FlameAttack_blood | 750 | 15 |
+| Wild Razorclaw | - | - | - |
+| Flamescale Defender | - | - | - |
+| Angry Flamespawn | - | - | - |
+
+## Q8
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Sigrismarr, Twisted Priest of Fjalnir | TripleIceBolt | 150 | 10 |
+|  | HomingIceSphere | 300 | 15 |
+|  | ImmunityPhase | None | None |
+|  | ImmunityPhase | None | None |
+| Shocking Forocity | LightningZone | 100 | 15 |
+|  | TeleportStrike | 200 | 20 |
+| Pale Enforcer | DashToPlayer | 150 | 12 |
+|  | SummonPillagers | None | 30 |
+| Big Heap of Ice | SummonIceHeaps | None | None |
+| Bloodthirsty Frostwolf | SummonDrones | None | 20 |
+| Frost Magician | FrostBolt | 200 | 8 |
+|  | IceStorm | 150 | 15 |
+| Frost Bringer | - | - | - |
+| Electrified Ferocity | LightningBolt | 150 | 10 |
+|  | TeleportToPlayer | None | 15 |
+| Charged Drone | - | - | - |
+| Pale Pillager | DashToPlayer | 150 | 12 |
+| Simple Troll | ThrowStunningStone | 100 | 15 |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Sigrismarr, Twisted Priest of Fjalnir | TripleIceBolt_hell | 300 | 10 |
+|  | HomingIceSphere_hell | 600 | 15 |
+|  | ImmunityPhase | None | None |
+|  | ImmunityPhase | None | None |
+| Shocking Forocity | LightningZone_hell | 200 | 15 |
+|  | TeleportStrike_hell | 400 | 20 |
+| Pale Enforcer | DashToPlayer_hell | 300 | 12 |
+|  | SummonPillagers_hell | None | 30 |
+| Big Heap of Ice | SummonIceHeaps_hell | None | None |
+| Bloodthirsty Frostwolf | SummonDrones_hell | None | 20 |
+| Frost Magician | FrostBolt_hell | 400 | 8 |
+|  | IceStorm_hell | 300 | 15 |
+| Frost Bringer | - | - | - |
+| Electrified Ferocity | LightningBolt_hell | 300 | 10 |
+|  | TeleportToPlayer_hell | None | 15 |
+| Charged Drone | - | - | - |
+| Pale Pillager | DashToPlayer_hell | 300 | 12 |
+| Simple Troll | ThrowStunningStone_hell | 200 | 15 |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Sigrismarr, Twisted Priest of Fjalnir | TripleIceBolt_blood | 750 | 10 |
+|  | HomingIceSphere_blood | 1500 | 15 |
+|  | ImmunityPhase | None | None |
+|  | ImmunityPhase | None | None |
+| Shocking Forocity | LightningZone_blood | 500 | 15 |
+|  | TeleportStrike_blood | 1000 | 20 |
+| Pale Enforcer | DashToPlayer_blood | 750 | 12 |
+|  | SummonPillagers_blood | None | 30 |
+| Big Heap of Ice | SummonIceHeaps_blood | None | None |
+| Bloodthirsty Frostwolf | SummonDrones_blood | None | 20 |
+| Frost Magician | FrostBolt_blood | 1000 | 8 |
+|  | IceStorm_blood | 750 | 15 |
+| Frost Bringer | - | - | - |
+| Electrified Ferocity | LightningBolt_blood | 750 | 10 |
+|  | TeleportToPlayer_blood | None | 15 |
+| Charged Drone | - | - | - |
+| Pale Pillager | DashToPlayer_blood | 750 | 12 |
+| Simple Troll | ThrowStunningStone_blood | 500 | 15 |
+
+## Q9
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| M`Edusa | PetrifyingGaze | None | 15 |
+|  | AcidSpit | 200 | 10 |
+|  | SummonSnakes | None | 20 |
+| Asterion | ChargeAttack | 200 | 12 |
+|  | GroundSlam | 150 | 15 |
+| Ebicarus | PowerfulStrike | 300 | 10 |
+| Cohort Swordsman | HealingPulse | None | 15 |
+| Stone Golem | ThrowBoulder | 200 | 10 |
+| Zorlobb Warrior | StunningBlow | 150 | 12 |
+| Minotaur | ChargeAttack | 200 | 12 |
+|  | GroundPound | 100 | 15 |
+| Agile Satyr Warrior | - | - | - |
+| Perfidious Satyr Archer | - | - | - |
+| Jabbax | - | - | - |
+| Gorgon Acolyte | PoisonBolt | 100 | 8 |
+|  | Petrify | None | 15 |
+| Poisonous Snake | SnakeExplosion | 150 | None |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| M`Edusa | PetrifyingGaze_hell | None | 15 |
+|  | AcidSpit_hell | 400 | 10 |
+|  | SummonSnakes_hell | None | 20 |
+| Asterion | ChargeAttack_hell | 400 | 12 |
+|  | GroundSlam_hell | 300 | 15 |
+| Ebicarus | PowerfulStrike_hell | 600 | 10 |
+| Cohort Swordsman | HealingPulse_hell | None | 15 |
+| Stone Golem | ThrowBoulder_hell | 400 | 10 |
+| Zorlobb Warrior | StunningBlow_hell | 300 | 12 |
+| Minotaur | ChargeAttack_hell | 400 | 12 |
+|  | GroundPound_hell | 200 | 15 |
+| Agile Satyr Warrior | - | - | - |
+| Perfidious Satyr Archer | - | - | - |
+| Jabbax | - | - | - |
+| Gorgon Acolyte | PoisonBolt_hell | 200 | 8 |
+|  | Petrify_hell | None | 15 |
+| Poisonous Snake | SnakeExplosion_hell | 300 | None |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| M`Edusa | PetrifyingGaze_blood | None | 15 |
+|  | AcidSpit_blood | 1000 | 10 |
+|  | SummonSnakes_blood | None | 20 |
+| Asterion | ChargeAttack_blood | 1000 | 12 |
+|  | GroundSlam_blood | 750 | 15 |
+| Ebicarus | PowerfulStrike_blood | 1500 | 10 |
+| Cohort Swordsman | HealingPulse_blood | None | 15 |
+| Stone Golem | ThrowBoulder_blood | 1000 | 10 |
+| Zorlobb Warrior | StunningBlow_blood | 750 | 12 |
+| Minotaur | ChargeAttack_blood | 1000 | 12 |
+|  | GroundPound_blood | 500 | 15 |
+| Agile Satyr Warrior | - | - | - |
+| Perfidious Satyr Archer | - | - | - |
+| Jabbax | - | - | - |
+| Gorgon Acolyte | PoisonBolt_blood | 500 | 8 |
+|  | Petrify_blood | None | 15 |
+| Poisonous Snake | SnakeExplosion_blood | 750 | None |
+
+## Q10
+
+
+### Poziom trudności: inf
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Gorga | SummonSnakes | None | 20 |
+|  | ScatteredShot | 150 | 10 |
+|  | MeleeAttack | 200 | None |
+|  | SummonReinforcements | None | None |
+| Melas the Swift-Footed | StunStrike | 150 | 15 |
+|  | LeapAttack | 150 | 10 |
+| Akheilos | PowerfulFlamingShot | 200 | 10 |
+| Scheming Gorgon | PetrifyingGaze | None | 15 |
+|  | VenomSpit | 150 | 10 |
+| Poisonous Jitterjelly | ShockAttack | 150 | 10 |
+|  | DeathExplosion | 300 | 1 |
+| Patrolling Jabbax | SummonJabbax | None | 15 |
+| Anderworld Jitterjelly | ShockAttack | 150 | 10 |
+|  | SmallDeathExplosion | 100 | None |
+| Combat-Ready Zorlobb | PowerfulStrike | 300 | 10 |
+| Anderworld Jabbax | - | - | - |
+| Armed Khaross | FlamingShot | 150 | 8 |
+| Mordacious Khaross | BurningStrike | 150 | 8 |
+| Venomous Snake | SnakeAttack | 100 | None |
+|  | SnakeExplosion | 150 | None |
+
+### Poziom trudności: hell
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Gorga | SummonSnakes_hell | None | 20 |
+|  | ScatteredShot_hell | 300 | 10 |
+|  | MeleeAttack_hell | 400 | None |
+|  | SummonReinforcements_hell | None | None |
+| Melas the Swift-Footed | StunStrike_hell | 300 | 15 |
+|  | LeapAttack_hell | 300 | 10 |
+| Akheilos | PowerfulFlamingShot_hell | 400 | 10 |
+| Scheming Gorgon | PetrifyingGaze_hell | None | 15 |
+|  | VenomSpit_hell | 300 | 12 |
+| Poisonous Jitterjelly | ShockAttack_hell | 300 | 10 |
+|  | DeathExplosion_hell | 600 | 1 |
+| Patrolling Jabbax | SummonJabbax_hell | None | 15 |
+| Anderworld Jitterjelly | ShockAttack_hell | 300 | 10 |
+|  | SmallDeathExplosion_hell | 200 | None |
+| Combat-Ready Zorlobb | PowerfulStrike_hell | 600 | 10 |
+| Anderworld Jabbax | - | - | - |
+| Armed Khaross | FlamingShot_hell | 300 | 8 |
+| Mordacious Khaross | BurningStrike_hell | 300 | 8 |
+| Venomous Snake | SnakeAttack_hell | 200 | None |
+|  | SnakeExplosion_hell | 300 | None |
+
+### Poziom trudności: blood
+
+| Mob | Skill | DMG | Cooldown |
+|-----|-------|-----|----------|
+| Gorga | SummonSnakes_blood | None | 20 |
+|  | ScatteredShot_blood | 750 | 10 |
+|  | MeleeAttack_blood | 1000 | None |
+|  | SummonReinforcements_blood | None | None |
+| Melas the Swift-Footed | StunStrike_blood | 750 | 15 |
+|  | LeapAttack_blood | 750 | 10 |
+| Akheilos | PowerfulFlamingShot_blood | 1000 | 10 |
+| Scheming Gorgon | PetrifyingGaze_blood | None | 15 |
+|  | VenomSpit_blood | 750 | 10 |
+| Poisonous Jitterjelly | ShockAttack_blood | 750 | 10 |
+|  | DeathExplosion_blood | 1500 | 1 |
+| Patrolling Jabbax | SummonJabbax_blood | None | 15 |
+| Anderworld Jitterjelly | ShockAttack_blood | 750 | 10 |
+|  | SmallDeathExplosion_blood | 500 | None |
+| Combat-Ready Zorlobb | PowerfulStrike_blood | 1500 | 10 |
+| Anderworld Jabbax | - | - | - |
+| Armed Khaross | FlamingShot_blood | 750 | 8 |
+| Mordacious Khaross | BurningStrike_blood | 750 | 8 |
+| Venomous Snake | SnakeAttack_blood | 500 | None |
+|  | SnakeExplosion_blood | 750 | None |

--- a/mob_stats.md
+++ b/mob_stats.md
@@ -1,0 +1,499 @@
+# Statystyki mobów dla Q1-Q10
+
+Plik automatycznie wygenerowany z konfiguracji MythicMobs.
+
+
+## Q1
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Grimmag the Risen | ZOMBIE | 5000 | 300 | Boss |
+| Perral World Dragonknight | SKELETON | 3000 | 150 | Mini Boss |
+| Raazghul the Corruptor | ZOMBIE | 2000 | 250 | Mini Boss |
+| Flamecult Worshipper | SKELETON | 1000 | 200 | Elite |
+| Flamecult Servant | ZOMBIE | 750 | 150 | Normal |
+| Flamecult Archer | SKELETON | 500 | 250 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Grimmag the Risen | ZOMBIE | 15000 | 600 | Boss |
+| Perral World Dragonknight | SKELETON | 9000 | 300 | Mini Boss |
+| Raazghul the Corruptor | ZOMBIE | 6000 | 500 | Mini Boss |
+| Flamecult Worshipper | SKELETON | 3000 | 400 | Elite |
+| Flamecult Servant | ZOMBIE | 2250 | 300 | Normal |
+| Flamecult Archer | SKELETON | 1500 | 500 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Grimmag the Risen | ZOMBIE | 50000 | 1500 | Boss |
+| Perral World Dragonknight | SKELETON | 30000 | 750 | Mini Boss |
+| Raazghul the Corruptor | ZOMBIE | 20000 | 1250 | Mini Boss |
+| Flamecult Worshipper | SKELETON | 10000 | 1000 | Elite |
+| Flamecult Servant | ZOMBIE | 7500 | 750 | Normal |
+| Flamecult Archer | SKELETON | 5000 | 1250 | Normal |
+
+## Q2
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Arachna, Scourge of Duria | ZOMBIE | 5000 | 100 | Boss |
+| Xerib the Hunchback | WITCH | 2000 | 60 | Mini Boss |
+| Archus the Mad | ZOMBIE | 3000 | 80 | Mini Boss |
+| Corrupted Root Creature | ZOMBIE | 1000 | 50 | Elite |
+| Gremlin Marauder | BABY_ZOMBIE | 100 | 30 | Normal |
+| Death Witch | ZOMBIE | 200 | 40 | Normal |
+| Poisonous Spider | ZOMBIE | 150 | 25 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Arachna, Scourge of Duria | ZOMBIE | 15000 | 200 | Boss |
+| Xerib the Hunchback | WITCH | 6000 | 120 | Mini Boss |
+| Archus the Mad | ZOMBIE | 9000 | 160 | Mini Boss |
+| Corrupted Root Creature | ZOMBIE | 3000 | 100 | Elite |
+| Gremlin Marauder | BABY_ZOMBIE | 300 | 60 | Normal |
+| Death Witch | ZOMBIE | 600 | 80 | Normal |
+| Poisonous Spider | ZOMBIE | 450 | 50 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Arachna, Scourge of Duria | ZOMBIE | 50000 | 500 | Boss |
+| Xerib the Hunchback | WITCH | 20000 | 300 | Mini Boss |
+| Archus the Mad | ZOMBIE | 30000 | 400 | Mini Boss |
+| Corrupted Root Creature | ZOMBIE | 10000 | 250 | Elite |
+| Gremlin Marauder | BABY_ZOMBIE | 1000 | 150 | Normal |
+| Death Witch | ZOMBIE | 2000 | 200 | Normal |
+| Poisonous Spider | ZOMBIE | 1500 | 125 | Normal |
+
+## Q3
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Undead King Heredur | ZOMBIE | 3000 | 200 | Boss |
+| Parallel World Evil Miller | ZOMBIE | 2000 | 150 | Mini Boss |
+| The Bloody Arrow | SKELETON | 1500 | 180 | Mini Boss |
+| Cursed Troll | ZOMBIE | 1000 | 150 | Elite |
+| Slain Assassin | ZOMBIE | 600 | 200 | Elite |
+| Cursed Farmer | ZOMBIE | 500 | 100 | Normal |
+| Cursed Archer | SKELETON | 400 | 120 | Normal |
+| Slain Warrior | ZOMBIE | 800 | 130 | Normal |
+| Slain Archer | SKELETON | 500 | 150 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Undead King Heredur | ZOMBIE | 9000 | 400 | Boss |
+| Parallel World Evil Miller | ZOMBIE | 6000 | 300 | Mini Boss |
+| The Bloody Arrow | SKELETON | 4500 | 360 | Mini Boss |
+| Cursed Troll | ZOMBIE | 3000 | 300 | Elite |
+| Slain Assassin | ZOMBIE | 1800 | 400 | Elite |
+| Cursed Farmer | ZOMBIE | 1500 | 200 | Normal |
+| Cursed Archer | SKELETON | 1200 | 240 | Normal |
+| Slain Warrior | ZOMBIE | 2400 | 260 | Normal |
+| Slain Archer | SKELETON | 1500 | 300 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Undead King Heredur | ZOMBIE | 60000 | 1000 | Boss |
+| Parallel World Evil Miller | ZOMBIE | 20000 | 750 | Mini Boss |
+| The Bloody Arrow | SKELETON | 15000 | 900 | Mini Boss |
+| Cursed Troll | ZOMBIE | 10000 | 750 | Elite |
+| Slain Assassin | ZOMBIE | 6000 | 1000 | Elite |
+| Cursed Farmer | ZOMBIE | 5000 | 500 | Normal |
+| Cursed Archer | SKELETON | 4000 | 600 | Normal |
+| Slain Warrior | ZOMBIE | 8000 | 650 | Normal |
+| Slain Archer | SKELETON | 5000 | 750 | Normal |
+
+## Q4
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Bearach, Champion of the Wilds | ZOMBIE | 3000 | 250 | Boss |
+| Parallel World Ancient Stag | SKELETON | 2000 | 200 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 2000 | 300 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 2500 | 350 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 3000 | 400 | Mini Boss |
+| Sanguine Clan`s Raging Snooper | ZOMBIE | 600 | 120 | Elite |
+| Sanguine Clan`s Raging Hunter | SKELETON | 800 | 150 | Elite |
+| Eternal Root Creature | ZOMBIE | 1200 | 150 | Elite |
+| Eternal Hunter | SKELETON | 1000 | 250 | Elite |
+| Sanguine Clan`s Raging Guardian | ZOMBIE | 400 | 100 | Normal |
+| Raging Hunting-Hound | ZOMBIE | 300 | 80 | Normal |
+| Eternal Satyr Warrior | ZOMBIE | 800 | 200 | Normal |
+| Eternal Hunting-Hound | ZOMBIE | 400 | 100 | Normal |
+| Lightning Wolf | ZOMBIE | 400 | 0 | Unknown |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Bearach, Champion of the Wilds | ZOMBIE | 9000 | 500 | Boss |
+| Parallel World Ancient Stag | SKELETON | 6000 | 400 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 6000 | 600 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 7500 | 700 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 9000 | 800 | Mini Boss |
+| Sanguine Clan`s Raging Snooper | ZOMBIE | 1800 | 240 | Elite |
+| Sanguine Clan`s Raging Hunter | SKELETON | 2400 | 300 | Elite |
+| Eternal Root Creature | ZOMBIE | 3600 | 300 | Elite |
+| Eternal Hunter | SKELETON | 3000 | 500 | Elite |
+| Sanguine Clan`s Raging Guardian | ZOMBIE | 1200 | 200 | Normal |
+| Raging Hunting-Hound | ZOMBIE | 900 | 160 | Normal |
+| Eternal Satyr Warrior | ZOMBIE | 2400 | 400 | Normal |
+| Eternal Hunting-Hound | ZOMBIE | 1200 | 200 | Normal |
+| Lightning Wolf | ZOMBIE | 1200 | 0 | Unknown |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Bearach, Champion of the Wilds | ZOMBIE | 30000 | 1250 | Boss |
+| Parallel World Ancient Stag | SKELETON | 20000 | 1000 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 20000 | 1500 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 25000 | 1750 | Mini Boss |
+| Ulgar the Master Butcher | ZOMBIE | 30000 | 2000 | Mini Boss |
+| Sanguine Clan`s Raging Snooper | ZOMBIE | 6000 | 600 | Elite |
+| Sanguine Clan`s Raging Hunter | SKELETON | 8000 | 750 | Elite |
+| Eternal Root Creature | ZOMBIE | 12000 | 750 | Elite |
+| Eternal Hunter | SKELETON | 10000 | 1250 | Elite |
+| Sanguine Clan`s Raging Guardian | ZOMBIE | 4000 | 500 | Normal |
+| Raging Hunting-Hound | ZOMBIE | 3000 | 400 | Normal |
+| Eternal Satyr Warrior | ZOMBIE | 8000 | 1000 | Normal |
+| Eternal Hunting-Hound | ZOMBIE | 4000 | 500 | Normal |
+| Lightning Wolf | ZOMBIE | 4000 | 0 | Unknown |
+
+## Q5
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Khalys, Leader of the Cultists | ZOMBIE | 3000 | 200 | Boss |
+| Parallel World Old Jabbax Shaman | ZOMBIE | 2000 | 180 | Mini Boss |
+| Wandering Experiment | ZOMBIE | 2000 | 0 | Mini Boss |
+| Furious Andermagic | ZOMBIE | 600 | 150 | Elite |
+| Wailing Andermagic Ghost | ZOMBIE | 800 | 100 | Elite |
+| Andermagic Scoropitl | ZOMBIE | 1200 | 150 | Elite |
+| Furious Maggot | ZOMBIE | 200 | 50 | Normal |
+| Furious Flagrancy | ZOMBIE | 800 | 120 | Normal |
+| Andermagic Guardian | ZOMBIE | 600 | 150 | Normal |
+| Living Andermagic | ZOMBIE | 400 | 140 | Normal |
+| Khalys Clone | ZOMBIE | 300 | 100 | Unknown |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Khalys, Leader of the Cultists | ZOMBIE | 9000 | 400 | Boss |
+| Parallel World Old Jabbax Shaman | ZOMBIE | 6000 | 360 | Mini Boss |
+| Wandering Experiment | ZOMBIE | 6000 | 0 | Mini Boss |
+| Furious Andermagic | ZOMBIE | 1800 | 300 | Elite |
+| Wailing Andermagic Ghost | ZOMBIE | 2400 | 200 | Elite |
+| Andermagic Scoropitl | ZOMBIE | 3600 | 300 | Elite |
+| Furious Maggot | ZOMBIE | 600 | 100 | Normal |
+| Furious Flagrancy | ZOMBIE | 2400 | 240 | Normal |
+| Andermagic Guardian | ZOMBIE | 1800 | 300 | Normal |
+| Living Andermagic | ZOMBIE | 1200 | 280 | Normal |
+| Khalys Clone | ZOMBIE | 900 | 200 | Unknown |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Khalys, Leader of the Cultists | ZOMBIE | 30000 | 1000 | Boss |
+| Parallel World Old Jabbax Shaman | ZOMBIE | 20000 | 900 | Mini Boss |
+| Wandering Experiment | ZOMBIE | 20000 | 0 | Mini Boss |
+| Furious Andermagic | ZOMBIE | 6000 | 750 | Elite |
+| Wailing Andermagic Ghost | ZOMBIE | 8000 | 500 | Elite |
+| Andermagic Scoropitl | ZOMBIE | 12000 | 750 | Elite |
+| Furious Maggot | ZOMBIE | 2000 | 250 | Normal |
+| Furious Flagrancy | ZOMBIE | 8000 | 600 | Normal |
+| Andermagic Guardian | ZOMBIE | 6000 | 750 | Normal |
+| Living Andermagic | ZOMBIE | 4000 | 700 | Normal |
+| Khalys Clone | ZOMBIE | 3000 | 500 | Unknown |
+
+## Q6
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Skeledragon | Zombie | 5000 | 300 | Boss |
+| Mortis & Skeledragon | Zombie | 7000 | 400 | Boss |
+| Mortis, Unchained God of Death | SKELETON | 10000 | 500 | Boss |
+| Mortis Death Knight | SKELETON | 3000 | 300 | Mini Boss |
+| Murot, High Priest of Mortis | SKELETON | 3000 | 200 | Mini Boss |
+| Death Knight | SKELETON | 1200 | 250 | Elite |
+| Death Archer | SKELETON | 1000 | 300 | Elite |
+| Fallen Warrior | SKELETON | 800 | 150 | Normal |
+| Fallen Archer | SKELETON | 600 | 200 | Normal |
+| Elite Skeleton Archer | SKELETON | 800 | 250 | Normal |
+| Raging Soul | SKELETON | 500 | 100 | Normal |
+| Elite Skeleton Warrior | SKELETON | 1000 | 200 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Skeledragon | Zombie | 15000 | 600 | Boss |
+| Mortis & Skeledragon | Zombie | 21000 | 800 | Boss |
+| Mortis, Unchained God of Death | SKELETON | 30000 | 1000 | Boss |
+| Mortis Death Knight | SKELETON | 9000 | 600 | Mini Boss |
+| Murot, High Priest of Mortis | SKELETON | 9000 | 400 | Mini Boss |
+| Death Knight | SKELETON | 3600 | 500 | Elite |
+| Death Archer | SKELETON | 3000 | 600 | Elite |
+| Fallen Warrior | SKELETON | 2400 | 300 | Normal |
+| Fallen Archer | SKELETON | 1800 | 400 | Normal |
+| Elite Skeleton Archer | SKELETON | 2400 | 500 | Normal |
+| Raging Soul | SKELETON | 1500 | 200 | Normal |
+| Elite Skeleton Warrior | SKELETON | 3000 | 400 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Skeledragon | Zombie | 50000 | 1500 | Boss |
+| Mortis & Skeledragon | Zombie | 70000 | 2000 | Boss |
+| Mortis, Unchained God of Death | SKELETON | 100000 | 2500 | Boss |
+| Mortis Death Knight | SKELETON | 30000 | 1500 | Mini Boss |
+| Murot, High Priest of Mortis | SKELETON | 30000 | 1000 | Mini Boss |
+| Death Knight | SKELETON | 12000 | 1250 | Elite |
+| Death Archer | SKELETON | 10000 | 1500 | Elite |
+| Fallen Warrior | SKELETON | 8000 | 750 | Normal |
+| Fallen Archer | SKELETON | 6000 | 1000 | Normal |
+| Elite Skeleton Archer | SKELETON | 8000 | 1250 | Normal |
+| Raging Soul | SKELETON | 5000 | 500 | Normal |
+| Elite Skeleton Warrior | SKELETON | 10000 | 1000 | Normal |
+
+## Q7
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Herald of the Anderworld | ZOMBIE | 5000 | 0 | Boss |
+| Iron Creeper Gate Guard | ZOMBIE | 3000 | 200 | Mini Boss |
+| Commander Embersword | ZOMBIE | 3000 | 250 | Mini Boss |
+| Thundering Cyclops | ZOMBIE | 1500 | 200 | Elite |
+| Dark Sentinel | ZOMBIE | 1800 | 250 | Elite |
+| Fireclaw Mercenary | ZOMBIE | 1200 | 200 | Elite |
+| Bone Warder | SKELETON | 800 | 150 | Normal |
+| B-1000 Combat Mechanoid | ZOMBIE | 1200 | 100 | Normal |
+| Wild Razorclaw | ZOMBIE | 600 | 250 | Normal |
+| Flamescale Defender | ZOMBIE | 800 | 150 | Normal |
+| Angry Flamespawn | ZOMBIE | 400 | 100 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Herald of the Anderworld | ZOMBIE | 15000 | 0 | Boss |
+| Iron Creeper Gate Guard | ZOMBIE | 9000 | 400 | Mini Boss |
+| Commander Embersword | ZOMBIE | 9000 | 500 | Mini Boss |
+| Thundering Cyclops | ZOMBIE | 4500 | 400 | Elite |
+| Dark Sentinel | ZOMBIE | 5400 | 500 | Elite |
+| Fireclaw Mercenary | ZOMBIE | 3600 | 400 | Elite |
+| Bone Warder | SKELETON | 2400 | 300 | Normal |
+| B-1000 Combat Mechanoid | ZOMBIE | 3600 | 200 | Normal |
+| Wild Razorclaw | ZOMBIE | 1800 | 500 | Normal |
+| Flamescale Defender | ZOMBIE | 2400 | 300 | Normal |
+| Angry Flamespawn | ZOMBIE | 1200 | 200 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Herald of the Anderworld | ZOMBIE | 50000 | 0 | Boss |
+| Iron Creeper Gate Guard | ZOMBIE | 30000 | 1000 | Mini Boss |
+| Commander Embersword | ZOMBIE | 30000 | 1250 | Mini Boss |
+| Thundering Cyclops | ZOMBIE | 15000 | 1000 | Elite |
+| Dark Sentinel | ZOMBIE | 18000 | 1250 | Elite |
+| Fireclaw Mercenary | ZOMBIE | 12000 | 1000 | Elite |
+| Bone Warder | SKELETON | 8000 | 750 | Normal |
+| B-1000 Combat Mechanoid | ZOMBIE | 12000 | 500 | Normal |
+| Wild Razorclaw | ZOMBIE | 6000 | 1250 | Normal |
+| Flamescale Defender | ZOMBIE | 8000 | 750 | Normal |
+| Angry Flamespawn | ZOMBIE | 4000 | 500 | Normal |
+
+## Q8
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Sigrismarr, Twisted Priest of Fjalnir | ZOMBIE | 5000 | 0 | Boss |
+| Shocking Forocity | ZOMBIE | 3000 | 250 | Mini Boss |
+| Pale Enforcer | ZOMBIE | 3000 | 200 | Mini Boss |
+| Big Heap of Ice | ZOMBIE | 2000 | 300 | Elite |
+| Bloodthirsty Frostwolf | ZOMBIE | 1500 | 200 | Elite |
+| Frost Magician | ZOMBIE | 600 | 300 | Elite |
+| Frost Bringer | ZOMBIE | 2000 | 250 | Elite |
+| Electrified Ferocity | ZOMBIE | 600 | 200 | Normal |
+| Charged Drone | ZOMBIE | 400 | 100 | Normal |
+| Pale Pillager | ZOMBIE | 800 | 200 | Normal |
+| Simple Troll | ZOMBIE | 1500 | 150 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Sigrismarr, Twisted Priest of Fjalnir | ZOMBIE | 15000 | 0 | Boss |
+| Shocking Forocity | ZOMBIE | 9000 | 500 | Mini Boss |
+| Pale Enforcer | ZOMBIE | 9000 | 400 | Mini Boss |
+| Big Heap of Ice | ZOMBIE | 6000 | 600 | Elite |
+| Bloodthirsty Frostwolf | ZOMBIE | 4500 | 400 | Elite |
+| Frost Magician | ZOMBIE | 1800 | 600 | Elite |
+| Frost Bringer | ZOMBIE | 6000 | 500 | Elite |
+| Electrified Ferocity | ZOMBIE | 1800 | 400 | Normal |
+| Charged Drone | ZOMBIE | 1200 | 200 | Normal |
+| Pale Pillager | ZOMBIE | 2400 | 400 | Normal |
+| Simple Troll | ZOMBIE | 4500 | 300 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Sigrismarr, Twisted Priest of Fjalnir | ZOMBIE | 50000 | 0 | Boss |
+| Shocking Forocity | ZOMBIE | 30000 | 1250 | Mini Boss |
+| Pale Enforcer | ZOMBIE | 30000 | 1000 | Mini Boss |
+| Big Heap of Ice | ZOMBIE | 20000 | 1500 | Elite |
+| Bloodthirsty Frostwolf | ZOMBIE | 15000 | 1000 | Elite |
+| Frost Magician | ZOMBIE | 6000 | 1500 | Elite |
+| Frost Bringer | ZOMBIE | 20000 | 1250 | Elite |
+| Electrified Ferocity | ZOMBIE | 6000 | 1000 | Normal |
+| Charged Drone | ZOMBIE | 4000 | 500 | Normal |
+| Pale Pillager | ZOMBIE | 8000 | 1000 | Normal |
+| Simple Troll | ZOMBIE | 15000 | 750 | Normal |
+
+## Q9
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| M`Edusa | ZOMBIE | 5000 | 200 | Boss |
+| Asterion | ZOMBIE | 3000 | 300 | Mini Boss |
+| Ebicarus | ZOMBIE | 3000 | 300 | Mini Boss |
+| Cohort Swordsman | ZOMBIE | 1200 | 200 | Elite |
+| Stone Golem | ZOMBIE | 2000 | 250 | Elite |
+| Zorlobb Warrior | ZOMBIE | 1500 | 250 | Elite |
+| Minotaur | ZOMBIE | 2000 | 250 | Elite |
+| Agile Satyr Warrior | ZOMBIE | 800 | 150 | Normal |
+| Perfidious Satyr Archer | SKELETON | 600 | 200 | Normal |
+| Jabbax | ZOMBIE | 500 | 100 | Normal |
+| Gorgon Acolyte | ZOMBIE | 600 | 200 | Normal |
+| Poisonous Snake | ZOMBIE | 100 | 150 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| M`Edusa | ZOMBIE | 15000 | 400 | Boss |
+| Asterion | ZOMBIE | 9000 | 600 | Mini Boss |
+| Ebicarus | ZOMBIE | 9000 | 600 | Mini Boss |
+| Cohort Swordsman | ZOMBIE | 3600 | 400 | Elite |
+| Stone Golem | ZOMBIE | 6000 | 500 | Elite |
+| Zorlobb Warrior | ZOMBIE | 4500 | 500 | Elite |
+| Minotaur | ZOMBIE | 6000 | 500 | Elite |
+| Agile Satyr Warrior | ZOMBIE | 2400 | 300 | Normal |
+| Perfidious Satyr Archer | SKELETON | 1800 | 400 | Normal |
+| Jabbax | ZOMBIE | 1500 | 200 | Normal |
+| Gorgon Acolyte | ZOMBIE | 1800 | 400 | Normal |
+| Poisonous Snake | ZOMBIE | 300 | 300 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| M`Edusa | ZOMBIE | 50000 | 1000 | Boss |
+| Asterion | ZOMBIE | 30000 | 1500 | Mini Boss |
+| Ebicarus | ZOMBIE | 30000 | 1500 | Mini Boss |
+| Cohort Swordsman | ZOMBIE | 12000 | 1000 | Elite |
+| Stone Golem | ZOMBIE | 20000 | 1250 | Elite |
+| Zorlobb Warrior | ZOMBIE | 15000 | 1250 | Elite |
+| Minotaur | ZOMBIE | 20000 | 1250 | Elite |
+| Agile Satyr Warrior | ZOMBIE | 8000 | 750 | Normal |
+| Perfidious Satyr Archer | SKELETON | 6000 | 1000 | Normal |
+| Jabbax | ZOMBIE | 5000 | 500 | Normal |
+| Gorgon Acolyte | ZOMBIE | 6000 | 1000 | Normal |
+| Poisonous Snake | ZOMBIE | 1000 | 750 | Normal |
+
+## Q10
+
+
+### Poziom trudności: inf
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Gorga | ZOMBIE | 5000 | 200 | Boss |
+| Melas the Swift-Footed | ZOMBIE | 2000 | 150 | Mini Boss |
+| Akheilos | ZOMBIE | 2000 | 200 | Mini Boss |
+| Scheming Gorgon | ZOMBIE | 800 | 200 | Elite |
+| Poisonous Jitterjelly | ZOMBIE | 1000 | 150 | Elite |
+| Patrolling Jabbax | ZOMBIE | 1200 | 150 | Elite |
+| Anderworld Jitterjelly | ZOMBIE | 600 | 100 | Normal |
+| Combat-Ready Zorlobb | ZOMBIE | 1200 | 100 | Normal |
+| Anderworld Jabbax | ZOMBIE | 400 | 100 | Normal |
+| Armed Khaross | ZOMBIE | 1000 | 150 | Normal |
+| Mordacious Khaross | ZOMBIE | 1000 | 150 | Normal |
+| Venomous Snake | ZOMBIE | 100 | 100 | Normal |
+
+### Poziom trudności: hell
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Gorga | ZOMBIE | 15000 | 400 | Boss |
+| Melas the Swift-Footed | ZOMBIE | 6000 | 300 | Mini Boss |
+| Akheilos | ZOMBIE | 6000 | 400 | Mini Boss |
+| Scheming Gorgon | ZOMBIE | 2400 | 400 | Elite |
+| Poisonous Jitterjelly | ZOMBIE | 3000 | 300 | Elite |
+| Patrolling Jabbax | ZOMBIE | 3600 | 300 | Elite |
+| Anderworld Jitterjelly | ZOMBIE | 1800 | 200 | Normal |
+| Combat-Ready Zorlobb | ZOMBIE | 3600 | 200 | Normal |
+| Anderworld Jabbax | ZOMBIE | 1200 | 200 | Normal |
+| Armed Khaross | ZOMBIE | 3000 | 300 | Normal |
+| Mordacious Khaross | ZOMBIE | 3000 | 300 | Normal |
+| Venomous Snake | ZOMBIE | 300 | 200 | Normal |
+
+### Poziom trudności: blood
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Gorga | ZOMBIE | 50000 | 1000 | Boss |
+| Melas the Swift-Footed | ZOMBIE | 20000 | 750 | Mini Boss |
+| Akheilos | ZOMBIE | 20000 | 1000 | Mini Boss |
+| Scheming Gorgon | ZOMBIE | 8000 | 1000 | Elite |
+| Poisonous Jitterjelly | ZOMBIE | 10000 | 750 | Elite |
+| Patrolling Jabbax | ZOMBIE | 12000 | 750 | Elite |
+| Anderworld Jitterjelly | ZOMBIE | 6000 | 500 | Normal |
+| Combat-Ready Zorlobb | ZOMBIE | 12000 | 500 | Normal |
+| Anderworld Jabbax | ZOMBIE | 4000 | 500 | Normal |
+| Armed Khaross | ZOMBIE | 10000 | 750 | Normal |
+| Mordacious Khaross | ZOMBIE | 10000 | 750 | Normal |
+| Venomous Snake | ZOMBIE | 1000 | 500 | Normal |


### PR DESCRIPTION
## Summary
- detect damage in nested skill parts by following `onHit`/`onTick` references
- regenerate mob skills report with corrected damage numbers

## Testing
- `pip install PyYAML`
- `python3 generate_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68872d21d020832aaa914f2a67782c3c