### PR TITLE
Telegraph damage skills for avoidable combat

### DIFF
--- a/mob_skills.md
+++ b/mob_skills.md
@@ -77,7 +77,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | Arachna, Scourge of Duria | WebShot_hell | 200 | 8 |
-|  | VenomSpit_hell | 300 | 12 |
+|  | VenomSpit_hell | 300 | 10 |
 |  | FallingPoisonSphere_hell | 0 | 12 |
 |  | SummonPoisonousSpiders_hell | None | 22 |
 | Xerib the Hunchback | SummoningSphereXerib_hell | None | 18 |
@@ -136,7 +136,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Undead King Heredur | FrostExplosion_hell | 400 | 15 |
 |  | SummonUndead_hell | None | 25 |
-|  | DeathBeam_hell | 1000 | 20 |
+|  | DeathBeam_hell | 0 | 20 |
 | Parallel World Evil Miller | SummonVillagers_hell | None | 30 |
 |  | IceBall_hell | 300 | 8 |
 |  | FrostExplosion_hell | 400 | 15 |
@@ -155,7 +155,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Undead King Heredur | FrostExplosion_blood | 1000 | 15 |
 |  | SummonUndead_blood | None | 25 |
-|  | DeathBeam_blood | 2500 | 20 |
+|  | DeathBeam_blood | 0 | 20 |
 | Parallel World Evil Miller | SummonVillagers_blood | None | 30 |
 |  | IceBall_blood | 750 | 8 |
 |  | FrostExplosion_blood | 1000 | 15 |
@@ -206,13 +206,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | PowerShot_hell | 400 | 15 |
 | Ulgar the Master Butcher | TransformPhase2_hell | None | None |
 |  | TransformPhase3_hell | None | None |
-|  | DeathExplosion_hell | 600 | 1 |
+|  | DeathExplosion_hell | 400 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_hell | None | None |
 |  | TransformPhase3_hell | None | None |
-|  | DeathExplosion_hell | 600 | 1 |
+|  | DeathExplosion_hell | 400 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_hell | None | None |
 |  | TransformPhase3_hell | None | None |
-|  | DeathExplosion_hell | 600 | 1 |
+|  | DeathExplosion_hell | 400 | 1 |
 | Sanguine Clan`s Raging Snooper | - | - | - |
 | Sanguine Clan`s Raging Hunter | SummonHounds_hell | None | 30 |
 | Eternal Root Creature | - | - | - |
@@ -232,13 +232,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | PowerShot_blood | 1000 | 15 |
 | Ulgar the Master Butcher | TransformPhase2_blood | None | None |
 |  | TransformPhase3_blood | None | None |
-|  | DeathExplosion_blood | 1500 | 1 |
+|  | DeathExplosion_blood | 1000 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_blood | None | None |
 |  | TransformPhase3_blood | None | None |
-|  | DeathExplosion_blood | 1500 | 1 |
+|  | DeathExplosion_blood | 1000 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_blood | None | None |
 |  | TransformPhase3_blood | None | None |
-|  | DeathExplosion_blood | 1500 | 1 |
+|  | DeathExplosion_blood | 1000 | 1 |
 | Sanguine Clan`s Raging Snooper | - | - | - |
 | Sanguine Clan`s Raging Hunter | SummonHounds_blood | None | 30 |
 | Eternal Root Creature | - | - | - |
@@ -280,9 +280,9 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Khalys, Leader of the Cultists | SummonCopy_hell | None | 45 |
 |  | MagicMissile_hell | 400 | 10 |
 |  | Teleport_hell | None | 30 |
-|  | DeathBeam_hell | 1000 | 20 |
+|  | DeathBeam_hell | 0 | 20 |
 | Parallel World Old Jabbax Shaman | SummonMaggots_hell | None | 30 |
-|  | MeteorStrike_hell | 600 | 15 |
+|  | MeteorStrike_hell | 500 | 15 |
 | Wandering Experiment | RunFromPlayer_hell | None | 5 |
 | Furious Andermagic | FireballAttack_hell | 300 | 10 |
 | Wailing Andermagic Ghost | SlowAura_hell | None | 5 |
@@ -301,9 +301,9 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Khalys, Leader of the Cultists | SummonCopy_blood | None | 45 |
 |  | MagicMissile_blood | 1000 | 10 |
 |  | Teleport_blood | None | 30 |
-|  | DeathBeam_blood | 2500 | 20 |
+|  | DeathBeam_blood | 0 | 20 |
 | Parallel World Old Jabbax Shaman | SummonMaggots_blood | None | 30 |
-|  | MeteorStrike_blood | 1500 | 15 |
+|  | MeteorStrike_blood | 1250 | 15 |
 | Wandering Experiment | RunFromPlayer_blood | None | 5 |
 | Furious Andermagic | FireballAttack_blood | 750 | 10 |
 | Wailing Andermagic Ghost | SlowAura_blood | None | 5 |
@@ -332,10 +332,10 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | HealingPulse | None | 15 |
 |  | DeathZone | 99999 | 25 |
 |  | SummonDragon | None | 60 |
-| Mortis Death Knight | DeathExplosion | 300 | 1 |
+| Mortis Death Knight | DeathExplosion | 200 | 1 |
 | Murot, High Priest of Mortis | MeteorStrike | 300 | 15 |
 |  | HomingOrb | 150 | 10 |
-| Death Knight | DeathExplosion | 300 | 1 |
+| Death Knight | DeathExplosion | 200 | 1 |
 | Death Archer | WitheringShot | 200 | 10 |
 | Fallen Warrior | - | - | - |
 | Fallen Archer | - | - | - |
@@ -357,10 +357,10 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | HealingPulse_hell | None | 15 |
 |  | DeathZone_hell | 99999 | 25 |
 |  | SummonDragon_hell | None | 60 |
-| Mortis Death Knight | DeathExplosion_hell | 600 | 1 |
-| Murot, High Priest of Mortis | MeteorStrike_hell | 600 | 15 |
+| Mortis Death Knight | DeathExplosion_hell | 400 | 1 |
+| Murot, High Priest of Mortis | MeteorStrike_hell | 500 | 15 |
 |  | HomingOrb_hell | 300 | 10 |
-| Death Knight | DeathExplosion_hell | 600 | 1 |
+| Death Knight | DeathExplosion_hell | 400 | 1 |
 | Death Archer | WitheringShot_hell | 400 | 10 |
 | Fallen Warrior | - | - | - |
 | Fallen Archer | - | - | - |
@@ -383,10 +383,10 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | HealingPulse_blood | None | 15 |
 |  | DeathZone_blood | 99999 | 25 |
 |  | SummonDragon_blood | None | 60 |
-| Mortis Death Knight | DeathExplosion_blood | 1500 | 1 |
-| Murot, High Priest of Mortis | MeteorStrike_blood | 1500 | 15 |
+| Mortis Death Knight | DeathExplosion_blood | 1000 | 1 |
+| Murot, High Priest of Mortis | MeteorStrike_blood | 1250 | 15 |
 |  | HomingOrb_blood | 750 | 10 |
-| Death Knight | DeathExplosion_blood | 1500 | 1 |
+| Death Knight | DeathExplosion_blood | 1000 | 1 |
 | Death Archer | WitheringShot_blood | 1000 | 10 |
 | Fallen Warrior | - | - | - |
 | Fallen Archer | - | - | - |
@@ -407,8 +407,8 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Iron Creeper Gate Guard | LaserBeam | 100 | 10 |
 | Commander Embersword | SummonFlamespawns | None | 30 |
 |  | 60 |  |  |
-| Thundering Cyclops | ThunderStrike | 200 | 12 |
-| Dark Sentinel | DeathExplosion | 300 | 1 |
+| Thundering Cyclops | ThunderStrike | 150 | None |
+| Dark Sentinel | DeathExplosion | 200 | 1 |
 | Fireclaw Mercenary | 60 |  |  |
 | Bone Warder | - | - | - |
 | B-1000 Combat Mechanoid | FlameAttack | 150 | 15 |
@@ -421,13 +421,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | Herald of the Anderworld | FlameStrike_hell | 400 | 5 |
-|  | MeteorShower_hell | 600 | 15 |
+|  | MeteorShower_hell | 500 | 15 |
 |  | SummonFlamespawnsLarge_hell | None | 30 |
 | Iron Creeper Gate Guard | LaserBeam_hell | 200 | 10 |
 | Commander Embersword | SummonFlamespawns_hell | None | 30 |
 |  | 80 |  |  |
 | Thundering Cyclops | ThunderStrike_hell | 400 | 12 |
-| Dark Sentinel | DeathExplosion_hell | 600 | 1 |
+| Dark Sentinel | DeathExplosion_hell | 400 | 1 |
 | Fireclaw Mercenary | 80 |  |  |
 | Bone Warder | - | - | - |
 | B-1000 Combat Mechanoid | FlameAttack_hell | 300 | 15 |
@@ -440,13 +440,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | Herald of the Anderworld | FlameStrike_blood | 1000 | 5 |
-|  | MeteorShower_blood | 1500 | 15 |
+|  | MeteorShower_blood | 1250 | 15 |
 |  | SummonFlamespawnsLarge_blood | None | 30 |
 | Iron Creeper Gate Guard | LaserBeam_blood | 500 | 10 |
 | Commander Embersword | SummonFlamespawns_blood | None | 30 |
 |  | 100 |  |  |
 | Thundering Cyclops | ThunderStrike_blood | 1000 | 12 |
-| Dark Sentinel | DeathExplosion_blood | 1500 | 1 |
+| Dark Sentinel | DeathExplosion_blood | 1000 | 1 |
 | Fireclaw Mercenary | 100 |  |  |
 | Bone Warder | - | - | - |
 | B-1000 Combat Mechanoid | FlameAttack_blood | 750 | 15 |
@@ -470,11 +470,12 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Pale Enforcer | DashToPlayer | 150 | 12 |
 |  | SummonPillagers | None | 30 |
 | Big Heap of Ice | SummonIceHeaps | None | None |
+| Heap of Ice | - | - | - |
 | Bloodthirsty Frostwolf | SummonDrones | None | 20 |
 | Frost Magician | FrostBolt | 200 | 8 |
 |  | IceStorm | 150 | 15 |
 | Frost Bringer | - | - | - |
-| Electrified Ferocity | LightningBolt | 150 | 10 |
+| Electrified Ferocity | LightningBolt | 50 | 10 |
 |  | TeleportToPlayer | None | 15 |
 | Charged Drone | - | - | - |
 | Pale Pillager | DashToPlayer | 150 | 12 |
@@ -493,11 +494,12 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Pale Enforcer | DashToPlayer_hell | 300 | 12 |
 |  | SummonPillagers_hell | None | 30 |
 | Big Heap of Ice | SummonIceHeaps_hell | None | None |
+| Heap of Ice | - | - | - |
 | Bloodthirsty Frostwolf | SummonDrones_hell | None | 20 |
 | Frost Magician | FrostBolt_hell | 400 | 8 |
 |  | IceStorm_hell | 300 | 15 |
 | Frost Bringer | - | - | - |
-| Electrified Ferocity | LightningBolt_hell | 300 | 10 |
+| Electrified Ferocity | LightningBolt_hell | 100 | 10 |
 |  | TeleportToPlayer_hell | None | 15 |
 | Charged Drone | - | - | - |
 | Pale Pillager | DashToPlayer_hell | 300 | 12 |
@@ -516,11 +518,12 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Pale Enforcer | DashToPlayer_blood | 750 | 12 |
 |  | SummonPillagers_blood | None | 30 |
 | Big Heap of Ice | SummonIceHeaps_blood | None | None |
+| Heap of Ice | - | - | - |
 | Bloodthirsty Frostwolf | SummonDrones_blood | None | 20 |
 | Frost Magician | FrostBolt_blood | 1000 | 8 |
 |  | IceStorm_blood | 750 | 15 |
 | Frost Bringer | - | - | - |
-| Electrified Ferocity | LightningBolt_blood | 750 | 10 |
+| Electrified Ferocity | LightningBolt_blood | 450 | 10 |
 |  | TeleportToPlayer_blood | None | 15 |
 | Charged Drone | - | - | - |
 | Pale Pillager | DashToPlayer_blood | 750 | 12 |
@@ -535,10 +538,10 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | M`Edusa | PetrifyingGaze | None | 15 |
 |  | AcidSpit | 200 | 10 |
-|  | SummonSnakes | None | 20 |
+|  | SummonSnakes | None | 15 |
 | Asterion | ChargeAttack | 200 | 12 |
 |  | GroundSlam | 150 | 15 |
-| Ebicarus | PowerfulStrike | 300 | 10 |
+| Ebicarus | PowerfulStrike | 50 | 15 |
 | Cohort Swordsman | HealingPulse | None | 15 |
 | Stone Golem | ThrowBoulder | 200 | 10 |
 | Zorlobb Warrior | StunningBlow | 150 | 12 |
@@ -557,10 +560,10 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | M`Edusa | PetrifyingGaze_hell | None | 15 |
 |  | AcidSpit_hell | 400 | 10 |
-|  | SummonSnakes_hell | None | 20 |
+|  | SummonSnakes_hell | None | 15 |
 | Asterion | ChargeAttack_hell | 400 | 12 |
 |  | GroundSlam_hell | 300 | 15 |
-| Ebicarus | PowerfulStrike_hell | 600 | 10 |
+| Ebicarus | PowerfulStrike_hell | 400 | 15 |
 | Cohort Swordsman | HealingPulse_hell | None | 15 |
 | Stone Golem | ThrowBoulder_hell | 400 | 10 |
 | Zorlobb Warrior | StunningBlow_hell | 300 | 12 |
@@ -579,10 +582,10 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | M`Edusa | PetrifyingGaze_blood | None | 15 |
 |  | AcidSpit_blood | 1000 | 10 |
-|  | SummonSnakes_blood | None | 20 |
+|  | SummonSnakes_blood | None | 15 |
 | Asterion | ChargeAttack_blood | 1000 | 12 |
 |  | GroundSlam_blood | 750 | 15 |
-| Ebicarus | PowerfulStrike_blood | 1500 | 10 |
+| Ebicarus | PowerfulStrike_blood | 1000 | 15 |
 | Cohort Swordsman | HealingPulse_blood | None | 15 |
 | Stone Golem | ThrowBoulder_blood | 1000 | 10 |
 | Zorlobb Warrior | StunningBlow_blood | 750 | 12 |
@@ -602,24 +605,24 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Gorga | SummonSnakes | None | 20 |
+| Gorga | SummonSnakes | None | 15 |
 |  | ScatteredShot | 150 | 10 |
-|  | MeleeAttack | 200 | None |
+|  | MeleeAttack | 100 | None |
 |  | SummonReinforcements | None | None |
-| Melas the Swift-Footed | StunStrike | 150 | 15 |
-|  | LeapAttack | 150 | 10 |
-| Akheilos | PowerfulFlamingShot | 200 | 10 |
+| Melas the Swift-Footed | StunStrike | 45 | 15 |
+|  | LeapAttack | 70 | 10 |
+| Akheilos | PowerfulFlamingShot | 100 | 10 |
 | Scheming Gorgon | PetrifyingGaze | None | 15 |
-|  | VenomSpit | 150 | 10 |
-| Poisonous Jitterjelly | ShockAttack | 150 | 10 |
-|  | DeathExplosion | 300 | 1 |
+|  | VenomSpit | 50 | 10 |
+| Poisonous Jitterjelly | ShockAttack | 50 | 10 |
+|  | DeathExplosion | 200 | 1 |
 | Patrolling Jabbax | SummonJabbax | None | 15 |
-| Anderworld Jitterjelly | ShockAttack | 150 | 10 |
+| Anderworld Jitterjelly | ShockAttack | 50 | 10 |
 |  | SmallDeathExplosion | 100 | None |
-| Combat-Ready Zorlobb | PowerfulStrike | 300 | 10 |
+| Combat-Ready Zorlobb | PowerfulStrike | 50 | 15 |
 | Anderworld Jabbax | - | - | - |
-| Armed Khaross | FlamingShot | 150 | 8 |
-| Mordacious Khaross | BurningStrike | 150 | 8 |
+| Armed Khaross | FlamingShot | 50 | 8 |
+| Mordacious Khaross | BurningStrike | 50 | 8 |
 | Venomous Snake | SnakeAttack | 100 | None |
 |  | SnakeExplosion | 150 | None |
 
@@ -627,7 +630,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Gorga | SummonSnakes_hell | None | 20 |
+| Gorga | SummonSnakes_hell | None | 15 |
 |  | ScatteredShot_hell | 300 | 10 |
 |  | MeleeAttack_hell | 400 | None |
 |  | SummonReinforcements_hell | None | None |
@@ -635,13 +638,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | LeapAttack_hell | 300 | 10 |
 | Akheilos | PowerfulFlamingShot_hell | 400 | 10 |
 | Scheming Gorgon | PetrifyingGaze_hell | None | 15 |
-|  | VenomSpit_hell | 300 | 12 |
+|  | VenomSpit_hell | 300 | 10 |
 | Poisonous Jitterjelly | ShockAttack_hell | 300 | 10 |
-|  | DeathExplosion_hell | 600 | 1 |
+|  | DeathExplosion_hell | 400 | 1 |
 | Patrolling Jabbax | SummonJabbax_hell | None | 15 |
 | Anderworld Jitterjelly | ShockAttack_hell | 300 | 10 |
 |  | SmallDeathExplosion_hell | 200 | None |
-| Combat-Ready Zorlobb | PowerfulStrike_hell | 600 | 10 |
+| Combat-Ready Zorlobb | PowerfulStrike_hell | 400 | 15 |
 | Anderworld Jabbax | - | - | - |
 | Armed Khaross | FlamingShot_hell | 300 | 8 |
 | Mordacious Khaross | BurningStrike_hell | 300 | 8 |
@@ -652,7 +655,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Gorga | SummonSnakes_blood | None | 20 |
+| Gorga | SummonSnakes_blood | None | 15 |
 |  | ScatteredShot_blood | 750 | 10 |
 |  | MeleeAttack_blood | 1000 | None |
 |  | SummonReinforcements_blood | None | None |
@@ -662,11 +665,11 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Scheming Gorgon | PetrifyingGaze_blood | None | 15 |
 |  | VenomSpit_blood | 750 | 10 |
 | Poisonous Jitterjelly | ShockAttack_blood | 750 | 10 |
-|  | DeathExplosion_blood | 1500 | 1 |
+|  | DeathExplosion_blood | 1000 | 1 |
 | Patrolling Jabbax | SummonJabbax_blood | None | 15 |
 | Anderworld Jitterjelly | ShockAttack_blood | 750 | 10 |
 |  | SmallDeathExplosion_blood | 500 | None |
-| Combat-Ready Zorlobb | PowerfulStrike_blood | 1500 | 10 |
+| Combat-Ready Zorlobb | PowerfulStrike_blood | 1000 | 15 |
 | Anderworld Jabbax | - | - | - |
 | Armed Khaross | FlamingShot_blood | 750 | 8 |
 | Mordacious Khaross | BurningStrike_blood | 750 | 8 |

--- a/mob_stats.md
+++ b/mob_stats.md
@@ -350,6 +350,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Shocking Forocity | ZOMBIE | 3000 | 250 | Mini Boss |
 | Pale Enforcer | ZOMBIE | 3000 | 200 | Mini Boss |
 | Big Heap of Ice | ZOMBIE | 2000 | 300 | Elite |
+| Heap of Ice | ZOMBIE | 500 | 100 | Elite |
 | Bloodthirsty Frostwolf | ZOMBIE | 1500 | 200 | Elite |
 | Frost Magician | ZOMBIE | 600 | 300 | Elite |
 | Frost Bringer | ZOMBIE | 2000 | 250 | Elite |
@@ -366,6 +367,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Shocking Forocity | ZOMBIE | 9000 | 500 | Mini Boss |
 | Pale Enforcer | ZOMBIE | 9000 | 400 | Mini Boss |
 | Big Heap of Ice | ZOMBIE | 6000 | 600 | Elite |
+| Heap of Ice | ZOMBIE | 1500 | 200 | Elite |
 | Bloodthirsty Frostwolf | ZOMBIE | 4500 | 400 | Elite |
 | Frost Magician | ZOMBIE | 1800 | 600 | Elite |
 | Frost Bringer | ZOMBIE | 6000 | 500 | Elite |
@@ -382,6 +384,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Shocking Forocity | ZOMBIE | 30000 | 1250 | Mini Boss |
 | Pale Enforcer | ZOMBIE | 30000 | 1000 | Mini Boss |
 | Big Heap of Ice | ZOMBIE | 20000 | 1500 | Elite |
+| Heap of Ice | ZOMBIE | 5000 | 500 | Elite |
 | Bloodthirsty Frostwolf | ZOMBIE | 15000 | 1000 | Elite |
 | Frost Magician | ZOMBIE | 6000 | 1500 | Elite |
 | Frost Bringer | ZOMBIE | 20000 | 1250 | Elite |

--- a/skills/11-15.yml
+++ b/skills/11-15.yml
@@ -6,6 +6,9 @@ Summon11-15:
 arrow:
   Cooldown: 5
   Skills:
+    - effect:particles{p=end_rod;amount=15;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.arrow.shoot;v=0.8;p=1.2} @Self
+    - delay 20
     - projectile{onTick=arrow-Tick;onHit=arrow-Hit;v=7;i=1;hR=1;vR=1;hnp=true}
 arrow-Tick:
   Skills:

--- a/skills/16-20.yml
+++ b/skills/16-20.yml
@@ -1,6 +1,9 @@
 fire:
   Cooldown: 10
   Skills:
+    - effect:particles{p=flame;amount=15;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.blaze.shoot;v=1;p=1} @Self
+    - delay 20
     - projectile{onTick=fire-Tick;onHit=fire-Hit;v=3;i=1;hR=1;vR=1;hnp=true}
 fire-Tick:
   Skills:
@@ -13,11 +16,17 @@ fire-Hit:
 fireball:
   cooldown: 5
   Skills:
+    - effect:particles{p=flame;amount=20;hS=0.4;vS=0.4} @Self
+    - sound{s=entity.ghast.shoot;v=1;p=1} @Self
+    - delay 20
     - shootfireball{y=1;v=4} @target
 
 fire#2:
   Cooldown: 7
   Skills:
+    - effect:particles{p=flame;amount=30;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.blaze.shoot;v=1;p=1} @Self
+    - delay 20
     - projectile{onTick=fire-Tick;onHit=fire-Hit;v=7;i=1;hR=1.5;vR=1.5;hnp=true}
   fire-Tick:
     Skills:

--- a/skills/21-25.yml
+++ b/skills/21-25.yml
@@ -1,9 +1,16 @@
 Summon21-25:
   Cooldown: 10
   Skills:
+    - effect:particles{p=portal;amount=20;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.evoker.prepare_summon;v=1;p=1} @Self
+    - delay 20
     - summon{mob=norse_gnome;amount=1;noise=5} @Self
 
 Summon21-25#2:
   Cooldown: 10
   Skills:
+    - effect:particles{p=portal;amount=20;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.evoker.prepare_summon;v=1;p=1} @Self
+    - delay 20
     - summon{mob=norse_gnome;amount=3;noise=5} @Self
+

--- a/skills/26-30.yml
+++ b/skills/26-30.yml
@@ -4,17 +4,26 @@ KnockupSkill:
 
 SatyrRoar:
   Skills:
+    - effect:particles{p=angry_villager;amount=20;hS=1;vS=1} @Self
+    - sound{s=entity.evoker.prepare_attack;v=1;p=0.8} @Self
+    - delay 20
     - damage{d=10} @LivingEntitiesInRadius{r=5}
     - potion{t=SLOW;d=200;level=2} @LivingEntitiesInRadius{r=5}
     - potion{t=WEAKNESS;d=200;level=2} @LivingEntitiesInRadius{r=5}
 SatyrLeap:
   Skills:
-    - leap{v=1.5} @self
+    - effect:particles{p=cloud;amount=15;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.horse.jump;v=1;p=1} @Self
+    - delay 10
+    - leap{v=1.5} @Self
     - damage{d=50} @LivingEntitiesInRadius{r=3}
     - potion{t=BLINDNESS;d=100;level=1} @LivingEntitiesInRadius{r=3}
 
 SatyrSmash:
   Skills:
+    - effect:particles{p=block_crack;material=STONE;amount=20;hS=1;vS=0.5} @Self
+    - sound{s=entity.zombie.attack_iron_door;v=1;p=1} @Self
+    - delay 20
     - damage{d=20}
     - velocity{x=0;y=2;z=0} @Target
     - potion{t=CONFUSION;d=100;level=1} @Target

--- a/skills/41-45.yml
+++ b/skills/41-45.yml
@@ -7,6 +7,9 @@ Summon41-45:
 
 RainOfDestruction:
   Skills:
+    - effect:particles{p=smoke_large;amount=20;hS=1;vS=1} @Self
+    - sound{s=entity.blaze.shoot;v=1;p=1} @Self
+    - delay 20
     - projectile{onTick=RainTick;onHit=RainHit;v=0.5;i=10;hR=10;vR=5;hnp=true;dir=[0,1,0]} @PlayersInRadius{r=15}
 
 RainTick:
@@ -21,6 +24,7 @@ RainHit:
 
 LifeDeathAura:
   Skills:
-    - damage{a=100;r=5} @EntitiesInRadius{r=5}
     - effect:particles{p=totem;amount=30;hS=1;vS=1} @Self
     - sound{s=entity.zombie.attack_iron_door;v=1;p=1} @Self
+    - delay 20
+    - damage{a=100;r=5} @EntitiesInRadius{r=5}

--- a/skills/6-10.yml
+++ b/skills/6-10.yml
@@ -23,6 +23,9 @@ Summon6-10:
 bolt:
   Cooldown: 5
   Skills:
+    - effect:particles{p=dragon_breath;amount=15;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.evoker.prepare_summon;v=1;p=1} @Self
+    - delay 20
     - projectile{onTick=Bolt-Tick;onHit=Bolt-Hit;v=6;i=1;hR=1;vR=1;hnp=true}
 Bolt-Tick:
     Skills:

--- a/skills/70-80.yml
+++ b/skills/70-80.yml
@@ -1,6 +1,9 @@
 SpawnDemons:
   Cooldown: 10
   Skills:
+    - effect:particles{p=portal;amount=30;hS=1;vS=1} @Self
+    - sound{s=entity.enderman.teleport;v=1;p=1} @Self
+    - delay 20
     - summon{mob=shadow_gazer;amount=10;noise=5} @Self
     - summon{mob=shade_crawler;amount=10;noise=5} @Self
 
@@ -14,6 +17,9 @@ HealingPulse:
 FireballAttack:
   Cooldown: 8
   Skills:
+  - effect:particles{p=FLAME;amount=15;hS=0.5;vS=0.5} @Self
+  - sound{s=entity.blaze.shoot;v=1;p=1} @Self
+  - delay 20
   - projectile{onTick=FireTick;onHit=FireHit;v=8;i=FIRE_CHARGE;hR=1;vR=1} @target
 
 FireTick:
@@ -28,6 +34,9 @@ FireHit:
 BiteAttack:
   Cooldown: 2
   Skills:
+  - effect:particles{p=BLOCK_CRACK;material=REDSTONE_BLOCK;amount=10} @Self
+  - sound{s=entity.generic.eat;v=1;p=1} @Self
+  - delay 10
   - damage{a=160} @target
   - effect:particles{p=BLOCK_CRACK;material=REDSTONE_BLOCK;amount=10} @target
 
@@ -35,6 +44,9 @@ BiteAttack:
 NauseaAttack:
   Cooldown: 5  # 5 sekund cooldownu
   Skills:
+    - effect:particles{p=SPELL_MOB;color=GREEN;amount=15;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.witch.prepare_potion;v=1;p=1} @Self
+    - delay 20
     - potion{type=CONFUSION;duration=100;level=1} @target
     - effect:particles{p=SPELL_MOB;color=GREEN;amount=10} @target # Efekt wizualny
 

--- a/skills/81-90.yml
+++ b/skills/81-90.yml
@@ -1,6 +1,8 @@
 RootGrasp:
   Skills:
     - effect:particles{particle=item_crack;material=oak_sapling;amount=20;speed=0.2;hS=0.5;vS=0.5} @target
+    - sound{s=block.grass.place;v=1;p=0.7} @target
+    - delay 20
     - potion{type=SLOW;duration=60;level=2} @target
     - damage{amount=100} @target
 
@@ -12,6 +14,9 @@ SpawnLeechbeasts:
 
 ThunderStrike:
   Skills:
+    - effect:particles{particle=electric_spark;amount=20;hS=1;vS=1} @target
+    - sound{s=entity.warden.sonic_charge;v=1;p=1} @target
+    - delay 20
     - effect:lightning @target
     - damage{amount=150;ignorearmor=true} @PIR{r=3}
     - effect:particles{particle=electric_spark;amount=30;speed=0.2;hS=1;vS=1} @PIR{r=3}

--- a/skills/91-100.yml
+++ b/skills/91-100.yml
@@ -2,16 +2,21 @@ PosthumousAttack:
   Skills:
     - effect:sound{s=entity.wither.death;v=2;p=1} @self
     - effect:particles{particle=explosion_large;amount=5} @self
+    - delay 20
     - damage{amount=250;radius=5} @LivingEntitiesInRadius{r=5}
 
 
 PowerfulAttack:
   Skills:
+    - effect:particles{particle=flame;amount=20;hS=1;vS=1} @self
+    - sound{s=entity.ender_dragon.growl;v=1.5;p=1} @self
     - delay 100
     - damage{amount=250;radius=5} @LivingEntitiesInRadius{r=5}
 
 
 LongRange:
   Skills:
-    - damage{amount=190;radius=3} @LivingEntitiesInRadius{r=3}
     - effect:particles{particle=sweep_attack;amount=10} @self
+    - sound{s=entity.player.attack.crit;v=1;p=1} @self
+    - delay 20
+    - damage{amount=190;radius=3} @LivingEntitiesInRadius{r=3}

--- a/skills/brigavik.yml
+++ b/skills/brigavik.yml
@@ -6,5 +6,8 @@ SummonLunkyDemons:
 ShadowNorseman_Dash:
   Cooldown: 15
   Skills:
+    - effect:particles{p=smoke_large;amount=20;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.enderman.teleport;v=1;p=1} @Self
+    - delay 20
     - leap{v=1;y=0.5} @target
     - damage{a=100} @target ~onHit

--- a/skills/q1.yml
+++ b/skills/q1.yml
@@ -20,6 +20,7 @@ PowerfulProjectile:
   Cooldown: 10
   Skills:
     - potion{type=SLOW;duration=60;level=10} @self
+    - effect:particles{p=FLAME;amount=30;hS=1;vS=1} @self
     - delay 5
     - projectile{onTick=Projectile-Tick;onHit=Projectile-Hit;v=5;i=FIRE_CHARGE;hR=1;vR=1;hnp=true} @PlayersInRadius{r=30;limit=1;sort=NEAREST}
     # Efekt SLOW wygaśnie po 3 sekundach
@@ -37,6 +38,7 @@ ExplosiveFireball:
   Cooldown: 15
   Skills:
     - potion{type=SLOW;duration=60;level=10} @self
+    - effect:particles{p=SMOKE_NORMAL;amount=30;hS=1;vS=1} @self
     - delay 5
     - projectile{onTick=Fireball-Tick;onHit=Fireball-Hit;v=4;i=FIRE_CHARGE;hR=1;vR=1;hnp=true} @PlayersInRadius{r=30;limit=1;sort=NEAREST}
     # Efekt SLOW wygaśnie po 3 sekundach
@@ -56,9 +58,13 @@ TeleportToPlayer:
   Cooldown: 15
   Skills:
     - potion{type=SLOW;duration=40;level=10} @self
-    - teleport @self @PlayersInRadius{r=30;limit=1;sort=NEAREST}
-    - ignite{ticks=250} @Target
-    - message{m="&d<mob.name>&f: Burn!"}
+    - target{t=PlayersInRadius{r=30;limit=1;sort=NEAREST}}
+    - message{m="&d<mob.name>&f: Burn!"} @target
+    - effect:particles{p=SMOKE_NORMAL;amount=40;hS=1;vS=1} @target
+    - sound{s=entity.enderman.teleport;v=1;p=1} @target
+    - delay 10
+    - teleport @self @target
+    - ignite{ticks=250} @target
     # Efekt SLOW wygaśnie po 2 sekundach
 
 BurningShotElite:
@@ -67,6 +73,8 @@ BurningShotElite:
     - offgcd
   Skills:
     - message{m="&d<mob.name>&f: You will be nothing but ashes!"}
+    - effect:particles{p=CRIT;amount=40;hS=1;vS=1} @self
+    - sound{s=entity.blaze.shoot;v=1;p=0.5} @self
     - delay 20
     - shoot{type=ARROW;velocity=30;damage=300} @Target
     - ignite{ticks=250} @Target
@@ -95,6 +103,7 @@ CatapultProjectile:
   Skills:
     - potion{type=SLOW;duration=60;level=2} @self
     - message{m="&d<mob.name>&f: Take this!"} @PlayersInRadius{r=30}
+    - effect:particles{p=LAVA;amount=20;hS=1;vS=1} @self
     - delay 10
     - projectile{onTick=Catapult-Tick;onHit=Catapult-Hit;v=7;i=FIRE_CHARGE;hR=1;vR=1;hnp=true} @PlayersInRadius{r=30;limit=1;sort=NEAREST}
 

--- a/skills/q10.yml
+++ b/skills/q10.yml
@@ -21,40 +21,47 @@ Venom-Hit:
 ShockAttack:
   Cooldown: 10
   Skills:
-    - damage{a=50} @target
-    - effect:particles{p=WAX_OFF;amount=20} @target
-    - potion{type=SLOW;duration=40;level=2} @target
+    - effect:particles{p=WAX_OFF;amount=20} @targetlocation
+    - delay 20
+    - damage{a=50} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=2} @targetlocation
 
 DeathExplosion:
   Skills:
-    - damage{a=50} @PlayersInRadius{r=5}
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
+    - damage{a=50} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=5}
 
 SmallDeathExplosion:
   Skills:
-    - damage{a=100} @PlayersInRadius{r=3}
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
+    - damage{a=100} @PlayersInRadius{r=3}
 
 PowerfulStrike:
   Cooldown: 15
   Skills:
-    - damage{a=50} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particles{p=CRIT;amount=20} @targetlocation
+    - delay 20
+    - damage{a=50} @PlayersInRadius{r=2} @targetlocation
 
 StunStrike:
   Cooldown: 15
   Skills:
-    - damage{a=45} @target
-    - potion{type=SLOW;duration=60;level=5} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particles{p=CRIT;amount=20} @targetlocation
+    - delay 20
+    - damage{a=45} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=SLOW;duration=60;level=5} @PlayersInRadius{r=2} @targetlocation
 
 LeapAttack:
   Cooldown: 10
   Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
+    - effect:particles{p=CLOUD;amount=20} @targetlocation
+    - delay 20
     - jump{velocity=1;height=1} @target
-    - damage{a=70} @target
+    - delay 10
+    - damage{a=70} @PlayersInRadius{r=2} @targetlocation
 
 # Mission 2 Skills
 SummonJabbax:
@@ -66,20 +73,24 @@ SummonJabbax:
 FlamingShot:
   Cooldown: 8
   Skills:
-    - shoot{type=ARROW;velocity=20;damage=50} @target
-    - skill{s=DoTEffect} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=FlamingShot-Tick;onHit=FlamingShot-Hit;v=20;i=ARROW;hR=1;vR=1} @target
 
 BurningStrike:
   Cooldown: 8
   Skills:
-    - damage{a=50} @target
-    - skill{s=DoTEffect} @target
+    - effect:particles{p=CRIT;amount=10} @targetlocation
+    - delay 20
+    - damage{a=50} @PlayersInRadius{r=1} @targetlocation
+    - skill{s=DoTEffect} @PlayersInRadius{r=1} @targetlocation
 
 PowerfulFlamingShot:
   Cooldown: 10
   Skills:
-    - shoot{type=ARROW;velocity=25;damage=100} @target
-    - skill{s=DoTEffect} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=PowerfulFlamingShot-Tick;onHit=PowerfulFlamingShot-Hit;v=25;i=ARROW;hR=1;vR=1} @target
 
 DoTEffect:
   Skills:  # Damage over Time effect
@@ -87,6 +98,24 @@ DoTEffect:
     - damage{a=50} @target
     - delay 20
     - damage{a=50} @target
+
+FlamingShot-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+FlamingShot-Hit:
+  Skills:
+    - damage{a=50} @target
+    - skill{s=DoTEffect} @target
+
+PowerfulFlamingShot-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+PowerfulFlamingShot-Hit:
+  Skills:
+    - damage{a=100} @target
+    - skill{s=DoTEffect} @target
 
 # Mission 3 Boss Skills
 SummonSnakes:
@@ -98,11 +127,23 @@ SummonSnakes:
 ScatteredShot:
   Cooldown: 10
   Skills:
-    - shoot{type=ARROW;velocity=20;damage=150;spread=12;amount=5} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=ScatteredShot-Tick;onHit=ScatteredShot-Hit;v=20;i=ARROW;hR=1;vR=1;spread=12;amount=5} @target
 
 MeleeAttack:
   Skills:
-    - damage{a=100} @target
+    - effect:particles{p=SWEEP_ATTACK;amount=1} @targetlocation
+    - delay 10
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
+
+ScatteredShot-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+ScatteredShot-Hit:
+  Skills:
+    - damage{a=150} @target
 
 SummonReinforcements:
   Conditions:
@@ -116,14 +157,17 @@ SummonReinforcements:
 
 SnakeAttack:
   Skills:
-    - damage{a=100} @target
-    - potion{type=SLOW;duration=40;level=2} @target
+    - effect:particles{p=WAX_OFF;amount=10} @targetlocation
+    - delay 20
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=1} @targetlocation
 
 SnakeExplosion:
   Skills:
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
     - damage{a=150} @PlayersInRadius{r=3}
     - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
 # Mission 1 Skills - Hell version (2x damage)
 PetrifyingGaze_hell:
   Cooldown: 15
@@ -144,40 +188,47 @@ Venom-Hit-Hell:
 ShockAttack_hell:
   Cooldown: 10
   Skills:
-    - damage{a=300} @target  # 2x150
-    - effect:particles{p=WAX_OFF;amount=20} @target
-    - potion{type=SLOW;duration=60;level=3} @target
+    - effect:particles{p=WAX_OFF;amount=20} @targetlocation
+    - delay 20
+    - damage{a=300} @PlayersInRadius{r=2} @targetlocation  # 2x150
+    - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=2} @targetlocation
 
 DeathExplosion_hell:
   Skills:
-    - damage{a=400} @PlayersInRadius{r=5}  # 2x200
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
+    - damage{a=400} @PlayersInRadius{r=5}  # 2x200
     - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=5}
 
 SmallDeathExplosion_hell:
   Skills:
-    - damage{a=200} @PlayersInRadius{r=3}  # 2x100
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=3}  # 2x100
 
 PowerfulStrike_hell:
   Cooldown: 15
   Skills:
-    - damage{a=400} @target  # 2x200
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particles{p=CRIT;amount=20} @targetlocation
+    - delay 20
+    - damage{a=400} @PlayersInRadius{r=2} @targetlocation  # 2x200
 
 StunStrike_hell:
   Cooldown: 15
   Skills:
-    - damage{a=300} @target  # 2x150
-    - potion{type=SLOW;duration=80;level=6} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particles{p=CRIT;amount=20} @targetlocation
+    - delay 20
+    - damage{a=300} @PlayersInRadius{r=2} @targetlocation  # 2x150
+    - potion{type=SLOW;duration=80;level=6} @PlayersInRadius{r=2} @targetlocation
 
 LeapAttack_hell:
   Cooldown: 10
   Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
+    - effect:particles{p=CLOUD;amount=20} @targetlocation
+    - delay 20
     - jump{velocity=1;height=1} @target
-    - damage{a=300} @target  # 2x150
+    - delay 10
+    - damage{a=300} @PlayersInRadius{r=2} @targetlocation  # 2x150
 
 # Mission 2 Skills
 SummonJabbax_hell:
@@ -189,20 +240,24 @@ SummonJabbax_hell:
 FlamingShot_hell:
   Cooldown: 8
   Skills:
-    - shoot{type=ARROW;velocity=20;damage=300} @target  # 2x150
-    - skill{s=DoTEffect_hell} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=FlamingShot_hell-Tick;onHit=FlamingShot_hell-Hit;v=20;i=ARROW;hR=1;vR=1} @target
 
 BurningStrike_hell:
   Cooldown: 8
   Skills:
-    - damage{a=300} @target  # 2x150
-    - skill{s=DoTEffect_hell} @target
+    - effect:particles{p=CRIT;amount=10} @targetlocation
+    - delay 20
+    - damage{a=300} @PlayersInRadius{r=1} @targetlocation  # 2x150
+    - skill{s=DoTEffect_hell} @PlayersInRadius{r=1} @targetlocation
 
 PowerfulFlamingShot_hell:
   Cooldown: 10
   Skills:
-    - shoot{type=ARROW;velocity=25;damage=400} @target  # 2x200
-    - skill{s=DoTEffect_hell} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=PowerfulFlamingShot_hell-Tick;onHit=PowerfulFlamingShot_hell-Hit;v=25;i=ARROW;hR=1;vR=1} @target
 
 DoTEffect_hell:
   Skills:
@@ -210,6 +265,24 @@ DoTEffect_hell:
     - damage{a=100} @target  # 2x50
     - delay 20
     - damage{a=100} @target  # 2x50
+
+FlamingShot_hell-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+FlamingShot_hell-Hit:
+  Skills:
+    - damage{a=300} @target  # 2x150
+    - skill{s=DoTEffect_hell} @target
+
+PowerfulFlamingShot_hell-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+PowerfulFlamingShot_hell-Hit:
+  Skills:
+    - damage{a=400} @target  # 2x200
+    - skill{s=DoTEffect_hell} @target
 
 # Mission 3 Boss Skills
 SummonSnakes_hell:
@@ -221,11 +294,23 @@ SummonSnakes_hell:
 ScatteredShot_hell:
   Cooldown: 10
   Skills:
-    - shoot{type=ARROW;velocity=20;damage=300;spread=12;amount=5}  # 2x150
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=ScatteredShot_hell-Tick;onHit=ScatteredShot_hell-Hit;v=20;i=ARROW;hR=1;vR=1;spread=12;amount=5}
 
 MeleeAttack_hell:
   Skills:
-    - damage{a=400} @target  # 2x200
+    - effect:particles{p=SWEEP_ATTACK;amount=1} @targetlocation
+    - delay 10
+    - damage{a=400} @PlayersInRadius{r=1} @targetlocation  # 2x200
+
+ScatteredShot_hell-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+ScatteredShot_hell-Hit:
+  Skills:
+    - damage{a=300} @target  # 2x150
 
 SummonReinforcements_hell:
   Conditions:
@@ -239,14 +324,17 @@ SummonReinforcements_hell:
 
 SnakeAttack_hell:
   Skills:
-    - damage{a=200} @target  # 2x100
-    - potion{type=SLOW;duration=60;level=3} @target
+    - effect:particles{p=WAX_OFF;amount=10} @targetlocation
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=1} @targetlocation  # 2x100
+    - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=1} @targetlocation
 
 SnakeExplosion_hell:
   Skills:
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
     - damage{a=300} @PlayersInRadius{r=3}  # 2x150
     - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
 
 # Mission 1 Skills - Blood version (5x damage)
 PetrifyingGaze_blood:
@@ -268,40 +356,47 @@ Venom-Hit-Blood:
 ShockAttack_blood:
   Cooldown: 10
   Skills:
-    - damage{a=750} @target # 5x150
-    - effect:particles{p=WAX_OFF;amount=20} @target
-    - potion{type=SLOW;duration=80;level=3} @target
+    - effect:particles{p=WAX_OFF;amount=20} @targetlocation
+    - delay 20
+    - damage{a=750} @PlayersInRadius{r=2} @targetlocation # 5x150
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=2} @targetlocation
 
 DeathExplosion_blood:
   Skills:
-    - damage{a=1000} @PlayersInRadius{r=5} # 5x200
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
+    - damage{a=1000} @PlayersInRadius{r=5} # 5x200
     - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
 
 SmallDeathExplosion_blood:
   Skills:
-    - damage{a=500} @PlayersInRadius{r=3} # 5x100
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
+    - damage{a=500} @PlayersInRadius{r=3} # 5x100
 
 PowerfulStrike_blood:
   Cooldown: 15
   Skills:
-    - damage{a=1000} @target # 5x200
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particles{p=CRIT;amount=20} @targetlocation
+    - delay 20
+    - damage{a=1000} @PlayersInRadius{r=2} @targetlocation # 5x200
 
 StunStrike_blood:
   Cooldown: 15
   Skills:
-    - damage{a=750} @target # 5x150
-    - potion{type=SLOW;duration=100;level=6} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particles{p=CRIT;amount=20} @targetlocation
+    - delay 20
+    - damage{a=750} @PlayersInRadius{r=2} @targetlocation # 5x150
+    - potion{type=SLOW;duration=100;level=6} @PlayersInRadius{r=2} @targetlocation
 
 LeapAttack_blood:
   Cooldown: 10
   Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
+    - effect:particles{p=CLOUD;amount=20} @targetlocation
+    - delay 20
     - jump{velocity=1;height=1} @target
-    - damage{a=750} @target # 5x150
+    - delay 10
+    - damage{a=750} @PlayersInRadius{r=2} @targetlocation # 5x150
 
 # Mission 2 Skills
 SummonJabbax_blood:
@@ -313,20 +408,24 @@ SummonJabbax_blood:
 FlamingShot_blood:
   Cooldown: 8
   Skills:
-    - shoot{type=ARROW;velocity=20;damage=750} @target # 5x150
-    - skill{s=DoTEffect_blood} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=FlamingShot_blood-Tick;onHit=FlamingShot_blood-Hit;v=20;i=ARROW;hR=1;vR=1} @target
 
 BurningStrike_blood:
   Cooldown: 8
   Skills:
-    - damage{a=750} @target # 5x150
-    - skill{s=DoTEffect_blood} @target
+    - effect:particles{p=CRIT;amount=10} @targetlocation
+    - delay 20
+    - damage{a=750} @PlayersInRadius{r=1} @targetlocation # 5x150
+    - skill{s=DoTEffect_blood} @PlayersInRadius{r=1} @targetlocation
 
 PowerfulFlamingShot_blood:
   Cooldown: 10
   Skills:
-    - shoot{type=ARROW;velocity=25;damage=1000} @target # 5x200
-    - skill{s=DoTEffect_blood} @target
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=PowerfulFlamingShot_blood-Tick;onHit=PowerfulFlamingShot_blood-Hit;v=25;i=ARROW;hR=1;vR=1} @target
 
 DoTEffect_blood:
   Skills:
@@ -334,6 +433,24 @@ DoTEffect_blood:
     - damage{a=250} @target # 5x50
     - delay 20
     - damage{a=250} @target # 5x50
+
+FlamingShot_blood-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+FlamingShot_blood-Hit:
+  Skills:
+    - damage{a=750} @target # 5x150
+    - skill{s=DoTEffect_blood} @target
+
+PowerfulFlamingShot_blood-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+PowerfulFlamingShot_blood-Hit:
+  Skills:
+    - damage{a=1000} @target # 5x200
+    - skill{s=DoTEffect_blood} @target
 
 # Mission 3 Boss Skills
 SummonSnakes_blood:
@@ -345,11 +462,23 @@ SummonSnakes_blood:
 ScatteredShot_blood:
   Cooldown: 10
   Skills:
-    - shoot{type=ARROW;velocity=20;damage=750;spread=12;amount=5} # 5x150
+    - effect:particles{p=CRIT;amount=10} @self
+    - delay 20
+    - projectile{onTick=ScatteredShot_blood-Tick;onHit=ScatteredShot_blood-Hit;v=20;i=ARROW;hR=1;vR=1;spread=12;amount=5} @target
 
 MeleeAttack_blood:
   Skills:
-    - damage{a=1000} @target # 5x200
+    - effect:particles{p=SWEEP_ATTACK;amount=1} @targetlocation
+    - delay 10
+    - damage{a=1000} @PlayersInRadius{r=1} @targetlocation # 5x200
+
+ScatteredShot_blood-Tick:
+  Skills:
+    - effect:particles{p=CRIT;amount=5} @origin
+
+ScatteredShot_blood-Hit:
+  Skills:
+    - damage{a=750} @target # 5x150
 
 SummonReinforcements_blood:
   Conditions:
@@ -363,11 +492,14 @@ SummonReinforcements_blood:
 
 SnakeAttack_blood:
   Skills:
-    - damage{a=500} @target # 5x100
-    - potion{type=SLOW;duration=80;level=3} @target
+    - effect:particles{p=WAX_OFF;amount=10} @targetlocation
+    - delay 20
+    - damage{a=500} @PlayersInRadius{r=1} @targetlocation # 5x100
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=1} @targetlocation
 
 SnakeExplosion_blood:
   Skills:
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - delay 20
     - damage{a=750} @PlayersInRadius{r=3} # 5x150
     - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self

--- a/skills/q2.yml
+++ b/skills/q2.yml
@@ -6,8 +6,9 @@
 MagicProjectile_inf:
   Cooldown: 5
   Skills:
-    - damage{a=40} @target
-    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @target
+    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @targetlocation
+    - delay 20
+    - damage{a=40} @PlayersInRadius{r=1} @targetlocation
 
 # Summon Sphere for Death Witch (Infernal)
 SummonSphere_inf:
@@ -20,8 +21,9 @@ SummonSphere_inf:
 MagicProjectile_hell:
   Cooldown: 4
   Skills:
-    - damage{a=80} @target
-    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @target
+    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @targetlocation
+    - delay 20
+    - damage{a=80} @PlayersInRadius{r=1} @targetlocation
 
 # Summon Sphere for Death Witch (Hell)
 SummonSphere_hell:
@@ -34,8 +36,9 @@ SummonSphere_hell:
 MagicProjectile_blood:
   Cooldown: 3
   Skills:
-    - damage{a=200} @target
-    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @target
+    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @targetlocation
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=1} @targetlocation
 
 # Summon Sphere for Death Witch (Blood)
 SummonSphere_blood:
@@ -49,27 +52,30 @@ VineChase_inf:
   Cooldown: 15
   Skills:
     - message{m="&6Corrupted Root Creature unleashes vines!"}
-    - effect:particles{p=BLOCK_CRACK;material=VINE;amount=5;hS=0.5;vS=0.5} @target
-    - damage{a=100} @target
-    - potion{type=SLOW;duration=100;level=2} @target
+    - effect:particles{p=BLOCK_CRACK;material=VINE;amount=5;hS=0.5;vS=0.5} @targetlocation
+    - delay 20
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=100;level=2} @PlayersInRadius{r=1} @targetlocation
 
 # Vine Chase for Corrupted Root Creature (Hell)
 VineChase_hell:
   Cooldown: 12
   Skills:
     - message{m="&6Corrupted Root Creature unleashes vines!"}
-    - effect:particles{p=BLOCK_CRACK;material=VINE;amount=7;hS=0.5;vS=0.5} @target
-    - damage{a=200} @target
-    - potion{type=SLOW;duration=120;level=3} @target
+    - effect:particles{p=BLOCK_CRACK;material=VINE;amount=7;hS=0.5;vS=0.5} @targetlocation
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=120;level=3} @PlayersInRadius{r=1} @targetlocation
 
 # Vine Chase for Corrupted Root Creature (Blood)
 VineChase_blood:
   Cooldown: 10
   Skills:
     - message{m="&6Corrupted Root Creature unleashes vines!"}
-    - effect:particles{p=BLOCK_CRACK;material=VINE;amount=10;hS=0.5;vS=0.5} @target
-    - damage{a=500} @target
-    - potion{type=SLOW;duration=140;level=4} @target
+    - effect:particles{p=BLOCK_CRACK;material=VINE;amount=10;hS=0.5;vS=0.5} @targetlocation
+    - delay 20
+    - damage{a=500} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=140;level=4} @PlayersInRadius{r=1} @targetlocation
 
 # Summoning Sphere for Xerib (Infernal)
 SummoningSphereXerib_inf:
@@ -84,19 +90,19 @@ PoisonMagicProjectile_inf:
   Cooldown: 10
   Skills:
     - message{m="&5Xerib hisses: &d'Taste my venom!'"}
-    - damage{a=60} @target
-    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @target
-    # Opóźnione obrażenia zamiast 'repeat'
+    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @targetlocation
     - delay 20
-    - damage{a=20} @target
+    - damage{a=60} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=20} @target
+    - damage{a=20} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=20} @target
+    - damage{a=20} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=20} @target
+    - damage{a=20} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=20} @target
+    - damage{a=20} @PlayersInRadius{r=1} @targetlocation
+    - delay 20
+    - damage{a=20} @PlayersInRadius{r=1} @targetlocation
 
 # Falling Poison Sphere for Xerib (Infernal)
 FallingPoisonSphere_inf:
@@ -104,6 +110,7 @@ FallingPoisonSphere_inf:
   Skills:
     - message{m="&5Xerib cackles: &d'Feel the wrath from above!'"}
     - effect:particles{p=SUSPENDED;amount=50;speed=1} @location
+    - delay 20
     - damage{a=<caster.mhp>*0.1} @PlayersInRadius{r=5}
     - potion{type=POISON;duration=80;level=2} @PlayersInRadius{r=5}
 
@@ -120,19 +127,19 @@ PoisonMagicProjectile_hell:
   Cooldown: 8
   Skills:
     - message{m="&5Xerib hisses: &d'Taste my venom!'"}
-    - damage{a=120} @target
-    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @target
-    # Opóźnione obrażenia zamiast 'repeat'
+    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @targetlocation
     - delay 20
-    - damage{a=40} @target
+    - damage{a=120} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=40} @target
+    - damage{a=40} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=40} @target
+    - damage{a=40} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=40} @target
+    - damage{a=40} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=40} @target
+    - damage{a=40} @PlayersInRadius{r=1} @targetlocation
+    - delay 20
+    - damage{a=40} @PlayersInRadius{r=1} @targetlocation
 
 # Falling Poison Sphere for Xerib (Hell)
 FallingPoisonSphere_hell:
@@ -140,6 +147,7 @@ FallingPoisonSphere_hell:
   Skills:
     - message{m="&5Xerib cackles: &d'Feel the wrath from above!'"}
     - effect:particles{p=SUSPENDED;amount=70;speed=1} @location
+    - delay 20
     - damage{a=<caster.mhp>*0.1} @PlayersInRadius{r=5}
     - potion{type=POISON;duration=100;level=3} @PlayersInRadius{r=5}
 
@@ -156,19 +164,19 @@ PoisonMagicProjectile_blood:
   Cooldown: 6
   Skills:
     - message{m="&5Xerib hisses: &d'Taste my venom!'"}
-    - damage{a=300} @target
-    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @target
-    # Opóźnione obrażenia zamiast 'repeat'
+    - effect:particles{p=SPELL_WITCH;amount=20;speed=1} @targetlocation
     - delay 20
-    - damage{a=100} @target
+    - damage{a=300} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=100} @target
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=100} @target
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=100} @target
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
     - delay 20
-    - damage{a=100} @target
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
+    - delay 20
+    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
 
 # Falling Poison Sphere for Xerib (Blood)
 FallingPoisonSphere_blood:
@@ -176,6 +184,7 @@ FallingPoisonSphere_blood:
   Skills:
     - message{m="&5Xerib cackles: &d'Feel the wrath from above!'"}
     - effect:particles{p=SUSPENDED;amount=100;speed=1} @location
+    - delay 20
     - damage{a=<caster.mhp>*0.1} @PlayersInRadius{r=5}
     - potion{type=POISON;duration=120;level=4} @PlayersInRadius{r=5}
 
@@ -183,28 +192,31 @@ FallingPoisonSphere_blood:
 ThrowStone_inf:
   Cooldown: 12
   Skills:
-    - damage{a=150} @target
-    - potion{type=SLOW;duration=100;level=3} @target
-    - potion{type=CONFUSION;duration=100;level=1} @target
-    - effect:particles{p=BLOCK_BREAK;material=COBBLESTONE;amount=30} @target
+    - effect:particles{p=BLOCK_BREAK;material=COBBLESTONE;amount=30} @targetlocation
+    - delay 20
+    - damage{a=150} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=100;level=3} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=CONFUSION;duration=100;level=1} @PlayersInRadius{r=1} @targetlocation
 
 # Throw Stone for Archus the Mad (Hell)
 ThrowStone_hell:
   Cooldown: 10
   Skills:
-    - damage{a=300} @target
-    - potion{type=SLOW;duration=120;level=4} @target
-    - potion{type=CONFUSION;duration=120;level=1} @target
-    - effect:particles{p=BLOCK_BREAK;material=COBBLESTONE;amount=40} @target
+    - effect:particles{p=BLOCK_BREAK;material=COBBLESTONE;amount=40} @targetlocation
+    - delay 20
+    - damage{a=300} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=120;level=4} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=CONFUSION;duration=120;level=1} @PlayersInRadius{r=1} @targetlocation
 
 # Throw Stone for Archus the Mad (Blood)
 ThrowStone_blood:
   Cooldown: 8
   Skills:
-    - damage{a=750} @target
-    - potion{type=SLOW;duration=140;level=5} @target
-    - potion{type=CONFUSION;duration=140;level=2} @target
-    - effect:particles{p=BLOCK_BREAK;material=COBBLESTONE;amount=50} @target
+    - effect:particles{p=BLOCK_BREAK;material=COBBLESTONE;amount=50} @targetlocation
+    - delay 20
+    - damage{a=750} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=SLOW;duration=140;level=5} @PlayersInRadius{r=1} @targetlocation
+    - potion{type=CONFUSION;duration=140;level=2} @PlayersInRadius{r=1} @targetlocation
 
 # Web Shot for Arachna (Infernal)
 WebShot_inf:

--- a/skills/q3.yml
+++ b/skills/q3.yml
@@ -41,6 +41,7 @@ FrostExplosion:
   Cooldown: 15
   Skills:
     - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - delay 40
     - damage{a=200} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
 
@@ -117,6 +118,7 @@ FrostExplosion_hell:
   Cooldown: 15
   Skills:
     - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - delay 40
     - damage{a=400} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
 
@@ -189,6 +191,7 @@ FrostExplosion_blood:
   Cooldown: 15
   Skills:
     - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - delay 40
     - damage{a=1000} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
 

--- a/skills/q4.yml
+++ b/skills/q4.yml
@@ -16,7 +16,11 @@ SummonHoundPack_inf:
 PowerShot_inf:
   Cooldown: 15
   Skills:
+    - message{m="&c<mob.name>&f prepares a powerful shot!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=200} @Target
+
 
 # Mission 2 Skills
 TransformPhase2_inf:
@@ -107,6 +111,9 @@ Whirlwind_inf:
 ShootLightning_inf:
   Cooldown: 10
   Skills:
+    - message{m="&c<mob.name>&f gathers lightning energy!"} @PlayersInRadius{r=30}
+    - effect:particles{p=END_ROD;amount=10;radius=1} @self
+    - delay 20
     - projectile{onTick=Lightning-Tick;onHit=Lightning-Hit;v=10;i=NETHER_STAR;hR=1;vR=1} @target
 
 Lightning-Tick:
@@ -137,6 +144,9 @@ SummonHoundPack_hell:
 PowerShot_hell:
   Cooldown: 15
   Skills:
+    - message{m="&c<mob.name>&f prepares a powerful shot!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=400} @Target  # 2x200
 
 # Mission 2 Skills
@@ -229,6 +239,9 @@ Whirlwind_hell:
 ShootLightning_hell:
   Cooldown: 10
   Skills:
+    - message{m="&c<mob.name>&f gathers lightning energy!"} @PlayersInRadius{r=30}
+    - effect:particles{p=END_ROD;amount=10;radius=1} @self
+    - delay 20
     - projectile{onTick=Lightning-Tick-Hell;onHit=Lightning-Hit-Hell;v=10;i=NETHER_STAR;hR=1;vR=1} @target
 
 Lightning-Tick-Hell:
@@ -259,6 +272,9 @@ SummonHoundPack_blood:
 PowerShot_blood:
   Cooldown: 15
   Skills:
+    - message{m="&c<mob.name>&f prepares a powerful shot!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=1000} @Target  # 5x200
 
 # Mission 2 Skills
@@ -351,6 +367,9 @@ Whirlwind_blood:
 ShootLightning_blood:
   Cooldown: 10
   Skills:
+    - message{m="&c<mob.name>&f gathers lightning energy!"} @PlayersInRadius{r=30}
+    - effect:particles{p=END_ROD;amount=10;radius=1} @self
+    - delay 20
     - projectile{onTick=Lightning-Tick-Blood;onHit=Lightning-Hit-Blood;v=10;i=NETHER_STAR;hR=1;vR=1} @target
 
 Lightning-Tick-Blood:
@@ -379,4 +398,7 @@ SummonHoundPack:
 PowerShot:
   Cooldown: 15
   Skills:
+    - message{m="&c<mob.name>&f prepares a powerful shot!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=200} @Target

--- a/skills/q5.yml
+++ b/skills/q5.yml
@@ -46,8 +46,9 @@ SlowAura_inf:
 DamageAura_inf:
   Cooldown: 10
   Skills:
-    - damage{a=50} @PlayersInRadius{r=5}
     - effect:particles{p=SPELL_WITCH;amount=30;radius=5} @self
+    - delay 20
+    - damage{a=50} @PlayersInRadius{r=5}
 
 RunFromPlayer_inf:
   Cooldown: 5
@@ -129,8 +130,9 @@ SlowAura_hell:
 DamageAura_hell:
   Cooldown: 10
   Skills:
-    - damage{a=100} @PlayersInRadius{r=5} # 2x50
     - effect:particles{p=SPELL_WITCH;amount=30;radius=5} @self
+    - delay 20
+    - damage{a=100} @PlayersInRadius{r=5} # 2x50
 
 RunFromPlayer_hell:
   Cooldown: 5
@@ -208,8 +210,9 @@ SlowAura_blood:
 DamageAura_blood:
   Cooldown: 10
   Skills:
-    - damage{a=250} @PlayersInRadius{r=5} # 5x50
     - effect:particles{p=SPELL_WITCH;amount=30;radius=5} @self
+    - delay 20
+    - damage{a=250} @PlayersInRadius{r=5} # 5x50
 
 RunFromPlayer_blood:
   Cooldown: 5

--- a/skills/q6.yml
+++ b/skills/q6.yml
@@ -11,6 +11,9 @@ DeathExplosion:
 WitheringShot:
   Cooldown: 10
   Skills:
+    - message{m="&6<mob.name>&f draws a withering arrow!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=200} @Target
     - potion{type=WITHER;duration=60;level=1} @Target
 
@@ -26,6 +29,9 @@ MeteorStrike:
 HomingOrb:
   Cooldown: 10
   Skills:
+    - message{m="&5<mob.name>&f forms a homing orb!"} @PlayersInRadius{r=30}
+    - effect:particles{p=DRAGON_BREATH;amount=20;radius=1} @self
+    - delay 20
     - projectile{onTick=Orb-Tick;onHit=Orb-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @target
 
 Orb-Tick:
@@ -125,6 +131,9 @@ DeathExplosion_hell:
 WitheringShot_hell:
   Cooldown: 10
   Skills:
+    - message{m="&6<mob.name>&f draws a withering arrow!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=400} @Target  # 2x200
     - potion{type=WITHER;duration=80;level=2} @Target
 
@@ -140,6 +149,9 @@ MeteorStrike_hell:
 HomingOrb_hell:
   Cooldown: 10
   Skills:
+    - message{m="&5<mob.name>&f forms a homing orb!"} @PlayersInRadius{r=30}
+    - effect:particles{p=DRAGON_BREATH;amount=20;radius=1} @self
+    - delay 20
     - projectile{onTick=Orb-Tick-Hell;onHit=Orb-Hit-Hell;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @target
 
 Orb-Hit-Hell:
@@ -235,6 +247,9 @@ DeathExplosion_blood:
 WitheringShot_blood:
   Cooldown: 10
   Skills:
+    - message{m="&6<mob.name>&f draws a withering arrow!"} @PlayersInRadius{r=30}
+    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
+    - delay 20
     - shoot{type=ARROW;velocity=30;damage=1000} @Target  # 5x200
     - potion{type=WITHER;duration=100;level=3} @Target
 
@@ -250,6 +265,9 @@ MeteorStrike_blood:
 HomingOrb_blood:
   Cooldown: 10
   Skills:
+    - message{m="&5<mob.name>&f forms a homing orb!"} @PlayersInRadius{r=30}
+    - effect:particles{p=DRAGON_BREATH;amount=20;radius=1} @self
+    - delay 20
     - projectile{onTick=Orb-Tick-Blood;onHit=Orb-Hit-Blood;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @target
 
 Orb-Hit-Blood:

--- a/skills/q7.yml
+++ b/skills/q7.yml
@@ -2,17 +2,19 @@
 FlameAttack:
   Cooldown: 15
   Skills:
-    - effect:particles{p=FLAME;amount=20} @target
-    - damage{a=150} @target
-    - ignite{ticks=60} @target
+    - effect:particles{p=FLAME;amount=20} @targetlocation
+    - delay 20
+    - damage{a=150} @PlayersInRadius{r=2} @targetlocation
+    - ignite{ticks=60} @PlayersInRadius{r=2} @targetlocation
 
 ThunderStrike:
   Cooldown: 12
   Skills:
-    - effect:particles{p=WAX_OFF;amount=30} @target
-    - damage{a=200} @target
-    - potion{type=LEVITATION;duration=40;level=1} @target
-    - potion{type=CONFUSION;duration=60;level=1} @target
+    - effect:particles{p=WAX_OFF;amount=30} @targetlocation
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=LEVITATION;duration=40;level=1} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=CONFUSION;duration=60;level=1} @PlayersInRadius{r=2} @targetlocation
 
 DeathExplosion:
   Cooldown: 1
@@ -26,6 +28,7 @@ LaserBeam:
   Cooldown: 10
   Skills:
     - effect:particles{p=END_ROD;amount=50} @Forward{f=10}
+    - delay 20
     - damage{a=100} @Forward{f=10}
 
 # Mission 2 Skills
@@ -40,20 +43,20 @@ FlameStrike:
   Cooldown: 5
   Skills:
     - message{m="&cThe Herald prepares to strike!"} @PlayersInRadius{r=20}
-    - delay 10
-    - damage{a=200} @target
-    - ignite{ticks=60} @target
-    - effect:particles{p=FLAME;amount=30} @target
+    - effect:particles{p=FLAME;amount=30} @targetlocation
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=2} @targetlocation
+    - ignite{ticks=60} @PlayersInRadius{r=2} @targetlocation
 
 PoweredFlameStrike:
   Cooldown: 10
   Skills:
     - message{m="&cThe Herald channels dark flames!"} @PlayersInRadius{r=20}
-    - delay 10
-    - damage{a=600} @target
-    - ignite{ticks=100} @target
-    - potion{type=SLOW;duration=60;level=2} @target
-    - effect:particles{p=FLAME;amount=50} @target
+    - effect:particles{p=FLAME;amount=50} @targetlocation
+    - delay 20
+    - damage{a=600} @PlayersInRadius{r=2} @targetlocation
+    - ignite{ticks=100} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=2} @targetlocation
 
 MeteorShower:
   Cooldown: 15
@@ -81,17 +84,19 @@ SummonFlamespawnsLarge:
 FlameAttack_hell:
   Cooldown: 15
   Skills:
-    - effect:particles{p=FLAME;amount=20} @target
-    - damage{a=300} @target  # 2x150
-    - ignite{ticks=80} @target
+    - effect:particles{p=FLAME;amount=20} @targetlocation
+    - delay 20
+    - damage{a=300} @PlayersInRadius{r=2} @targetlocation  # 2x150
+    - ignite{ticks=80} @PlayersInRadius{r=2} @targetlocation
 
 ThunderStrike_hell:
   Cooldown: 12
   Skills:
-    - effect:particles{p=WAX_OFF;amount=30} @target
-    - damage{a=400} @target  # 2x200
-    - potion{type=LEVITATION;duration=60;level=2} @target
-    - potion{type=CONFUSION;duration=80;level=1} @target
+    - effect:particles{p=WAX_OFF;amount=30} @targetlocation
+    - delay 20
+    - damage{a=400} @PlayersInRadius{r=2} @targetlocation  # 2x200
+    - potion{type=LEVITATION;duration=60;level=2} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=CONFUSION;duration=80;level=1} @PlayersInRadius{r=2} @targetlocation
 
 DeathExplosion_hell:
   Cooldown: 1
@@ -105,6 +110,7 @@ LaserBeam_hell:
   Cooldown: 10
   Skills:
     - effect:particles{p=END_ROD;amount=50} @Forward{f=10}
+    - delay 20
     - damage{a=200} @Forward{f=10}  # 2x100
 
 # Mission 2 Skills
@@ -119,20 +125,20 @@ FlameStrike_hell:
   Cooldown: 5
   Skills:
     - message{m="&cThe Herald prepares to strike!"} @PlayersInRadius{r=20}
-    - delay 10
-    - damage{a=400} @target  # 2x200
-    - ignite{ticks=80} @target
-    - effect:particles{p=FLAME;amount=30} @target
+    - effect:particles{p=FLAME;amount=30} @targetlocation
+    - delay 20
+    - damage{a=400} @PlayersInRadius{r=2} @targetlocation  # 2x200
+    - ignite{ticks=80} @PlayersInRadius{r=2} @targetlocation
 
 PoweredFlameStrike_hell:
   Cooldown: 10
   Skills:
     - message{m="&cThe Herald channels dark flames!"} @PlayersInRadius{r=20}
-    - delay 10
-    - damage{a=1200} @target  # 2x600
-    - ignite{ticks=120} @target
-    - potion{type=SLOW;duration=80;level=3} @target
-    - effect:particles{p=FLAME;amount=50} @target
+    - effect:particles{p=FLAME;amount=50} @targetlocation
+    - delay 20
+    - damage{a=1200} @PlayersInRadius{r=2} @targetlocation  # 2x600
+    - ignite{ticks=120} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=2} @targetlocation
 
 MeteorShower_hell:
   Cooldown: 15
@@ -160,17 +166,19 @@ SummonFlamespawnsLarge_hell:
 FlameAttack_blood:
   Cooldown: 15
   Skills:
-    - effect:particles{p=FLAME;amount=20} @target
-    - damage{a=750} @target  # 5x150
-    - ignite{ticks=100} @target
+    - effect:particles{p=FLAME;amount=20} @targetlocation
+    - delay 20
+    - damage{a=750} @PlayersInRadius{r=2} @targetlocation  # 5x150
+    - ignite{ticks=100} @PlayersInRadius{r=2} @targetlocation
 
 ThunderStrike_blood:
   Cooldown: 12
   Skills:
-    - effect:particles{p=WAX_OFF;amount=30} @target
-    - damage{a=1000} @target  # 5x200
-    - potion{type=LEVITATION;duration=80;level=3} @target
-    - potion{type=CONFUSION;duration=100;level=2} @target
+    - effect:particles{p=WAX_OFF;amount=30} @targetlocation
+    - delay 20
+    - damage{a=1000} @PlayersInRadius{r=2} @targetlocation  # 5x200
+    - potion{type=LEVITATION;duration=80;level=3} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=CONFUSION;duration=100;level=2} @PlayersInRadius{r=2} @targetlocation
 
 DeathExplosion_blood:
   Cooldown: 1
@@ -184,6 +192,7 @@ LaserBeam_blood:
   Cooldown: 10
   Skills:
     - effect:particles{p=END_ROD;amount=50} @Forward{f=10}
+    - delay 20
     - damage{a=500} @Forward{f=10}  # 5x100
 
 # Mission 2 Skills
@@ -198,20 +207,20 @@ FlameStrike_blood:
   Cooldown: 5
   Skills:
     - message{m="&cThe Herald prepares to strike!"} @PlayersInRadius{r=20}
-    - delay 10
-    - damage{a=1000} @target  # 5x200
-    - ignite{ticks=100} @target
-    - effect:particles{p=FLAME;amount=30} @target
+    - effect:particles{p=FLAME;amount=30} @targetlocation
+    - delay 20
+    - damage{a=1000} @PlayersInRadius{r=2} @targetlocation  # 5x200
+    - ignite{ticks=100} @PlayersInRadius{r=2} @targetlocation
 
 PoweredFlameStrike_blood:
   Cooldown: 10
   Skills:
     - message{m="&cThe Herald channels dark flames!"} @PlayersInRadius{r=20}
-    - delay 10
-    - damage{a=3000} @target  # 5x600
-    - ignite{ticks=140} @target
-    - potion{type=SLOW;duration=100;level=4} @target
-    - effect:particles{p=FLAME;amount=50} @target
+    - effect:particles{p=FLAME;amount=50} @targetlocation
+    - delay 20
+    - damage{a=3000} @PlayersInRadius{r=2} @targetlocation  # 5x600
+    - ignite{ticks=140} @PlayersInRadius{r=2} @targetlocation
+    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=2} @targetlocation
 
 MeteorShower_blood:
   Cooldown: 15

--- a/skills/q8.yml
+++ b/skills/q8.yml
@@ -33,6 +33,7 @@ LightningZone:
   Skills:
     - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
     - effect:particles{p=WAX_OFF;amount=50;radius=5} @target
+    - delay 40
     - damage{a=100} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
 
@@ -85,6 +86,7 @@ IceStorm:
   Cooldown: 15
   Skills:
     - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - delay 40
     - damage{a=150} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
 
@@ -170,6 +172,7 @@ LightningZone_hell:
   Skills:
     - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
     - effect:particles{p=WAX_OFF;amount=50;radius=5} @target
+    - delay 40
     - damage{a=200} @PlayersInRadius{r=5}  # 2x100
     - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
 
@@ -214,6 +217,7 @@ IceStorm_hell:
   Cooldown: 15
   Skills:
     - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - delay 40
     - damage{a=300} @PlayersInRadius{r=5}  # 2x150
     - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
 
@@ -290,6 +294,7 @@ LightningZone_blood:
   Skills:
     - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
     - effect:particles{p=WAX_OFF;amount=50;radius=5} @target
+    - delay 40
     - damage{a=500} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
 
@@ -333,6 +338,7 @@ IceStorm_blood:
   Cooldown: 15
   Skills:
     - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - delay 40
     - damage{a=750} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
 

--- a/skills/q9.yml
+++ b/skills/q9.yml
@@ -30,6 +30,7 @@ GroundSlam:
   Cooldown: 15
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
+    - delay 40
     - damage{a=150} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
 
@@ -65,6 +66,7 @@ GroundPound:
   Cooldown: 15
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
+    - delay 40
     - damage{a=100} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=5}
 
@@ -136,6 +138,7 @@ GroundSlam_hell:
   Cooldown: 15
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
+    - delay 40
     - damage{a=300} @PlayersInRadius{r=5}  # 2x150
     - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
 
@@ -167,6 +170,7 @@ GroundPound_hell:
   Cooldown: 15
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
+    - delay 40
     - damage{a=200} @PlayersInRadius{r=5}  # 2x100
     - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=5}
 
@@ -234,6 +238,7 @@ GroundSlam_blood:
   Cooldown: 15
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
+    - delay 40
     - damage{a=750} @PlayersInRadius{r=5}  # 5x150
     - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
 
@@ -265,6 +270,7 @@ GroundPound_blood:
   Cooldown: 15
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
+    - delay 40
     - damage{a=500} @PlayersInRadius{r=5}  # 5x100
     - potion{type=SLOW;duration=80;level=4} @PlayersInRadius{r=5}
 

--- a/skills/tetanocetl.yml
+++ b/skills/tetanocetl.yml
@@ -1,5 +1,8 @@
 ShamanBlindnessBall:
   Skills:
+    - effect:particles{p=soul_fire_flame;amount=10;hS=0.4;vS=0.4} @Self
+    - sound{s=entity.wither.shoot;v=1;p=1} @Self
+    - delay 20
     - projectile{onHit=applyBlindness;v=5} @target
 applyBlindness:
   Skills:
@@ -12,6 +15,9 @@ ResurrectToltecWarrior:
 PoisonSpit:
   Cooldown: 15
   Skills:
+    - effect:particles{p=VILLAGER_ANGRY;amount=15;hS=0.5;vS=0.5} @Self
+    - sound{s=entity.llama.spit;v=1;p=1} @Self
+    - delay 20
     - projectile{onTick=PoisonSpit-Tick;onHit=PoisonSpit-Hit;v=4;i=1;hR=1;vR=1;hnp=true}
 PoisonSpit-Tick:
   Skills:


### PR DESCRIPTION
## Summary
- add pre-hit particles and wind-up to Q10 leap, shot, and melee abilities
- give Q7 bosses a visible charge before firing beams or calling down flame strikes
- telegraph gnome summons and demon attacks with portal particles and delays

## Testing
- `pip install pyyaml`
- `python generate_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_688f167dcd8c832a8c40dfe42380f164