### PR TITLE
Anchor Q10 combat skills and integrate Q9/Q8 VFX upgrades

### DIFF
--- a/mob_skills.md
+++ b/mob_skills.md
@@ -77,7 +77,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | Arachna, Scourge of Duria | WebShot_hell | 200 | 8 |
-|  | VenomSpit_hell | 300 | 10 |
+|  | VenomSpit_hell | 300 | 12 |
 |  | FallingPoisonSphere_hell | 0 | 12 |
 |  | SummonPoisonousSpiders_hell | None | 22 |
 | Xerib the Hunchback | SummoningSphereXerib_hell | None | 18 |
@@ -136,7 +136,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Undead King Heredur | FrostExplosion_hell | 400 | 15 |
 |  | SummonUndead_hell | None | 25 |
-|  | DeathBeam_hell | 0 | 20 |
+|  | DeathBeam_hell | 1000 | 20 |
 | Parallel World Evil Miller | SummonVillagers_hell | None | 30 |
 |  | IceBall_hell | 300 | 8 |
 |  | FrostExplosion_hell | 400 | 15 |
@@ -155,7 +155,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Undead King Heredur | FrostExplosion_blood | 1000 | 15 |
 |  | SummonUndead_blood | None | 25 |
-|  | DeathBeam_blood | 0 | 20 |
+|  | DeathBeam_blood | 2500 | 20 |
 | Parallel World Evil Miller | SummonVillagers_blood | None | 30 |
 |  | IceBall_blood | 750 | 8 |
 |  | FrostExplosion_blood | 1000 | 15 |
@@ -206,13 +206,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | PowerShot_hell | 400 | 15 |
 | Ulgar the Master Butcher | TransformPhase2_hell | None | None |
 |  | TransformPhase3_hell | None | None |
-|  | DeathExplosion_hell | 400 | 1 |
+|  | DeathExplosion_hell | 500 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_hell | None | None |
 |  | TransformPhase3_hell | None | None |
-|  | DeathExplosion_hell | 400 | 1 |
+|  | DeathExplosion_hell | 500 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_hell | None | None |
 |  | TransformPhase3_hell | None | None |
-|  | DeathExplosion_hell | 400 | 1 |
+|  | DeathExplosion_hell | 500 | 1 |
 | Sanguine Clan`s Raging Snooper | - | - | - |
 | Sanguine Clan`s Raging Hunter | SummonHounds_hell | None | 30 |
 | Eternal Root Creature | - | - | - |
@@ -232,13 +232,13 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | PowerShot_blood | 1000 | 15 |
 | Ulgar the Master Butcher | TransformPhase2_blood | None | None |
 |  | TransformPhase3_blood | None | None |
-|  | DeathExplosion_blood | 1000 | 1 |
+|  | DeathExplosion_blood | 1200 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_blood | None | None |
 |  | TransformPhase3_blood | None | None |
-|  | DeathExplosion_blood | 1000 | 1 |
+|  | DeathExplosion_blood | 1200 | 1 |
 | Ulgar the Master Butcher | TransformPhase2_blood | None | None |
 |  | TransformPhase3_blood | None | None |
-|  | DeathExplosion_blood | 1000 | 1 |
+|  | DeathExplosion_blood | 1200 | 1 |
 | Sanguine Clan`s Raging Snooper | - | - | - |
 | Sanguine Clan`s Raging Hunter | SummonHounds_blood | None | 30 |
 | Eternal Root Creature | - | - | - |
@@ -280,9 +280,9 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Khalys, Leader of the Cultists | SummonCopy_hell | None | 45 |
 |  | MagicMissile_hell | 400 | 10 |
 |  | Teleport_hell | None | 30 |
-|  | DeathBeam_hell | 0 | 20 |
+|  | DeathBeam_hell | 1000 | 20 |
 | Parallel World Old Jabbax Shaman | SummonMaggots_hell | None | 30 |
-|  | MeteorStrike_hell | 500 | 15 |
+|  | MeteorStrike_hell | 650 | 15 |
 | Wandering Experiment | RunFromPlayer_hell | None | 5 |
 | Furious Andermagic | FireballAttack_hell | 300 | 10 |
 | Wailing Andermagic Ghost | SlowAura_hell | None | 5 |
@@ -301,9 +301,9 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Khalys, Leader of the Cultists | SummonCopy_blood | None | 45 |
 |  | MagicMissile_blood | 1000 | 10 |
 |  | Teleport_blood | None | 30 |
-|  | DeathBeam_blood | 0 | 20 |
+|  | DeathBeam_blood | 2500 | 20 |
 | Parallel World Old Jabbax Shaman | SummonMaggots_blood | None | 30 |
-|  | MeteorStrike_blood | 1250 | 15 |
+|  | MeteorStrike_blood | 1600 | 15 |
 | Wandering Experiment | RunFromPlayer_blood | None | 5 |
 | Furious Andermagic | FireballAttack_blood | 750 | 10 |
 | Wailing Andermagic Ghost | SlowAura_blood | None | 5 |
@@ -322,77 +322,115 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Skeledragon | DragonBreath | 200 | 15 |
+| Skeledragon | DragonBreath | 90 | 12 |
 |  | SummonPhase2 | None | None |
-| Mortis & Skeledragon | DragonBreath | 200 | 15 |
-|  | ScytheWhirlwind | 400 | 20 |
-|  | SummonPhase3 | None | None |
-| Mortis, Unchained God of Death | ScytheWhirlwind | 400 | 20 |
-|  | DeathDash | 500 | 10 |
-|  | HealingPulse | None | 15 |
 |  | DeathZone | 99999 | 25 |
-|  | SummonDragon | None | 60 |
-| Mortis Death Knight | DeathExplosion | 200 | 1 |
-| Murot, High Priest of Mortis | MeteorStrike | 300 | 15 |
-|  | HomingOrb | 150 | 10 |
-| Death Knight | DeathExplosion | 200 | 1 |
-| Death Archer | WitheringShot | 200 | 10 |
-| Fallen Warrior | - | - | - |
-| Fallen Archer | - | - | - |
-| Elite Skeleton Archer | - | - | - |
-| Raging Soul | - | - | - |
-| Elite Skeleton Warrior | - | - | - |
+| Mortis & Skeledragon | DragonBreath | 90 | 12 |
+|  | ScytheWhirlwind | 140 | 16 |
+|  | SummonPhase3 | None | None |
+|  | DragonBreath | 90 | 12 |
+|  | ScytheWhirlwind | 140 | 16 |
+| Mortis, Unchained God of Death | ScytheWhirlwind | 140 | 16 |
+|  | DeathDash | 220 | 12 |
+|  | HealingPulse | None | 20 |
+|  | DeathZone | 99999 | 25 |
+|  | SummonDragon | None | None |
+|  | DeathZone | 99999 | 25 |
+| Mortis Death Knight | DeathExplosion | 220 | 1 |
+|  | ScytheWhirlwind | 140 | 16 |
+|  | DeathDash | 220 | 12 |
+|  | HealingPulse | None | 20 |
+| Murot, High Priest of Mortis | MeteorStrike | 320 | 15 |
+|  | HomingOrb | 170 | 10 |
+|  | MeteorStrike | 320 | 15 |
+|  | HealingPulse | None | 20 |
+| Death Knight | DeathExplosion | 220 | 1 |
+|  | ScytheWhirlwind | 140 | 16 |
+| Death Archer | WitheringShot | 220 | 10 |
+|  | HomingOrb | 170 | 10 |
+| Fallen Warrior | DeathDash | 220 | 12 |
+| Fallen Archer | WitheringShot | 220 | 10 |
+| Elite Skeleton Archer | WitheringShot | 220 | 10 |
+|  | HomingOrb | 170 | 10 |
+| Raging Soul | DeathExplosion | 220 | 1 |
+| Elite Skeleton Warrior | DeathDash | 220 | 12 |
+|  | ScytheWhirlwind | 140 | 16 |
 
 ### Poziom trudności: hell
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Skeledragon | DragonBreath_hell | 400 | 15 |
+| Skeledragon | DragonBreath_hell | 140 | 12 |
 |  | SummonPhase2_hell | None | None |
-| Mortis & Skeledragon | DragonBreath_hell | 400 | 15 |
-|  | ScytheWhirlwind_hell | 800 | 20 |
-|  | SummonPhase3_hell | None | None |
-| Mortis, Unchained God of Death | ScytheWhirlwind_hell | 800 | 20 |
-|  | DeathDash_hell | 1000 | 10 |
-|  | HealingPulse_hell | None | 15 |
 |  | DeathZone_hell | 99999 | 25 |
-|  | SummonDragon_hell | None | 60 |
-| Mortis Death Knight | DeathExplosion_hell | 400 | 1 |
-| Murot, High Priest of Mortis | MeteorStrike_hell | 500 | 15 |
+| Mortis & Skeledragon | DragonBreath_hell | 140 | 12 |
+|  | ScytheWhirlwind_hell | 260 | 16 |
+|  | SummonPhase3_hell | None | None |
+|  | DragonBreath_hell | 140 | 12 |
+|  | ScytheWhirlwind_hell | 260 | 16 |
+| Mortis, Unchained God of Death | ScytheWhirlwind_hell | 260 | 16 |
+|  | DeathDash_hell | 480 | 12 |
+|  | HealingPulse_hell | None | 20 |
+|  | DeathZone_hell | 99999 | 25 |
+|  | SummonDragon_hell | None | None |
+|  | DeathZone_hell | 99999 | 25 |
+| Mortis Death Knight | DeathExplosion_hell | 500 | 1 |
+|  | ScytheWhirlwind_hell | 260 | 16 |
+|  | DeathDash_hell | 480 | 12 |
+|  | HealingPulse_hell | None | 20 |
+| Murot, High Priest of Mortis | MeteorStrike_hell | 650 | 15 |
 |  | HomingOrb_hell | 300 | 10 |
-| Death Knight | DeathExplosion_hell | 400 | 1 |
-| Death Archer | WitheringShot_hell | 400 | 10 |
-| Fallen Warrior | - | - | - |
-| Fallen Archer | - | - | - |
-| Elite Skeleton Archer | - | - | - |
-| Raging Soul | - | - | - |
-| Elite Skeleton Warrior | - | - | - |
+|  | MeteorStrike_hell | 650 | 15 |
+|  | HealingPulse_hell | None | 20 |
+| Death Knight | DeathExplosion_hell | 500 | 1 |
+|  | ScytheWhirlwind_hell | 260 | 16 |
+| Death Archer | WitheringShot_hell | 450 | 10 |
+|  | HomingOrb_hell | 300 | 10 |
+| Fallen Warrior | DeathDash_hell | 480 | 12 |
+| Fallen Archer | WitheringShot_hell | 450 | 10 |
+| Elite Skeleton Archer | WitheringShot_hell | 450 | 10 |
+|  | HomingOrb_hell | 300 | 10 |
+| Raging Soul | DeathExplosion_hell | 500 | 1 |
+| Elite Skeleton Warrior | DeathDash_hell | 480 | 12 |
+|  | ScytheWhirlwind_hell | 260 | 16 |
 
 ### Poziom trudności: blood
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Skeledragon | DragonBreath_blood | 1000 | 15 |
+| Skeledragon | DragonBreath_blood | 220 | 12 |
 |  | SummonPhase2_blood | None | None |
-| Mortis & Skeledragon | DragonBreath_blood | 1000 | 15 |
-|  | ScytheWhirlwind_blood | 2000 | 20 |
-|  | SummonPhase3_blood | None | None |
-| Mortis, Unchained God of Death | ScytheWhirlwind_blood | 2000 | 20 |
-|  | DeathDash_blood | 2500 | 10 |
-|  | HealingPulse_blood | None | 15 |
-|  | HealingPulse_blood | None | 15 |
 |  | DeathZone_blood | 99999 | 25 |
-|  | SummonDragon_blood | None | 60 |
-| Mortis Death Knight | DeathExplosion_blood | 1000 | 1 |
-| Murot, High Priest of Mortis | MeteorStrike_blood | 1250 | 15 |
-|  | HomingOrb_blood | 750 | 10 |
-| Death Knight | DeathExplosion_blood | 1000 | 1 |
-| Death Archer | WitheringShot_blood | 1000 | 10 |
-| Fallen Warrior | - | - | - |
-| Fallen Archer | - | - | - |
-| Elite Skeleton Archer | - | - | - |
-| Raging Soul | - | - | - |
-| Elite Skeleton Warrior | - | - | - |
+| Mortis & Skeledragon | DragonBreath_blood | 220 | 12 |
+|  | ScytheWhirlwind_blood | 420 | 16 |
+|  | SummonPhase3_blood | None | None |
+|  | DragonBreath_blood | 220 | 12 |
+|  | ScytheWhirlwind_blood | 420 | 16 |
+| Mortis, Unchained God of Death | ScytheWhirlwind_blood | 420 | 16 |
+|  | DeathDash_blood | 1000 | 12 |
+|  | HealingPulse_blood | None | 20 |
+|  | DeathZone_blood | 99999 | 25 |
+|  | SummonDragon_blood | None | None |
+|  | DeathZone_blood | 99999 | 25 |
+| Mortis Death Knight | DeathExplosion_blood | 1200 | 1 |
+|  | ScytheWhirlwind_blood | 420 | 16 |
+|  | DeathDash_blood | 1000 | 12 |
+|  | HealingPulse_blood | None | 20 |
+| Murot, High Priest of Mortis | MeteorStrike_blood | 1600 | 15 |
+|  | HomingOrb_blood | 900 | 10 |
+|  | MeteorStrike_blood | 1600 | 15 |
+|  | HealingPulse_blood | None | 20 |
+| Death Knight | DeathExplosion_blood | 1200 | 1 |
+|  | ScytheWhirlwind_blood | 420 | 16 |
+| Death Archer | WitheringShot_blood | 1100 | 10 |
+|  | HomingOrb_blood | 900 | 10 |
+| Fallen Warrior | DeathDash_blood | 1000 | 12 |
+| Fallen Archer | WitheringShot_blood | 1100 | 10 |
+| Elite Skeleton Archer | WitheringShot_blood | 1100 | 10 |
+|  | HomingOrb_blood | 900 | 10 |
+| Raging Soul | DeathExplosion_blood | 1200 | 1 |
+| Elite Skeleton Warrior | DeathDash_blood | 1000 | 12 |
+|  | ScytheWhirlwind_blood | 420 | 16 |
 
 ## Q7
 
@@ -401,17 +439,17 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Herald of the Anderworld | FlameStrike | 200 | 5 |
-|  | MeteorShower | 300 | 15 |
-|  | SummonFlamespawnsLarge | None | 30 |
-| Iron Creeper Gate Guard | LaserBeam | 100 | 10 |
-| Commander Embersword | SummonFlamespawns | None | 30 |
+| Herald of the Anderworld | FlameStrike | 220 | 6 |
+|  | MeteorShower | 320 | 16 |
+|  | SummonFlamespawnsLarge | None | 28 |
+| Iron Creeper Gate Guard | LaserBeam | 90 | 8 |
+| Commander Embersword | SummonFlamespawns | None | 28 |
 |  | 60 |  |  |
-| Thundering Cyclops | ThunderStrike | 150 | None |
-| Dark Sentinel | DeathExplosion | 200 | 1 |
+| Thundering Cyclops | ThunderStrike | 240 | 10 |
+| Dark Sentinel | DeathExplosion | 220 | 1 |
 | Fireclaw Mercenary | 60 |  |  |
 | Bone Warder | - | - | - |
-| B-1000 Combat Mechanoid | FlameAttack | 150 | 15 |
+| B-1000 Combat Mechanoid | FlameAttack | 180 | 12 |
 | Wild Razorclaw | - | - | - |
 | Flamescale Defender | - | - | - |
 | Angry Flamespawn | - | - | - |
@@ -420,17 +458,17 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Herald of the Anderworld | FlameStrike_hell | 400 | 5 |
-|  | MeteorShower_hell | 500 | 15 |
-|  | SummonFlamespawnsLarge_hell | None | 30 |
-| Iron Creeper Gate Guard | LaserBeam_hell | 200 | 10 |
-| Commander Embersword | SummonFlamespawns_hell | None | 30 |
+| Herald of the Anderworld | FlameStrike_hell | 440 | 5 |
+|  | MeteorShower_hell | 500 | 14 |
+|  | SummonFlamespawnsLarge_hell | None | 28 |
+| Iron Creeper Gate Guard | LaserBeam_hell | 130 | 7 |
+| Commander Embersword | SummonFlamespawns_hell | None | 26 |
 |  | 80 |  |  |
-| Thundering Cyclops | ThunderStrike_hell | 400 | 12 |
-| Dark Sentinel | DeathExplosion_hell | 400 | 1 |
+| Thundering Cyclops | ThunderStrike_hell | 480 | 9 |
+| Dark Sentinel | DeathExplosion_hell | 500 | 1 |
 | Fireclaw Mercenary | 80 |  |  |
 | Bone Warder | - | - | - |
-| B-1000 Combat Mechanoid | FlameAttack_hell | 300 | 15 |
+| B-1000 Combat Mechanoid | FlameAttack_hell | 360 | 10 |
 | Wild Razorclaw | - | - | - |
 | Flamescale Defender | - | - | - |
 | Angry Flamespawn | - | - | - |
@@ -439,17 +477,17 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
-| Herald of the Anderworld | FlameStrike_blood | 1000 | 5 |
-|  | MeteorShower_blood | 1250 | 15 |
-|  | SummonFlamespawnsLarge_blood | None | 30 |
-| Iron Creeper Gate Guard | LaserBeam_blood | 500 | 10 |
-| Commander Embersword | SummonFlamespawns_blood | None | 30 |
+| Herald of the Anderworld | FlameStrike_blood | 750 | 5 |
+|  | MeteorShower_blood | 1250 | 12 |
+|  | SummonFlamespawnsLarge_blood | None | 26 |
+| Iron Creeper Gate Guard | LaserBeam_blood | 180 | 6 |
+| Commander Embersword | SummonFlamespawns_blood | None | 24 |
 |  | 100 |  |  |
-| Thundering Cyclops | ThunderStrike_blood | 1000 | 12 |
-| Dark Sentinel | DeathExplosion_blood | 1000 | 1 |
+| Thundering Cyclops | ThunderStrike_blood | 800 | 8 |
+| Dark Sentinel | DeathExplosion_blood | 1200 | 1 |
 | Fireclaw Mercenary | 100 |  |  |
 | Bone Warder | - | - | - |
-| B-1000 Combat Mechanoid | FlameAttack_blood | 750 | 15 |
+| B-1000 Combat Mechanoid | FlameAttack_blood | 600 | 8 |
 | Wild Razorclaw | - | - | - |
 | Flamescale Defender | - | - | - |
 | Angry Flamespawn | - | - | - |
@@ -490,7 +528,7 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |  | ImmunityPhase | None | None |
 |  | ImmunityPhase | None | None |
 | Shocking Forocity | LightningZone_hell | 200 | 15 |
-|  | TeleportStrike_hell | 400 | 20 |
+|  | TeleportStrike_hell | 500 | 20 |
 | Pale Enforcer | DashToPlayer_hell | 300 | 12 |
 |  | SummonPillagers_hell | None | 30 |
 | Big Heap of Ice | SummonIceHeaps_hell | None | None |
@@ -537,21 +575,22 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | M`Edusa | PetrifyingGaze | None | 15 |
-|  | AcidSpit | 200 | 10 |
+|  | AcidSpit | 40 | 8 |
 |  | SummonSnakes | None | 15 |
-| Asterion | ChargeAttack | 200 | 12 |
-|  | GroundSlam | 150 | 15 |
+| Asterion | ChargeAttack | 200 | 11 |
+|  | GroundSlam | 150 | 14 |
 | Ebicarus | PowerfulStrike | 50 | 15 |
-| Cohort Swordsman | HealingPulse | None | 15 |
+| Cohort Swordsman | HealingPulse | None | 20 |
 | Stone Golem | ThrowBoulder | 200 | 10 |
-| Zorlobb Warrior | StunningBlow | 150 | 12 |
-| Minotaur | ChargeAttack | 200 | 12 |
-|  | GroundPound | 100 | 15 |
-| Agile Satyr Warrior | - | - | - |
-| Perfidious Satyr Archer | - | - | - |
+|  | StoneShatter | 150 | None |
+| Zorlobb Warrior | StunningBlow | 150 | 11 |
+| Minotaur | ChargeAttack | 200 | 11 |
+|  | GroundPound |  |  |
+| Agile Satyr Warrior | SatyrWarCry | None | None |
+| Perfidious Satyr Archer | SatyrWarCry | None | None |
 | Jabbax | - | - | - |
 | Gorgon Acolyte | PoisonBolt | 100 | 8 |
-|  | Petrify | None | 15 |
+|  | Petrify |  |  |
 | Poisonous Snake | SnakeExplosion | 150 | None |
 
 ### Poziom trudności: hell
@@ -559,18 +598,19 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | M`Edusa | PetrifyingGaze_hell | None | 15 |
-|  | AcidSpit_hell | 400 | 10 |
+|  | AcidSpit_hell | 80 | 8 |
 |  | SummonSnakes_hell | None | 15 |
-| Asterion | ChargeAttack_hell | 400 | 12 |
-|  | GroundSlam_hell | 300 | 15 |
-| Ebicarus | PowerfulStrike_hell | 400 | 15 |
-| Cohort Swordsman | HealingPulse_hell | None | 15 |
+| Asterion | ChargeAttack_hell | 400 | 11 |
+|  | GroundSlam_hell | 200 | 14 |
+| Ebicarus | PowerfulStrike_hell | 100 | 15 |
+| Cohort Swordsman | HealingPulse_hell | None | 20 |
 | Stone Golem | ThrowBoulder_hell | 400 | 10 |
-| Zorlobb Warrior | StunningBlow_hell | 300 | 12 |
-| Minotaur | ChargeAttack_hell | 400 | 12 |
-|  | GroundPound_hell | 200 | 15 |
-| Agile Satyr Warrior | - | - | - |
-| Perfidious Satyr Archer | - | - | - |
+|  | StoneShatter_hell | 300 | None |
+| Zorlobb Warrior | StunningBlow_hell | 300 | 11 |
+| Minotaur | ChargeAttack_hell | 400 | 11 |
+|  | GroundPound_hell |  |  |
+| Agile Satyr Warrior | SatyrWarCry_hell | None | None |
+| Perfidious Satyr Archer | SatyrWarCry_hell | None | None |
 | Jabbax | - | - | - |
 | Gorgon Acolyte | PoisonBolt_hell | 200 | 8 |
 |  | Petrify_hell | None | 15 |
@@ -581,21 +621,22 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 | Mob | Skill | DMG | Cooldown |
 |-----|-------|-----|----------|
 | M`Edusa | PetrifyingGaze_blood | None | 15 |
-|  | AcidSpit_blood | 1000 | 10 |
+|  | AcidSpit_blood | 200 | 8 |
 |  | SummonSnakes_blood | None | 15 |
-| Asterion | ChargeAttack_blood | 1000 | 12 |
-|  | GroundSlam_blood | 750 | 15 |
-| Ebicarus | PowerfulStrike_blood | 1000 | 15 |
-| Cohort Swordsman | HealingPulse_blood | None | 15 |
+| Asterion | ChargeAttack_blood | 600 | 10 |
+|  | GroundSlam_blood | 300 | 14 |
+| Ebicarus | PowerfulStrike_blood | 250 | 15 |
+| Cohort Swordsman | HealingPulse_blood | None | 20 |
 | Stone Golem | ThrowBoulder_blood | 1000 | 10 |
-| Zorlobb Warrior | StunningBlow_blood | 750 | 12 |
-| Minotaur | ChargeAttack_blood | 1000 | 12 |
-|  | GroundPound_blood | 500 | 15 |
-| Agile Satyr Warrior | - | - | - |
-| Perfidious Satyr Archer | - | - | - |
+|  | StoneShatter_blood | 450 | None |
+| Zorlobb Warrior | StunningBlow_blood | 450 | 11 |
+| Minotaur | ChargeAttack_blood | 600 | 10 |
+|  | GroundPound_blood |  |  |
+| Agile Satyr Warrior | SatyrWarCry_blood | None | None |
+| Perfidious Satyr Archer | SatyrWarCry_blood | None | None |
 | Jabbax | - | - | - |
-| Gorgon Acolyte | PoisonBolt_blood | 500 | 8 |
-|  | Petrify_blood | None | 15 |
+| Gorgon Acolyte | PoisonBolt_blood | 300 | 8 |
+|  | Petrify_blood | None | 14 |
 | Poisonous Snake | SnakeExplosion_blood | 750 | None |
 
 ## Q10
@@ -607,17 +648,17 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Gorga | SummonSnakes | None | 15 |
 |  | ScatteredShot | 150 | 10 |
-|  | MeleeAttack | 100 | None |
+|  | MeleeAttack | 100 | 6 |
 |  | SummonReinforcements | None | None |
 | Melas the Swift-Footed | StunStrike | 45 | 15 |
-|  | LeapAttack | 70 | 10 |
+|  | LeapAttack | 60 | 6 |
 | Akheilos | PowerfulFlamingShot | 100 | 10 |
 | Scheming Gorgon | PetrifyingGaze | None | 15 |
-|  | VenomSpit | 50 | 10 |
-| Poisonous Jitterjelly | ShockAttack | 50 | 10 |
-|  | DeathExplosion | 200 | 1 |
+|  | AcidSpit | 40 | 8 |
+| Poisonous Jitterjelly | ZapBolt | 50 | 10 |
+|  | DeathExplosion | 220 | 1 |
 | Patrolling Jabbax | SummonJabbax | None | 15 |
-| Anderworld Jitterjelly | ShockAttack | 50 | 10 |
+| Anderworld Jitterjelly | ZapBolt | 50 | 10 |
 |  | SmallDeathExplosion | 100 | None |
 | Combat-Ready Zorlobb | PowerfulStrike | 50 | 15 |
 | Anderworld Jabbax | - | - | - |
@@ -632,19 +673,19 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Gorga | SummonSnakes_hell | None | 15 |
 |  | ScatteredShot_hell | 300 | 10 |
-|  | MeleeAttack_hell | 400 | None |
+|  | MeleeAttack_hell | 200 | 6 |
 |  | SummonReinforcements_hell | None | None |
-| Melas the Swift-Footed | StunStrike_hell | 300 | 15 |
-|  | LeapAttack_hell | 300 | 10 |
+| Melas the Swift-Footed | StunStrike_hell | 90 | 15 |
+|  | LeapAttack_hell | 120 | 6 |
 | Akheilos | PowerfulFlamingShot_hell | 400 | 10 |
 | Scheming Gorgon | PetrifyingGaze_hell | None | 15 |
-|  | VenomSpit_hell | 300 | 10 |
-| Poisonous Jitterjelly | ShockAttack_hell | 300 | 10 |
-|  | DeathExplosion_hell | 400 | 1 |
+|  | AcidSpit_hell | 80 | 8 |
+| Poisonous Jitterjelly | ZapBolt_hell | 100 | 10 |
+|  | DeathExplosion_hell | 500 | 1 |
 | Patrolling Jabbax | SummonJabbax_hell | None | 15 |
-| Anderworld Jitterjelly | ShockAttack_hell | 300 | 10 |
+| Anderworld Jitterjelly | ZapBolt_hell | 100 | 10 |
 |  | SmallDeathExplosion_hell | 200 | None |
-| Combat-Ready Zorlobb | PowerfulStrike_hell | 400 | 15 |
+| Combat-Ready Zorlobb | PowerfulStrike_hell | 100 | 15 |
 | Anderworld Jabbax | - | - | - |
 | Armed Khaross | FlamingShot_hell | 300 | 8 |
 | Mordacious Khaross | BurningStrike_hell | 300 | 8 |
@@ -657,19 +698,19 @@ Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 |-----|-------|-----|----------|
 | Gorga | SummonSnakes_blood | None | 15 |
 |  | ScatteredShot_blood | 750 | 10 |
-|  | MeleeAttack_blood | 1000 | None |
+|  | MeleeAttack_blood | 500 | 6 |
 |  | SummonReinforcements_blood | None | None |
-| Melas the Swift-Footed | StunStrike_blood | 750 | 15 |
-|  | LeapAttack_blood | 750 | 10 |
+| Melas the Swift-Footed | StunStrike_blood | 225 | 15 |
+|  | LeapAttack_blood | 300 | 6 |
 | Akheilos | PowerfulFlamingShot_blood | 1000 | 10 |
 | Scheming Gorgon | PetrifyingGaze_blood | None | 15 |
-|  | VenomSpit_blood | 750 | 10 |
-| Poisonous Jitterjelly | ShockAttack_blood | 750 | 10 |
-|  | DeathExplosion_blood | 1000 | 1 |
+|  | AcidSpit_blood | 200 | 8 |
+| Poisonous Jitterjelly | ZapBolt_blood | 250 | 10 |
+|  | DeathExplosion_blood | 1200 | 1 |
 | Patrolling Jabbax | SummonJabbax_blood | None | 15 |
-| Anderworld Jitterjelly | ShockAttack_blood | 750 | 10 |
+| Anderworld Jitterjelly | ZapBolt_blood | 250 | 10 |
 |  | SmallDeathExplosion_blood | 500 | None |
-| Combat-Ready Zorlobb | PowerfulStrike_blood | 1000 | 15 |
+| Combat-Ready Zorlobb | PowerfulStrike_blood | 250 | 15 |
 | Anderworld Jabbax | - | - | - |
 | Armed Khaross | FlamingShot_blood | 750 | 8 |
 | Mordacious Khaross | BurningStrike_blood | 750 | 8 |

--- a/mob_stats_exp.md
+++ b/mob_stats_exp.md
@@ -3,6 +3,13 @@
 Plik automatycznie wygenerowany z konfiguracji MythicMobs.
 
 
+## Poziom other
+
+| Nazwa | Typ | HP | DMG | Rzadkość |
+|-------|-----|----|-----|----------|
+| Overseer Kragg | WITHER_SKELETON | 9000 | 400 | Boss |
+| Cursed Miner | ZOMBIE | 1500 | 200 | Normal |
+
 ## Poziom 1-5
 
 | Nazwa | Typ | HP | DMG | Rzadkość |

--- a/mobs/q10_blood.yml
+++ b/mobs/q10_blood.yml
@@ -24,7 +24,7 @@ scheming_gorgon_blood:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=PetrifyingGaze_blood} @target ~onTimer:15
-    - skill{s=VenomSpit_blood} @target ~onTimer:10
+    - skill{s=AcidSpit_blood} @target ~onTimer:10
   Drops:
     - scheming_gorgon_blood_drop
     - q_blood_elite_crafting
@@ -49,7 +49,7 @@ poisonous_jitterjelly_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ShockAttack_blood} @target ~onTimer:10
+    - skill{s=ZapBolt_blood} @target ~onTimer:10
     - skill{s=DeathExplosion_blood} @self ~onDeath
   Drops:
     - poisonous_jitterjelly_blood_drop
@@ -75,7 +75,7 @@ anderworld_jitterjelly_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ShockAttack_blood} @target ~onTimer:12
+    - skill{s=ZapBolt_blood} @target ~onTimer:12
     - skill{s=SmallDeathExplosion_blood} @self ~onDeath
   Drops:
     - anderworld_jitterjelly_blood_drop

--- a/mobs/q10_hell.yml
+++ b/mobs/q10_hell.yml
@@ -24,7 +24,7 @@ scheming_gorgon_hell:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=PetrifyingGaze_hell} @target ~onTimer:15
-    - skill{s=VenomSpit_hell} @target ~onTimer:10
+    - skill{s=AcidSpit_hell} @target ~onTimer:10
   Drops:
     - scheming_gorgon_hell_drop
     - q_hell_elite_crafting
@@ -49,7 +49,7 @@ poisonous_jitterjelly_hell:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ShockAttack_hell} @target ~onTimer:10
+    - skill{s=ZapBolt_hell} @target ~onTimer:10
     - skill{s=DeathExplosion_hell} @self ~onDeath
   Drops:
     - poisonous_jitterjelly_hell_drop
@@ -75,7 +75,7 @@ anderworld_jitterjelly_hell:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ShockAttack_hell} @target ~onTimer:12
+    - skill{s=ZapBolt_hell} @target ~onTimer:12
     - skill{s=SmallDeathExplosion_hell} @self ~onDeath
   Drops:
     - anderworld_jitterjelly_hell_drop

--- a/mobs/q10_inf.yml
+++ b/mobs/q10_inf.yml
@@ -24,7 +24,7 @@ scheming_gorgon_inf:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=PetrifyingGaze} @target ~onTimer:15
-    - skill{s=VenomSpit} @target ~onTimer:10
+    - skill{s=AcidSpit} @target ~onTimer:10
   Drops:
     - scheming_gorgon_inf_drop
     - q_inf_elite_crafting
@@ -49,7 +49,7 @@ poisonous_jitterjelly_inf:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ShockAttack} @target ~onTimer:10
+    - skill{s=ZapBolt} @target ~onTimer:10
     - skill{s=DeathExplosion} @self ~onDeath
   Drops:
     - poisonous_jitterjelly_inf_drop
@@ -75,7 +75,7 @@ anderworld_jitterjelly_inf:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ShockAttack} @target ~onTimer:12
+    - skill{s=ZapBolt} @target ~onTimer:12
     - skill{s=SmallDeathExplosion} @self ~onDeath
   Drops:
     - anderworld_jitterjelly_inf_drop

--- a/mobs/q6_blood.yml
+++ b/mobs/q6_blood.yml
@@ -25,6 +25,7 @@ fallen_warrior_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=DeathDash_blood} @target ~onTimer:80 ?incombat
   Drops:
     - fallen_warrior_blood_drop
     - q_blood_mob_crafting
@@ -40,8 +41,8 @@ fallen_archer_blood:
     FollowRange: 20
     MovementSpeed: 0.2
     ShowHealth: true
-    PreventSunburn: true
     AlwaysShowName: true
+    PreventSunburn: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
@@ -54,6 +55,7 @@ fallen_archer_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=WitheringShot_blood} @target ~onTimer:110 ?incombat
   Drops:
     - fallen_archer_blood_drop
     - q_blood_mob_crafting
@@ -62,7 +64,7 @@ death_knight_blood:
   Type: SKELETON
   Display: '&e&lDeath Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 12000  # 10x1200
-  Damage: 1250   # 5x250
+  Damage: 1250  # 5x250
   Faction: q6_blood
   Group: q6_blood
   Options:
@@ -84,6 +86,7 @@ death_knight_blood:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=DeathExplosion_blood} @self ~onDeath
+    - skill{s=ScytheWhirlwind_blood} @self ~onTimer:140 ?incombat
   Drops:
     - death_knight_blood_drop
     - q_blood_elite_crafting
@@ -92,15 +95,15 @@ mortis_death_knight_blood:
   Type: SKELETON
   Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
-  Damage: 1500   # 5x300
+  Damage: 1500  # 5x300
   Faction: q6_blood
   Group: q6_blood
   Options:
     FollowRange: 15
     MovementSpeed: 0.2
     ShowHealth: true
-    PreventSunburn: true
     AlwaysShowName: true
+    PreventSunburn: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
@@ -116,6 +119,9 @@ mortis_death_knight_blood:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=DeathExplosion_blood} @self ~onDeath
+    - skill{s=ScytheWhirlwind_blood} @self ~onTimer:120 ?incombat
+    - skill{s=DeathDash_blood} @target ~onTimer:90 ?incombat
+    - skill{s=HealingPulse_blood} @self ~onTimer:200 ?incombat
   Drops:
     - mortis_death_knight_blood_drop
     - q_blood_elite_crafting
@@ -132,11 +138,11 @@ elite_skeleton_archer_blood:
     FollowRange: 25
     MovementSpeed: 0.3
     ShowHealth: true
-    PreventSunburn: true
     AlwaysShowName: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
+    PreventSunburn: true
   Equipment:
     - bow HAND
     - iron_helmet HEAD
@@ -146,6 +152,8 @@ elite_skeleton_archer_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=WitheringShot_blood} @target ~onTimer:90 ?incombat
+    - skill{s=HomingOrb_blood} @target ~onTimer:150 ?incombat
   Drops:
     - elite_skeleton_archer_blood_drop
     - q_blood_mob_crafting
@@ -154,18 +162,18 @@ death_archer_blood:
   Type: SKELETON
   Display: '&e&lDeath Archer &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 10000  # 10x1000
-  Damage: 1500   # 5x300
+  Damage: 1500  # 5x300
   Faction: q6_blood
   Group: q6_blood
   Options:
     FollowRange: 25
-    PreventSunburn: true
     MovementSpeed: 0.25
     ShowHealth: true
     AlwaysShowName: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
+    PreventSunburn: true
   Equipment:
     - bow HAND
     - netherite_helmet HEAD
@@ -175,7 +183,8 @@ death_archer_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=WitheringShot_blood} @target ~onTimer:10
+    - skill{s=WitheringShot_blood} @target ~onTimer:80 ?incombat
+    - skill{s=HomingOrb_blood} @target ~onTimer:120 ?incombat
   Drops:
     - death_archer_blood_drop
     - q_blood_elite_crafting
@@ -193,9 +202,9 @@ raging_soul_blood:
     ShowHealth: true
     AlwaysShowName: true
     PreventItemPickup: true
-    PreventSunburn: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
+    PreventSunburn: true
   Equipment:
     - leather_helmet{color=black} HEAD
     - leather_chestplate{color=black} CHEST
@@ -204,6 +213,7 @@ raging_soul_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=DeathExplosion_blood} @self ~onDeath
   Drops:
     - raging_soul_blood_drop
     - q_blood_mob_crafting
@@ -212,7 +222,7 @@ elite_skeleton_warrior_blood:
   Type: SKELETON
   Display: '&lElite Skeleton Warrior &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 10000  # 10x1000
-  Damage: 1000   # 5x200
+  Damage: 1000  # 5x200
   Faction: q6_blood
   Group: q6_blood
   Options:
@@ -234,6 +244,8 @@ elite_skeleton_warrior_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=DeathDash_blood} @target ~onTimer:70 ?incombat
+    - skill{s=ScytheWhirlwind_blood} @self ~onTimer:120 ?incombat
   Drops:
     - elite_skeleton_warrior_blood_drop
     - q_blood_mob_crafting
@@ -241,8 +253,8 @@ elite_skeleton_warrior_blood:
 murot_high_priest_blood:
   Type: SKELETON
   Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
-  Health: 30000  # 10x3000
-  Damage: 1000   # 5x200
+  Health: 30000
+  Damage: 1000
   Faction: q6_blood
   Group: q6_blood
   Options:
@@ -252,8 +264,8 @@ murot_high_priest_blood:
     AlwaysShowName: true
     PreventItemPickup: true
     PreventOtherDrops: true
-    PreventRandomEquipment: true
     PreventSunburn: true
+    PreventRandomEquipment: true
     KnockbackResistance: 0.5
     Despawn: CHUNK
   Equipment:
@@ -266,6 +278,8 @@ murot_high_priest_blood:
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=MeteorStrike_blood} @target ~onTimer:15
     - skill{s=HomingOrb_blood} @target ~onTimer:10
+    - skill{s=MeteorStrike_blood} @target ~onTimer:160 ?incombat
+    - skill{s=HealingPulse_blood} @self ~onTimer:200 ?incombat
   Drops:
     - murot_priest_blood_drop
     - q_blood_elite_crafting
@@ -275,24 +289,24 @@ skeledragon_phase1_blood:
   Type: Zombie
   Disguise: Horse
   Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
-  Health: 50000  # 10x5000
-  Damage: 1500   # 5x300
+  Health: 50000
+  Damage: 1500
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
     Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
-    Color: RED
+    Color: BLUE
     Style: SEGMENTED_12
   Options:
     FollowRange: 40
     MovementSpeed: 0.3
     ShowHealth: true
     AlwaysShowName: true
+    PreventSunburn: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
-    PreventSunburn: true
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Skills:
@@ -300,20 +314,21 @@ skeledragon_phase1_blood:
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=DragonBreath_blood} @target ~onTimer:15
     - skill{s=SummonPhase2_blood} @self ~onDeath
+    - skill{s=DeathZone_blood} @target ~onTimer:300 ?incombat
   Drops: []
 
 skeledragon_phase2_blood:
   Type: Zombie
   Disguise: Horse
   Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
-  Health: 70000  # 10x7000
-  Damage: 2000   # 5x400
+  Health: 70000
+  Damage: 2000
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
     Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
-    Color: RED
+    Color: BLUE
     Style: SEGMENTED_12
   Options:
     FollowRange: 40
@@ -332,28 +347,30 @@ skeledragon_phase2_blood:
     - skill{s=DragonBreath_blood} @target ~onTimer:15
     - skill{s=ScytheWhirlwind_blood} @self ~onTimer:20
     - skill{s=SummonPhase3_blood} @self ~onDeath
+    - skill{s=DragonBreath_blood} @target ~onTimer:15 ?incombat
+    - skill{s=ScytheWhirlwind_blood} @self ~onTimer:120 ?incombat
   Drops: []
 
 mortis_phase3_blood:
   Type: SKELETON
   Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
-  Health: 100000  # 10x10000
-  Damage: 2500    # 5x500
+  Health: 100000
+  Damage: 2500
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
     Title: '&c<&skull> Mortis - Final Phase <&skull>'
-    Color: RED
+    Color: BLUE
     Style: SEGMENTED_12
   Options:
     FollowRange: 40
     MovementSpeed: 0.3
     ShowHealth: true
-    PreventSunburn: true
     AlwaysShowName: true
     PreventItemPickup: true
     PreventOtherDrops: true
+    PreventSunburn: true
     PreventRandomEquipment: true
     KnockbackResistance: 0.8
     Despawn: CHUNK
@@ -369,8 +386,8 @@ mortis_phase3_blood:
     - skill{s=ScytheWhirlwind_blood} @self ~onTimer:20
     - skill{s=DeathDash_blood} @target ~onTimer:10
     - skill{s=HealingPulse_blood} @self ~onTimer:15
-    - skill{s=HealingPulse_blood} @self ~onTimer:15
     - skill{s=DeathZone_blood} @target ~onTimer:25
     - skill{s=SummonDragon_blood} @self ~onTimer:60 ?health{r=0.0to0.3}
+    - skill{s=DeathZone_blood} @target ~onTimer:220 ?incombat
   Drops:
     - mortis_blood_drop

--- a/mobs/q6_hell.yml
+++ b/mobs/q6_hell.yml
@@ -16,18 +16,19 @@ fallen_warrior_hell:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - iron_sword HAND
-    - shield OFFHAND
-    - iron_helmet HEAD
-    - iron_chestplate CHEST
-    - iron_leggings LEGS
-    - iron_boots FEET
+  - iron_sword HAND
+  - shield OFFHAND
+  - iron_helmet HEAD
+  - iron_chestplate CHEST
+  - iron_leggings LEGS
+  - iron_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathDash_hell} @target ~onTimer:80 ?incombat
   Drops:
-    - fallen_warrior_hell_drop
-    - q_hell_mob_crafting
+  - fallen_warrior_hell_drop
+  - q_hell_mob_crafting
 
 fallen_archer_hell:
   Type: SKELETON
@@ -46,17 +47,18 @@ fallen_archer_hell:
     PreventSunburn: true
     PreventRandomEquipment: true
   Equipment:
-    - bow HAND
-    - iron_helmet HEAD
-    - leather_chestplate CHEST
-    - leather_leggings LEGS
-    - leather_boots FEET
+  - bow HAND
+  - iron_helmet HEAD
+  - leather_chestplate CHEST
+  - leather_leggings LEGS
+  - leather_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=WitheringShot_hell} @target ~onTimer:110 ?incombat
   Drops:
-    - fallen_archer_hell_drop
-    - q_hell_mob_crafting
+  - fallen_archer_hell_drop
+  - q_hell_mob_crafting
 
 death_knight_hell:
   Type: SKELETON
@@ -75,18 +77,19 @@ death_knight_hell:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - netherite_sword HAND
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_sword HAND
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DeathExplosion_hell} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathExplosion_hell} @self ~onDeath
+  - skill{s=ScytheWhirlwind_hell} @self ~onTimer:140 ?incombat
   Drops:
-    - death_knight_hell_drop
-    - q_hell_elite_crafting
+  - death_knight_hell_drop
+  - q_hell_elite_crafting
 
 mortis_death_knight_hell:
   Type: SKELETON
@@ -107,18 +110,21 @@ mortis_death_knight_hell:
     KnockbackResistance: 0.5
     Despawn: CHUNK
   Equipment:
-    - netherite_sword HAND
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_sword HAND
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DeathExplosion_hell} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathExplosion_hell} @self ~onDeath
+  - skill{s=ScytheWhirlwind_hell} @self ~onTimer:120 ?incombat
+  - skill{s=DeathDash_hell} @target ~onTimer:90 ?incombat
+  - skill{s=HealingPulse_hell} @self ~onTimer:200 ?incombat
   Drops:
-    - mortis_death_knight_hell_drop
-    - q_hell_elite_crafting
+  - mortis_death_knight_hell_drop
+  - q_hell_elite_crafting
 
 # Mission 2 Mobs
 elite_skeleton_archer_hell:
@@ -138,17 +144,19 @@ elite_skeleton_archer_hell:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - bow HAND
-    - iron_helmet HEAD
-    - iron_chestplate CHEST
-    - iron_leggings LEGS
-    - iron_boots FEET
+  - bow HAND
+  - iron_helmet HEAD
+  - iron_chestplate CHEST
+  - iron_leggings LEGS
+  - iron_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=WitheringShot_hell} @target ~onTimer:90 ?incombat
+  - skill{s=HomingOrb_hell} @target ~onTimer:150 ?incombat
   Drops:
-    - elite_skeleton_archer_hell_drop
-    - q_hell_mob_crafting
+  - elite_skeleton_archer_hell_drop
+  - q_hell_mob_crafting
 
 death_archer_hell:
   Type: SKELETON
@@ -167,18 +175,19 @@ death_archer_hell:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - bow HAND
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - bow HAND
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=WitheringShot_hell} @target ~onTimer:10
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=WitheringShot_hell} @target ~onTimer:80 ?incombat
+  - skill{s=HomingOrb_hell} @target ~onTimer:120 ?incombat
   Drops:
-    - death_archer_hell_drop
-    - q_hell_elite_crafting
+  - death_archer_hell_drop
+  - q_hell_elite_crafting
 
 raging_soul_hell:
   Type: SKELETON
@@ -197,16 +206,17 @@ raging_soul_hell:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - leather_helmet{color=black} HEAD
-    - leather_chestplate{color=black} CHEST
-    - leather_leggings{color=black} LEGS
-    - leather_boots{color=black} FEET
+  - leather_helmet{color=black} HEAD
+  - leather_chestplate{color=black} CHEST
+  - leather_leggings{color=black} LEGS
+  - leather_boots{color=black} FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathExplosion_hell} @self ~onDeath
   Drops:
-    - raging_soul_hell_drop
-    - q_hell_mob_crafting
+  - raging_soul_hell_drop
+  - q_hell_mob_crafting
 
 elite_skeleton_warrior_hell:
   Type: SKELETON
@@ -219,30 +229,32 @@ elite_skeleton_warrior_hell:
     FollowRange: 15
     MovementSpeed: 0.2
     ShowHealth: true
-    AlwaysShowName: true
     PreventSunburn: true
+    AlwaysShowName: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - iron_sword HAND
-    - shield OFFHAND
-    - iron_helmet HEAD
-    - iron_chestplate CHEST
-    - iron_leggings LEGS
-    - iron_boots FEET
+  - iron_sword HAND
+  - shield OFFHAND
+  - iron_helmet HEAD
+  - iron_chestplate CHEST
+  - iron_leggings LEGS
+  - iron_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathDash_hell} @target ~onTimer:70 ?incombat
+  - skill{s=ScytheWhirlwind_hell} @self ~onTimer:120 ?incombat
   Drops:
-    - elite_skeleton_warrior_hell_drop
-    - q_hell_mob_crafting
+  - elite_skeleton_warrior_hell_drop
+  - q_hell_mob_crafting
 
 murot_high_priest_hell:
   Type: SKELETON
   Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
-  Health: 9000  # 3x3000
-  Damage: 400   # 2x200
+  Health: 9000
+  Damage: 400
   Faction: q6_hell
   Group: q6_hell
   Options:
@@ -250,70 +262,73 @@ murot_high_priest_hell:
     MovementSpeed: 0.15
     ShowHealth: true
     AlwaysShowName: true
-    PreventSunburn: true
     PreventItemPickup: true
     PreventOtherDrops: true
+    PreventSunburn: true
     PreventRandomEquipment: true
     KnockbackResistance: 0.5
     Despawn: CHUNK
   Equipment:
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=MeteorStrike_hell} @target ~onTimer:15
-    - skill{s=HomingOrb_hell} @target ~onTimer:10
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=MeteorStrike_hell} @target ~onTimer:15
+  - skill{s=HomingOrb_hell} @target ~onTimer:10
+  - skill{s=MeteorStrike_hell} @target ~onTimer:160 ?incombat
+  - skill{s=HealingPulse_hell} @self ~onTimer:200 ?incombat
   Drops:
-    - murot_priest_hell_drop
-    - q_hell_elite_crafting
+  - murot_priest_hell_drop
+  - q_hell_elite_crafting
 
 # Mission 3 Boss Phases
 skeledragon_phase1_hell:
   Type: Zombie
   Disguise: Horse
   Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
-  Health: 15000  # 3x5000
-  Damage: 600    # 2x300
+  Health: 15000
+  Damage: 600
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
     Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
-    Color: PURPLE
+    Color: BLUE
     Style: SEGMENTED_12
   Options:
     FollowRange: 40
     MovementSpeed: 0.3
     ShowHealth: true
     AlwaysShowName: true
+    PreventSunburn: true
     PreventItemPickup: true
     PreventOtherDrops: true
     PreventRandomEquipment: true
-    PreventSunburn: true
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DragonBreath_hell} @target ~onTimer:15
-    - skill{s=SummonPhase2_hell} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DragonBreath_hell} @target ~onTimer:15
+  - skill{s=SummonPhase2_hell} @self ~onDeath
+  - skill{s=DeathZone_hell} @target ~onTimer:300 ?incombat
   Drops: []
 
 skeledragon_phase2_hell:
   Type: Zombie
   Disguise: Horse
   Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
-  Health: 21000  # 3x7000
-  Damage: 800    # 2x400
+  Health: 21000
+  Damage: 800
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
     Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
-    Color: PURPLE
+    Color: BLUE
     Style: SEGMENTED_12
   Options:
     FollowRange: 40
@@ -327,49 +342,52 @@ skeledragon_phase2_hell:
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DragonBreath_hell} @target ~onTimer:15
-    - skill{s=ScytheWhirlwind_hell} @self ~onTimer:20
-    - skill{s=SummonPhase3_hell} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DragonBreath_hell} @target ~onTimer:15
+  - skill{s=ScytheWhirlwind_hell} @self ~onTimer:20
+  - skill{s=SummonPhase3_hell} @self ~onDeath
+  - skill{s=DragonBreath_hell} @target ~onTimer:15 ?incombat
+  - skill{s=ScytheWhirlwind_hell} @self ~onTimer:120 ?incombat
   Drops: []
 
 mortis_phase3_hell:
   Type: SKELETON
   Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
-  Health: 30000  # 3x10000
-  Damage: 1000   # 2x500
+  Health: 30000
+  Damage: 1000
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
     Title: '&c<&skull> Mortis - Final Phase <&skull>'
-    Color: PURPLE
+    Color: BLUE
     Style: SEGMENTED_12
   Options:
     FollowRange: 40
     MovementSpeed: 0.3
-    PreventSunburn: true
     ShowHealth: true
     AlwaysShowName: true
     PreventItemPickup: true
     PreventOtherDrops: true
+    PreventSunburn: true
     PreventRandomEquipment: true
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Equipment:
-    - netherite_hoe HAND
-    - skeleton_skull HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_hoe HAND
+  - skeleton_skull HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ScytheWhirlwind_hell} @self ~onTimer:20
-    - skill{s=DeathDash_hell} @target ~onTimer:10
-    - skill{s=HealingPulse_hell} @self ~onTimer:15
-    - skill{s=DeathZone_hell} @target ~onTimer:25
-    - skill{s=SummonDragon_hell} @self ~onTimer:60 ?health{r=0.0to0.3}
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=ScytheWhirlwind_hell} @self ~onTimer:20
+  - skill{s=DeathDash_hell} @target ~onTimer:10
+  - skill{s=HealingPulse_hell} @self ~onTimer:15
+  - skill{s=DeathZone_hell} @target ~onTimer:25
+  - skill{s=SummonDragon_hell} @self ~onTimer:60 ?health{r=0.0to0.3}
+  - skill{s=DeathZone_hell} @target ~onTimer:220 ?incombat
   Drops:
-    - mortis_hell_drop
+  - mortis_hell_drop

--- a/mobs/q6_inf.yml
+++ b/mobs/q6_inf.yml
@@ -16,18 +16,19 @@ fallen_warrior_inf:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - iron_sword HAND
-    - shield OFFHAND
-    - iron_helmet HEAD
-    - iron_chestplate CHEST
-    - iron_leggings LEGS
-    - iron_boots FEET
+  - iron_sword HAND
+  - shield OFFHAND
+  - iron_helmet HEAD
+  - iron_chestplate CHEST
+  - iron_leggings LEGS
+  - iron_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathDash} @target ~onTimer:80 ?incombat
   Drops:
-    - fallen_warrior_inf_drop
-    - q_inf_mob_crafting
+  - fallen_warrior_inf_drop
+  - q_inf_mob_crafting
 
 fallen_archer_inf:
   Type: SKELETON
@@ -46,17 +47,18 @@ fallen_archer_inf:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - bow HAND
-    - iron_helmet HEAD
-    - leather_chestplate CHEST
-    - leather_leggings LEGS
-    - leather_boots FEET
+  - bow HAND
+  - iron_helmet HEAD
+  - leather_chestplate CHEST
+  - leather_leggings LEGS
+  - leather_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=WitheringShot} @target ~onTimer:110 ?incombat
   Drops:
-    - fallen_archer_inf_drop
-    - q_inf_mob_crafting
+  - fallen_archer_inf_drop
+  - q_inf_mob_crafting
 
 death_knight_inf:
   Type: SKELETON
@@ -75,18 +77,19 @@ death_knight_inf:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - netherite_sword HAND
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_sword HAND
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DeathExplosion} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathExplosion} @self ~onDeath
+  - skill{s=ScytheWhirlwind} @self ~onTimer:140 ?incombat
   Drops:
-    - death_knight_inf_drop
-    - q_inf_elite_crafting
+  - death_knight_inf_drop
+  - q_inf_elite_crafting
 
 mortis_death_knight_inf:
   Type: SKELETON
@@ -107,18 +110,21 @@ mortis_death_knight_inf:
     KnockbackResistance: 0.5
     Despawn: CHUNK
   Equipment:
-    - netherite_sword HAND
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_sword HAND
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DeathExplosion} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathExplosion} @self ~onDeath
+  - skill{s=ScytheWhirlwind} @self ~onTimer:120 ?incombat
+  - skill{s=DeathDash} @target ~onTimer:90 ?incombat
+  - skill{s=HealingPulse} @self ~onTimer:200 ?incombat
   Drops:
-    - mortis_death_knight_inf_drop
-    - q_inf_elite_crafting
+  - mortis_death_knight_inf_drop
+  - q_inf_elite_crafting
 
 # Mission 2 Mobs
 elite_skeleton_archer_inf:
@@ -138,17 +144,19 @@ elite_skeleton_archer_inf:
     PreventRandomEquipment: true
     PreventSunburn: true
   Equipment:
-    - bow HAND
-    - iron_helmet HEAD
-    - iron_chestplate CHEST
-    - iron_leggings LEGS
-    - iron_boots FEET
+  - bow HAND
+  - iron_helmet HEAD
+  - iron_chestplate CHEST
+  - iron_leggings LEGS
+  - iron_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=WitheringShot} @target ~onTimer:90 ?incombat
+  - skill{s=HomingOrb} @target ~onTimer:150 ?incombat
   Drops:
-    - elite_skeleton_archer_inf_drop
-    - q_inf_mob_crafting
+  - elite_skeleton_archer_inf_drop
+  - q_inf_mob_crafting
 
 death_archer_inf:
   Type: SKELETON
@@ -167,18 +175,19 @@ death_archer_inf:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - bow HAND
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - bow HAND
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=WitheringShot} @target ~onTimer:10
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=WitheringShot} @target ~onTimer:80 ?incombat
+  - skill{s=HomingOrb} @target ~onTimer:120 ?incombat
   Drops:
-    - death_archer_inf_drop
-    - q_inf_elite_crafting
+  - death_archer_inf_drop
+  - q_inf_elite_crafting
 
 raging_soul_inf:
   Type: SKELETON
@@ -197,16 +206,17 @@ raging_soul_inf:
     PreventRandomEquipment: true
     PreventSunburn: true
   Equipment:
-    - leather_helmet{color=black} HEAD
-    - leather_chestplate{color=black} CHEST
-    - leather_leggings{color=black} LEGS
-    - leather_boots{color=black} FEET
+  - leather_helmet{color=black} HEAD
+  - leather_chestplate{color=black} CHEST
+  - leather_leggings{color=black} LEGS
+  - leather_boots{color=black} FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathExplosion} @self ~onDeath
   Drops:
-    - raging_soul_inf_drop
-    - q_inf_mob_crafting
+  - raging_soul_inf_drop
+  - q_inf_mob_crafting
 
 elite_skeleton_warrior_inf:
   Type: SKELETON
@@ -225,18 +235,20 @@ elite_skeleton_warrior_inf:
     PreventOtherDrops: true
     PreventRandomEquipment: true
   Equipment:
-    - iron_sword HAND
-    - shield OFFHAND
-    - iron_helmet HEAD
-    - iron_chestplate CHEST
-    - iron_leggings LEGS
-    - iron_boots FEET
+  - iron_sword HAND
+  - shield OFFHAND
+  - iron_helmet HEAD
+  - iron_chestplate CHEST
+  - iron_leggings LEGS
+  - iron_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DeathDash} @target ~onTimer:70 ?incombat
+  - skill{s=ScytheWhirlwind} @self ~onTimer:120 ?incombat
   Drops:
-    - elite_skeleton_warrior_inf_drop
-    - q_inf_mob_crafting
+  - elite_skeleton_warrior_inf_drop
+  - q_inf_mob_crafting
 
 murot_high_priest_inf:
   Type: SKELETON
@@ -257,18 +269,20 @@ murot_high_priest_inf:
     KnockbackResistance: 0.5
     Despawn: CHUNK
   Equipment:
-    - netherite_helmet HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_helmet HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=MeteorStrike} @target ~onTimer:15
-    - skill{s=HomingOrb} @target ~onTimer:10
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=MeteorStrike} @target ~onTimer:15
+  - skill{s=HomingOrb} @target ~onTimer:10
+  - skill{s=MeteorStrike} @target ~onTimer:160 ?incombat
+  - skill{s=HealingPulse} @self ~onTimer:200 ?incombat
   Drops:
-    - murot_priest_inf_drop
-    - q_inf_elite_crafting
+  - murot_priest_inf_drop
+  - q_inf_elite_crafting
 
 # Mission 3 Boss Phases
 skeledragon_phase1_inf:
@@ -296,10 +310,11 @@ skeledragon_phase1_inf:
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DragonBreath} @target ~onTimer:15
-    - skill{s=SummonPhase2} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DragonBreath} @target ~onTimer:15
+  - skill{s=SummonPhase2} @self ~onDeath
+  - skill{s=DeathZone} @target ~onTimer:300 ?incombat
   Drops: []
 
 skeledragon_phase2_inf:
@@ -327,11 +342,13 @@ skeledragon_phase2_inf:
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=DragonBreath} @target ~onTimer:15
-    - skill{s=ScytheWhirlwind} @self ~onTimer:20
-    - skill{s=SummonPhase3} @self ~onDeath
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=DragonBreath} @target ~onTimer:15
+  - skill{s=ScytheWhirlwind} @self ~onTimer:20
+  - skill{s=SummonPhase3} @self ~onDeath
+  - skill{s=DragonBreath} @target ~onTimer:15 ?incombat
+  - skill{s=ScytheWhirlwind} @self ~onTimer:120 ?incombat
   Drops: []
 
 mortis_phase3_inf:
@@ -358,18 +375,19 @@ mortis_phase3_inf:
     KnockbackResistance: 0.8
     Despawn: CHUNK
   Equipment:
-    - netherite_hoe HAND
-    - skeleton_skull HEAD
-    - netherite_chestplate CHEST
-    - netherite_leggings LEGS
-    - netherite_boots FEET
+  - netherite_hoe HAND
+  - skeleton_skull HEAD
+  - netherite_chestplate CHEST
+  - netherite_leggings LEGS
+  - netherite_boots FEET
   Skills:
-    - setname{name="<caster.name>";delay=2} @self ~onDamaged
-    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
-    - skill{s=ScytheWhirlwind} @self ~onTimer:20
-    - skill{s=DeathDash} @target ~onTimer:10
-    - skill{s=HealingPulse} @self ~onTimer:15
-    - skill{s=DeathZone} @target ~onTimer:25
-    - skill{s=SummonDragon} @self ~onTimer:60 ?health{r=0.0to0.3}
+  - setname{name="<caster.name>";delay=2} @self ~onDamaged
+  - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  - skill{s=ScytheWhirlwind} @self ~onTimer:20
+  - skill{s=DeathDash} @target ~onTimer:10
+  - skill{s=HealingPulse} @self ~onTimer:15
+  - skill{s=DeathZone} @target ~onTimer:25
+  - skill{s=SummonDragon} @self ~onTimer:60 ?health{r=0.0to0.3}
+  - skill{s=DeathZone} @target ~onTimer:220 ?incombat
   Drops:
-    - mortis_inf_drop
+  - mortis_inf_drop

--- a/mobs/q9_blood.yml
+++ b/mobs/q9_blood.yml
@@ -23,6 +23,7 @@ agile_satyr_warrior_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=SatyrWarCry_blood} @self ~onTimer:25 0.4
   Drops:
     - agile_satyr_warrior_blood_drop
     - q_blood_mob_crafting
@@ -52,6 +53,7 @@ perfidious_satyr_archer_blood:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=SatyrWarCry_blood} @self ~onTimer:25 0.4
   Drops:
     - perfidious_satyr_archer_blood_drop
     - q_blood_mob_crafting
@@ -112,6 +114,7 @@ stone_golem_blood:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=ThrowBoulder_blood} @target ~onTimer:10
+    - skill{s=StoneShatter_blood} @self ~onTimer:16 0.5
   Drops:
     - stone_golem_blood_drop
     - q_blood_elite_crafting

--- a/mobs/q9_hell.yml
+++ b/mobs/q9_hell.yml
@@ -23,6 +23,7 @@ agile_satyr_warrior_hell:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=SatyrWarCry_hell} @self ~onTimer:25 0.4
   Drops:
     - agile_satyr_warrior_hell_drop
     - q_hell_mob_crafting
@@ -52,6 +53,7 @@ perfidious_satyr_archer_hell:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=SatyrWarCry_hell} @self ~onTimer:25 0.4
   Drops:
     - perfidious_satyr_archer_hell_drop
     - q_hell_mob_crafting
@@ -112,6 +114,7 @@ stone_golem_hell:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=ThrowBoulder_hell} @target ~onTimer:10
+    - skill{s=StoneShatter_hell} @self ~onTimer:16 0.5
   Drops:
     - stone_golem_hell_drop
     - q_hell_elite_crafting

--- a/mobs/q9_inf.yml
+++ b/mobs/q9_inf.yml
@@ -24,6 +24,7 @@ agile_satyr_warrior_inf:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=SatyrWarCry} @self ~onTimer:25 0.4
   Drops:
     - agile_satyr_warrior_inf_drop
     - q_inf_mob_crafting
@@ -53,6 +54,7 @@ perfidious_satyr_archer_inf:
   Skills:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+    - skill{s=SatyrWarCry} @self ~onTimer:25 0.4
   Drops:
     - perfidious_satyr_archer_inf_drop
     - q_inf_mob_crafting
@@ -113,6 +115,7 @@ stone_golem_inf:
     - setname{name="<caster.name>";delay=2} @self ~onDamaged
     - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
     - skill{s=ThrowBoulder} @target ~onTimer:10
+    - skill{s=StoneShatter} @self ~onTimer:16 0.5
   Drops:
     - stone_golem_inf_drop
     - q_inf_elite_crafting

--- a/skills/q10.yml
+++ b/skills/q10.yml
@@ -4,27 +4,101 @@ PetrifyingGaze:
     - potion{type=SLOW;duration=60;level=10} @target
     - effect:particles{p=BLOCK_CRACK;material=STONE;amount=30} @target
 
-VenomSpit:
+AcidSpit:
+  Cooldown: 8
+  Skills:
+    - projectile{onTick=AcidSpit-Tick;onHit=AcidSpit-Hit;v=12;i=DRAGON_BREATH;hR=0.5;vR=0.5;g=0.04} @target
+
+AcidSpit-Tick:
+  Skills:
+    - effect:particles{p=SPELL_MOB;amount=3} @origin
+
+AcidSpit-Hit:
+  Skills:
+    - effect:particles{p=BLOCK_CRACK;material=SLIME_BLOCK;amount=30;hS=0.4;vS=0.1} @origin
+    - damage{a=40} @target
+    - potion{type=POISON;duration=100;level=1} @target
+    - damage{a=30} @PlayersInRadius{r=2} @origin
+    - potion{type=POISON;duration=60;level=1} @PlayersInRadius{r=2} @origin
+
+AcidSpit_hell:
+  Cooldown: 8
+  Skills:
+    - projectile{onTick=AcidSpit-Tick;onHit=AcidSpit-Hit_hell;v=12;i=DRAGON_BREATH;hR=0.5;vR=0.5;g=0.04} @target
+
+AcidSpit-Hit_hell:
+  Skills:
+    - effect:particles{p=BLOCK_CRACK;material=SLIME_BLOCK;amount=40;hS=0.4;vS=0.1} @origin
+    - damage{a=80} @target
+    - potion{type=POISON;duration=120;level=1} @target
+    - damage{a=60} @PlayersInRadius{r=2} @origin
+
+AcidSpit_blood:
+  Cooldown: 8
+  Skills:
+    - projectile{onTick=AcidSpit-Tick;onHit=AcidSpit-Hit_blood;v=12;i=DRAGON_BREATH;hR=0.5;vR=0.5;g=0.04} @target
+
+AcidSpit-Hit_blood:
+  Skills:
+    - effect:particles{p=BLOCK_CRACK;material=SLIME_BLOCK;amount=60;hS=0.4;vS=0.1} @origin
+    - damage{a=200} @target
+    - potion{type=POISON;duration=140;level=2} @target
+    - damage{a=150} @PlayersInRadius{r=2} @origin
+
+ZapBolt:
   Cooldown: 10
   Skills:
-    - projectile{onTick=Venom-Tick;onHit=Venom-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1} @target
+    - projectile{onTick=ZapBolt-Tick;onHit=ZapBolt-Hit;v=16;i=TRIDENT;hR=0.5;vR=0.5} @target
 
-Venom-Tick:
+ZapBolt-Tick:
   Skills:
-    - effect:particles{p=SPELL_MOB;amount=5} @origin
+    - effect:particles{p=ELECTRIC_SPARK;amount=2} @origin
 
-Venom-Hit:
+ZapBolt-Hit:
   Skills:
+    - effect:lightning @target
     - damage{a=50} @target
-    - potion{type=POISON;duration=60;level=2} @target
+    - potion{type=SLOW;duration=40;level=1} @target
+    - skill{s=ZapBolt-Chain} @PlayersInRadius{r=6;limit=2;sort=NEAREST;ignoreself=true}
 
-ShockAttack:
+ZapBolt-Chain:
+  Skills:
+    - effect:lightning @target
+    - damage{a=25} @target
+
+ZapBolt_hell:
   Cooldown: 10
   Skills:
-    - effect:particles{p=WAX_OFF;amount=20} @targetlocation
-    - delay 20
-    - damage{a=50} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=2} @targetlocation
+    - projectile{onTick=ZapBolt-Tick;onHit=ZapBolt-Hit_hell;v=16;i=TRIDENT;hR=0.5;vR=0.5} @target
+
+ZapBolt-Hit_hell:
+  Skills:
+    - effect:lightning @target
+    - damage{a=100} @target
+    - potion{type=SLOW;duration=50;level=1} @target
+    - skill{s=ZapBolt-Chain_hell} @PlayersInRadius{r=6;limit=2;sort=NEAREST;ignoreself=true}
+
+ZapBolt-Chain_hell:
+  Skills:
+    - effect:lightning @target
+    - damage{a=50} @target
+
+ZapBolt_blood:
+  Cooldown: 10
+  Skills:
+    - projectile{onTick=ZapBolt-Tick;onHit=ZapBolt-Hit_blood;v=16;i=TRIDENT;hR=0.5;vR=0.5} @target
+
+ZapBolt-Hit_blood:
+  Skills:
+    - effect:lightning @target
+    - damage{a=250} @target
+    - potion{type=SLOW;duration=60;level=2} @target
+    - skill{s=ZapBolt-Chain_blood} @PlayersInRadius{r=6;limit=3;sort=NEAREST;ignoreself=true}
+
+ZapBolt-Chain_blood:
+  Skills:
+    - effect:lightning @target
+    - damage{a=125} @target
 
 DeathExplosion:
   Skills:
@@ -40,24 +114,24 @@ SmallDeathExplosion:
     - damage{a=100} @PlayersInRadius{r=3}
 
 PowerfulStrike:
-  Cooldown: 8
+  Cooldown: 15
   Conditions:
+    - distance{d=..3}
     - lineofsight
-    - distance{d=..2}
   Skills:
-    - effect:particles{p=SWEEP_ATTACK;amount=1} @self
-    - damage{a=45} @target
-    - throw{v=5;vy=0.2} @target
+    - effect:particles{p=CRIT;amount=20} @self
+    - delay 10
+    - damage{a=50} @PlayersInRadius{r=2} @self
 StunStrike:
-  Cooldown: 10
+  Cooldown: 15
   Conditions:
-    - distance{d=..2}
+    - distance{d=..3}
+    - lineofsight
   Skills:
-    - damage{a=18} @target
-    - delay 6
-    - damage{a=18} @target
-    - delay 6
-    - damage{a=18} @target
+    - effect:particles{p=CRIT;amount=20} @self
+    - delay 10
+    - damage{a=45} @PlayersInRadius{r=2} @self
+    - potion{type=SLOW;duration=60;level=5} @PlayersInRadius{r=2} @self
 
 LeapAttack:
   Cooldown: 6
@@ -140,10 +214,13 @@ ScatteredShot:
     - projectile{onTick=ScatteredShot-Tick;onHit=ScatteredShot-Hit;v=20;i=ARROW;hR=1;vR=1;spread=12;amount=5} @target
 
 MeleeAttack:
+  Cooldown: 6
+  Conditions:
+    - distance{d=..2}
   Skills:
-    - effect:particles{p=SWEEP_ATTACK;amount=1} @targetlocation
-    - delay 10
-    - damage{a=100} @PlayersInRadius{r=1} @targetlocation
+    - effect:particles{p=SWEEP_ATTACK;amount=1} @self
+    - delay 5
+    - damage{a=100} @target
 
 ScatteredShot-Tick:
   Skills:
@@ -183,24 +260,6 @@ PetrifyingGaze_hell:
     - potion{type=SLOW;duration=80;level=10} @target
     - effect:particles{p=BLOCK_CRACK;material=STONE;amount=30} @target
 
-VenomSpit_hell:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Venom-Tick-Hell;onHit=Venom-Hit-Hell;v=8;i=DRAGON_BREATH;hR=1;vR=1} @target
-
-Venom-Hit-Hell:
-  Skills:
-    - damage{a=300} @target  # 2x150
-    - potion{type=POISON;duration=80;level=3} @target
-
-ShockAttack_hell:
-  Cooldown: 10
-  Skills:
-    - effect:particles{p=WAX_OFF;amount=20} @targetlocation
-    - delay 20
-    - damage{a=300} @PlayersInRadius{r=2} @targetlocation  # 2x150
-    - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=2} @targetlocation
-
 DeathExplosion_hell:
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
@@ -215,24 +274,24 @@ SmallDeathExplosion_hell:
     - damage{a=200} @PlayersInRadius{r=3}  # 2x100
 
 PowerfulStrike_hell:
-  Cooldown: 8
+  Cooldown: 15
   Conditions:
+    - distance{d=..3}
     - lineofsight
-    - distance{d=..2}
   Skills:
-    - effect:particles{p=SWEEP_ATTACK;amount=1} @self
-    - damage{a=90} @target
-    - throw{v=5;vy=0.25} @target
+    - effect:particles{p=CRIT;amount=20} @self
+    - delay 10
+    - damage{a=100} @PlayersInRadius{r=2} @self
 StunStrike_hell:
-  Cooldown: 10
+  Cooldown: 15
   Conditions:
-    - distance{d=..2}
+    - distance{d=..3}
+    - lineofsight
   Skills:
-    - damage{a=36} @target
-    - delay 6
-    - damage{a=36} @target
-    - delay 6
-    - damage{a=36} @target
+    - effect:particles{p=CRIT;amount=20} @self
+    - delay 10
+    - damage{a=90} @PlayersInRadius{r=2} @self
+    - potion{type=SLOW;duration=60;level=5} @PlayersInRadius{r=2} @self
 
 LeapAttack_hell:
   Cooldown: 6
@@ -315,10 +374,13 @@ ScatteredShot_hell:
     - projectile{onTick=ScatteredShot_hell-Tick;onHit=ScatteredShot_hell-Hit;v=20;i=ARROW;hR=1;vR=1;spread=12;amount=5}
 
 MeleeAttack_hell:
+  Cooldown: 6
+  Conditions:
+    - distance{d=..2}
   Skills:
-    - effect:particles{p=SWEEP_ATTACK;amount=1} @targetlocation
-    - delay 10
-    - damage{a=400} @PlayersInRadius{r=1} @targetlocation  # 2x200
+    - effect:particles{p=SWEEP_ATTACK;amount=1} @self
+    - delay 5
+    - damage{a=200} @target
 
 ScatteredShot_hell-Tick:
   Skills:
@@ -359,24 +421,6 @@ PetrifyingGaze_blood:
     - potion{type=SLOW;duration=100;level=10} @target
     - effect:particles{p=BLOCK_CRACK;material=STONE;amount=30} @target
 
-VenomSpit_blood:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Venom-Tick;onHit=Venom-Hit-Blood;v=8;i=DRAGON_BREATH;hR=1;vR=1} @target
-
-Venom-Hit-Blood:
-  Skills:
-    - damage{a=750} @target # 5x150
-    - potion{type=POISON;duration=100;level=3} @target
-
-ShockAttack_blood:
-  Cooldown: 10
-  Skills:
-    - effect:particles{p=WAX_OFF;amount=20} @targetlocation
-    - delay 20
-    - damage{a=750} @PlayersInRadius{r=2} @targetlocation # 5x150
-    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=2} @targetlocation
-
 DeathExplosion_blood:
   Skills:
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
@@ -391,26 +435,25 @@ SmallDeathExplosion_blood:
     - damage{a=500} @PlayersInRadius{r=3} # 5x100
 
 PowerfulStrike_blood:
-  Cooldown: 8
+  Cooldown: 15
   Conditions:
+    - distance{d=..3}
     - lineofsight
-    - distance{d=..2}
   Skills:
-    - effect:particles{p=SWEEP_ATTACK;amount=1} @self
-    - damage{a=225} @target
-    - throw{v=6;vy=0.3} @target
-
+    - effect:particles{p=CRIT;amount=20} @self
+    - delay 10
+    - damage{a=250} @PlayersInRadius{r=2} @self
 
 StunStrike_blood:
-  Cooldown: 10
+  Cooldown: 15
   Conditions:
-    - distance{d=..2}
+    - distance{d=..3}
+    - lineofsight
   Skills:
-    - damage{a=90} @target
-    - delay 6
-    - damage{a=90} @target
-    - delay 6
-    - damage{a=90} @target
+    - effect:particles{p=CRIT;amount=20} @self
+    - delay 10
+    - damage{a=225} @PlayersInRadius{r=2} @self
+    - potion{type=SLOW;duration=60;level=5} @PlayersInRadius{r=2} @self
 
 LeapAttack_blood:
   Cooldown: 6
@@ -493,10 +536,13 @@ ScatteredShot_blood:
     - projectile{onTick=ScatteredShot_blood-Tick;onHit=ScatteredShot_blood-Hit;v=20;i=ARROW;hR=1;vR=1;spread=12;amount=5} @target
 
 MeleeAttack_blood:
+  Cooldown: 6
+  Conditions:
+    - distance{d=..2}
   Skills:
-    - effect:particles{p=SWEEP_ATTACK;amount=1} @targetlocation
-    - delay 10
-    - damage{a=1000} @PlayersInRadius{r=1} @targetlocation # 5x200
+    - effect:particles{p=SWEEP_ATTACK;amount=1} @self
+    - delay 5
+    - damage{a=500} @target
 
 ScatteredShot_blood-Tick:
   Skills:

--- a/skills/q6.yml
+++ b/skills/q6.yml
@@ -2,350 +2,505 @@
 DeathExplosion:
   Cooldown: 1
   Skills:
-    - message{m="&cDeath explosion imminent!"} @PlayersInRadius{r=10}
-    - delay 20
-    - damage{a=200} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=20} @self
+  - message{m="&cA &lDeath Explosion&r is coming! &7(Run!)"} @PlayersInRadius{r=12}
+  - sound{s=entity.wither.spawn;v=1;p=0.8} @self
+  - effect:particles{p=SMOKE_LARGE;amount=30;radius=2;y=0.2} @self
+  - delay 10
+  - effect:particles{p=SMOKE_LARGE;amount=40;radius=3;y=0.2} @self
+  - delay 10
+  - effect:particles{p=SMOKE_LARGE;amount=60;radius=4;y=0.2} @self
+  - delay 10
+  - effect:particles{p=DRAGON_BREATH;amount=80;radius=5;y=0.2} @self
+  - delay 10
+  - damage{a=220} @PlayersInRadius{r=4}
+  - potion{type=WITHER;duration=80;level=1} @PlayersInRadius{r=4}
+  - ignite{ticks=60} @PlayersInRadius{r=4}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @self
+  - sound{s=entity.generic.explode;v=1;p=1} @self
+  - summon{mob=raging_soul_inf;amount=2;radius=3} @self
 
-# Mission 2 Skills
 WitheringShot:
   Cooldown: 10
   Skills:
-    - message{m="&6<mob.name>&f draws a withering arrow!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
-    - delay 20
-    - shoot{type=ARROW;velocity=30;damage=200} @Target
-    - potion{type=WITHER;duration=60;level=1} @Target
+  - message{m="&6<mob.name>&f draws a bowstring tainted with darkness!"} @PlayersInRadius{r=30}
+  - sound{s=entity.skeleton.shoot;v=1;p=1.2} @self
+  - effect:particles{p=SMOKE_LARGE;amount=12;radius=1} @self
+  - delay 15
+  - shoot{type=ARROW;velocity=30;damage=220;spread=12;amount=3} @Target
+  - potion{type=WITHER;duration=80;level=1} @Target
 
 MeteorStrike:
   Cooldown: 15
   Skills:
-    - message{m="&5Murot calls down a meteor!"} @PlayersInRadius{r=30}
-    - effect:particles{p=FLAME;amount=50} @target
-    - delay 20
-    - damage{a=300} @PlayersInRadius{r=5}
-    - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - message{m="&5<mob.name>&f summons a &dMeteor!"} @PlayersInRadius{r=30}
+  - sound{s=entity.ender_dragon.growl;v=1;p=0.6} @target
+  - effect:particles{p=FLAME;amount=80} @target
+  - effect:particles{p=SMOKE_LARGE;amount=60} @target
+  - delay 40
+  - damage{a=320} @PlayersInRadius{r=5}
+  - ignite{ticks=80} @PlayersInRadius{r=5}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - sound{s=entity.generic.explode;v=1;p=1} @target
 
 HomingOrb:
   Cooldown: 10
   Skills:
-    - message{m="&5<mob.name>&f forms a homing orb!"} @PlayersInRadius{r=30}
-    - effect:particles{p=DRAGON_BREATH;amount=20;radius=1} @self
-    - delay 20
-    - projectile{onTick=Orb-Tick;onHit=Orb-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @target
+  - message{m="&5<mob.name>&f forms a &dNecro Orb&f that &ltracks&f its target!"} @PlayersInRadius{r=30}
+  - effect:particles{p=DRAGON_BREATH;amount=30;radius=1} @self
+  - sound{s=block.beacon.ambient;v=1;p=1} @self
+  - delay 10
+  - projectile{onTick=Orb-Tick;onHit=Orb-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @Target
+  - delay 20
+  - projectile{onTick=Orb-Tick;onHit=Orb-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @Target
 
 Orb-Tick:
   Skills:
-    - effect:particles{p=SPELL_WITCH;amount=5} @origin
+  - effect:particles{p=SPELL_WITCH;amount=6;hS=0.2;vS=0.2} @origin
+  - sound{s=block.enchantment_table.use;v=0.6;p=2} @origin
 
 Orb-Hit:
   Skills:
-    - damage{a=150} @target
-    - effect:particles{p=SPELL;amount=20} @target
+  - damage{a=170} @target
+  - potion{type=SLOW;duration=60;level=1} @target
+  - potion{type=WEAKNESS;duration=60;level=1} @target
+  - effect:particles{p=SPELL;amount=25} @target
+  - sound{s=entity.witch.celebrate;v=1;p=0.8} @target
 
-# Mission 3 Boss Skills
 DragonBreath:
-  Cooldown: 15
+  Cooldown: 12
   Skills:
-    - message{m="&6Skeledragon inhales deeply, preparing its fiery breath!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SMOKE_LARGE;amount=75;radius=10} @self
-    - delay 40
-    - message{m="&cSkeledragon unleashes its breath!"} @PlayersInRadius{r=30}
-    - effect:particles{p=DRAGON_BREATH;amount=100;radius=10} @Forward{f=20}
-    - damage{a=200} @Forward{f=20;spread=0}
-    - ignite{ticks=60} @Forward{f=20;spread=0}
+  - message{m="&c<&skull>&f Dragon Breath!"} @PlayersInRadius{r=35}
+  - sound{s=entity.ender_dragon.shoot;v=1.2;p=0.8} @self
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=6;y=0.2} @self
+  - damage{a=90} @PlayersInRadius{r=6}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=6;y=0.2} @self
+  - damage{a=90} @PlayersInRadius{r=6}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=6;y=0.2} @self
+  - damage{a=90} @PlayersInRadius{r=6}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=6;y=0.2} @self
+  - damage{a=90} @PlayersInRadius{r=6}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=6;y=0.2} @self
+  - damage{a=90} @PlayersInRadius{r=6}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=6;y=0.2} @self
+  - damage{a=90} @PlayersInRadius{r=6}
+  - delay 5
 
 ScytheWhirlwind:
-  Cooldown: 20
+  Cooldown: 16
   Skills:
-    # Telegraph: warn players before the whirlwind starts so they can dodge
-    - message{m="&6Skeledragon raises its scythe, winds swirling!"} @PlayersInRadius{r=30}
-    - effect:particles{p=CLOUD;amount=100;radius=10} @self
-    - delay 40
-    - message{m="&cWhirling scythe attack incoming!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SPELL_WITCH;amount=100;radius=10} @self
-    - delay 60
-    - damage{a=400} @PlayersInRadius{r=10}
+  - message{m="&7<mob.name>&f whirls its blade!"} @PlayersInRadius{r=25}
+  - sound{s=entity.player.attack.sweep;v=1.2;p=1} @self
+  - effect:particles{p=SWEEP_ATTACK;amount=40;radius=5;y=0.2} @self
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=4}
+  - delay 6
 
 DeathDash:
-  Cooldown: 10
+  Cooldown: 12
   Skills:
-    # Telegraph: make the dash clearly visible and give players time to react
-    - message{m="&6Skeledragon fixates on its prey, ready to dash!"} @PlayersInRadius{r=30}
-    - effect:particles{p=VILLAGER_ANGRY;amount=30;radius=5} @self
-    - delay 20
-    - effect:particles{p=SMOKE_LARGE;amount=50} @self
-    - delay 30
-    - teleport @Target
-    - damage{a=500} @Target
+  - message{m="&8<mob.name>&f vanishes into shadowy snow!"} @PlayersInRadius{r=25}
+  - effect:particles{p=SMOKE_LARGE;amount=40;radius=1} @self
+  - sound{s=entity.enderman.teleport;v=1;p=1} @self
+  - delay 5
+  - teleport @Target
+  - damage{a=220} @PlayersInRadius{r=2}
+  - effect:particles{p=CRIT_MAGIC;amount=40;radius=2} @self
+  - sound{s=entity.player.attack.strong;v=1;p=1} @self
+
 HealingPulse:
-  Cooldown: 15
+  Cooldown: 20
   Skills:
-    - heal{a=500} @self
-    - effect:particles{p=HEART;amount=20} @self
+  - message{m="&a<&sparkles>&f Healing pulse!"} @PlayersInRadius{r=30}
+  - heal{a=600} @self
+  - potion{type=REGENERATION;duration=100;level=1} @self
+  - effect:particles{p=HEART;amount=30} @self
+  - sound{s=entity.experience_orb.pickup;v=1;p=1.8} @self
 
 DeathZone:
   Cooldown: 25
   Skills:
-    # Telegraph: give players a clear warning and longer window to escape the Death Zone
-    - message{m="&6A sinister aura gathers... Skeledragon is creating a death zone! Move away!"} @PlayersInRadius{r=30}
-    - effect:particles{p=REDSTONE;amount=100;radius=10} @target
-    - delay 60
-    - damage{a=99999} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_HUGE;amount=10} @target
+  - message{m="&6A dark zone is forming... &cMOVE AWAY!"} @PlayersInRadius{r=35}
+  - effect:particles{p=REDSTONE;amount=120;radius=6;y=0.2} @target
+  - sound{s=block.portal.ambient;v=1;p=0.6} @target
+  - delay 30
+  - effect:particles{p=SOUL;amount=160;radius=5;y=0.2} @target
+  - delay 30
+  - damage{a=99999} @PlayersInRadius{r=4}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - sound{s=entity.generic.explode;v=1;p=1} @target
 
 SummonDragon:
-  Cooldown: 60
   Skills:
-    - message{m="&cMortis summons Skeledragon!"} @PlayersInRadius{r=30}
-    - summon{mob=skeledragon_phase1_inf;amount=1;radius=5} @self
+  - message{m="&cMortis joins the fight!"} @PlayersInRadius{r=30}
+  - sound{s=entity.ender_dragon.growl;v=1.2;p=0.8} @self
+  - summon{mob=skeledragon_phase2_inf;amount=1;radius=0} @self
 
 SummonPhase2:
   Skills:
-    # Telegraph: announce Mortis' arrival before spawning phase 2 mobs
-    - message{m="&6Mortis whistles for his steed, preparing phase two!"} @PlayersInRadius{r=30}
-    - effect:particles{p=VILLAGER_HAPPY;amount=50;radius=5} @self
-    - delay 40
-    - message{m="&cMortis joins the battle!"} @PlayersInRadius{r=30}
-    - summon{mob=skeledragon_phase2_inf;amount=1;radius=0} @self
-    - summon{mob=death_archer_inf;amount=3;radius=5} @self
-    - summon{mob=elite_skeleton_archer_inf;amount=10;radius=5} @self
-    - summon{mob=elite_skeleton_warrior_inf;amount=10;radius=5} @self
+  - message{m="&5Murot calls for support!"} @PlayersInRadius{r=30}
+  - sound{s=entity.evoker.prepare_summon;v=1.2;p=1} @self
+  - delay 60
+  - summon{mob=skeledragon_phase2_inf;amount=1;radius=0} @self
+  - summon{mob=death_archer_inf;amount=3;radius=5} @self
+  - summon{mob=elite_skeleton_archer_inf;amount=6;radius=6} @self
+  - summon{mob=elite_skeleton_warrior_inf;amount=6;radius=6} @self
 
 SummonPhase3:
   Skills:
-    - message{m="&cMortis breaks free!"} @PlayersInRadius{r=30}
-    - delay 100
-    - summon{mob=mortis_phase3_inf;amount=1;radius=0} @self
+  - message{m="&cMortis breaks free!"} @PlayersInRadius{r=30}
+  - sound{s=entity.wither.spawn;v=1.2;p=0.7} @self
+  - delay 80
+  - summon{mob=mortis_phase3_inf;amount=1;radius=0} @self
 
 # Mission 1 Skills - Hell version (2x damage)
 DeathExplosion_hell:
   Cooldown: 1
   Skills:
-    - message{m="&cDeath explosion imminent!"} @PlayersInRadius{r=10}
-    - delay 20
-    - damage{a=400} @PlayersInRadius{r=3}  # 2x200
-    - effect:particles{p=EXPLOSION_LARGE;amount=20} @self
+  - message{m="&cA &lDeath Explosion&r is coming! &7(Run!)"} @PlayersInRadius{r=12}
+  - sound{s=entity.wither.spawn;v=1;p=0.8} @self
+  - effect:particles{p=SMOKE_LARGE;amount=30;radius=3;y=0.2} @self
+  - delay 10
+  - effect:particles{p=SMOKE_LARGE;amount=40;radius=4;y=0.2} @self
+  - delay 10
+  - effect:particles{p=SMOKE_LARGE;amount=60;radius=5;y=0.2} @self
+  - delay 10
+  - effect:particles{p=DRAGON_BREATH;amount=80;radius=6;y=0.2} @self
+  - delay 10
+  - damage{a=500} @PlayersInRadius{r=5}
+  - potion{type=WITHER;duration=100;level=1} @PlayersInRadius{r=5}
+  - ignite{ticks=60} @PlayersInRadius{r=5}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @self
+  - sound{s=entity.generic.explode;v=1;p=1} @self
+  - summon{mob=raging_soul_hell;amount=2;radius=3} @self
 
 # Mission 2 Skills
 WitheringShot_hell:
   Cooldown: 10
   Skills:
-    - message{m="&6<mob.name>&f draws a withering arrow!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
-    - delay 20
-    - shoot{type=ARROW;velocity=30;damage=400} @Target  # 2x200
-    - potion{type=WITHER;duration=80;level=2} @Target
+  - message{m="&6<mob.name>&f draws a bowstring tainted with darkness!"} @PlayersInRadius{r=30}
+  - sound{s=entity.skeleton.shoot;v=1;p=1.2} @self
+  - effect:particles{p=SMOKE_LARGE;amount=12;radius=1} @self
+  - delay 15
+  - shoot{type=ARROW;velocity=30;damage=450;spread=12;amount=4} @Target
+  - potion{type=WITHER;duration=100;level=2} @Target
 
 MeteorStrike_hell:
   Cooldown: 15
   Skills:
-    - message{m="&5Murot calls down a meteor!"} @PlayersInRadius{r=30}
-    - effect:particles{p=FLAME;amount=50} @target
-    - delay 20
-    - damage{a=600} @PlayersInRadius{r=5}  # 2x300
-    - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - message{m="&5<mob.name>&f summons a &dMeteor!"} @PlayersInRadius{r=30}
+  - sound{s=entity.ender_dragon.growl;v=1;p=0.6} @target
+  - effect:particles{p=FLAME;amount=80} @target
+  - effect:particles{p=SMOKE_LARGE;amount=60} @target
+  - delay 40
+  - damage{a=650} @PlayersInRadius{r=6}
+  - ignite{ticks=120} @PlayersInRadius{r=6}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - sound{s=entity.generic.explode;v=1;p=1} @target
 
 HomingOrb_hell:
   Cooldown: 10
   Skills:
-    - message{m="&5<mob.name>&f forms a homing orb!"} @PlayersInRadius{r=30}
-    - effect:particles{p=DRAGON_BREATH;amount=20;radius=1} @self
-    - delay 20
-    - projectile{onTick=Orb-Tick-Hell;onHit=Orb-Hit-Hell;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @target
+  - message{m="&5<mob.name>&f forms a &dNecro Orb&f that &ltracks&f its target!"} @PlayersInRadius{r=30}
+  - effect:particles{p=DRAGON_BREATH;amount=30;radius=1} @self
+  - sound{s=block.beacon.ambient;v=1;p=1} @self
+  - delay 10
+  - projectile{onTick=Orb-Tick;onHit=Orb-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @Target
+  - delay 20
+  - projectile{onTick=Orb-Tick;onHit=Orb-Hit-Hell;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @Target
 
 Orb-Hit-Hell:
   Skills:
-    - damage{a=300} @target  # 2x150
-    - effect:particles{p=SPELL;amount=20} @target
+  - damage{a=300} @target
+  - effect:particles{p=SPELL;amount=20} @target
 
 # Mission 3 Boss Skills
 DragonBreath_hell:
-  Cooldown: 15
+  Cooldown: 12
   Skills:
-    - message{m="&6Skeledragon inhales deeply, preparing its fiery breath!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SMOKE_LARGE;amount=75;radius=10} @self
-    - delay 40
-    - message{m="&cSkeledragon unleashes its breath!"} @PlayersInRadius{r=30}
-    - effect:particles{p=DRAGON_BREATH;amount=100;radius=10} @Forward{f=20}
-    - damage{a=400} @Forward{f=20;spread=0}  # 2x200
-    - ignite{ticks=80} @Forward{f=20;spread=0}
+  - message{m="&c<&skull>&f Dragon Breath!"} @PlayersInRadius{r=35}
+  - sound{s=entity.ender_dragon.shoot;v=1.2;p=0.8} @self
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=7;y=0.2} @self
+  - damage{a=140} @PlayersInRadius{r=7}
+  - delay 5
 
 ScytheWhirlwind_hell:
-  Cooldown: 20
+  Cooldown: 16
   Skills:
-    # Telegraph: warn players before the whirlwind starts so they can dodge
-    - message{m="&6Skeledragon raises its scythe, winds swirling!"} @PlayersInRadius{r=30}
-    - effect:particles{p=CLOUD;amount=100;radius=10} @self
-    - delay 40
-    - message{m="&cWhirling scythe attack incoming!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SPELL_WITCH;amount=100;radius=10} @self
-    - delay 60
-    - damage{a=800} @PlayersInRadius{r=10}  # 2x400
+  - message{m="&7<mob.name>&f whirls its blade!"} @PlayersInRadius{r=25}
+  - sound{s=entity.player.attack.sweep;v=1.2;p=1} @self
+  - effect:particles{p=SWEEP_ATTACK;amount=40;radius=5;y=0.2} @self
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=260} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=260} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=260} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=260} @PlayersInRadius{r=4}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
+  - damage{a=260} @PlayersInRadius{r=4}
+  - delay 6
 
 DeathDash_hell:
-  Cooldown: 10
+  Cooldown: 12
   Skills:
-    # Telegraph: make the dash clearly visible and give players time to react
-    - message{m="&6Skeledragon fixates on its prey, ready to dash!"} @PlayersInRadius{r=30}
-    - effect:particles{p=VILLAGER_ANGRY;amount=30;radius=5} @self
-    - delay 20
-    - effect:particles{p=SMOKE_LARGE;amount=50} @self
-    - delay 30
-    - teleport @Target
-    - damage{a=1000} @Target
+  - message{m="&8<mob.name>&f vanishes into shadowy snow!"} @PlayersInRadius{r=25}
+  - effect:particles{p=SMOKE_LARGE;amount=40;radius=1} @self
+  - sound{s=entity.enderman.teleport;v=1;p=1} @self
+  - delay 5
+  - teleport @Target
+  - damage{a=480} @PlayersInRadius{r=2}
+  - effect:particles{p=CRIT_MAGIC;amount=40;radius=2} @self
+  - sound{s=entity.player.attack.strong;v=1;p=1} @self
+
 HealingPulse_hell:
-  Cooldown: 15
+  Cooldown: 20
   Skills:
-    - heal{a=1500} @self  # 3x500 (HP scaling)
-    - effect:particles{p=HEART;amount=20} @self
+  - message{m="&a<&sparkles>&f Healing pulse!"} @PlayersInRadius{r=30}
+  - heal{a=1600} @self
+  - potion{type=REGENERATION;duration=140;level=1} @self
+  - effect:particles{p=HEART;amount=30} @self
+  - sound{s=entity.experience_orb.pickup;v=1;p=1.8} @self
 
 DeathZone_hell:
   Cooldown: 25
   Skills:
-    # Telegraph: give players a clear warning and longer window to escape the Death Zone
-    - message{m="&6A sinister aura gathers... Skeledragon is creating a death zone! Move away!"} @PlayersInRadius{r=30}
-    - effect:particles{p=REDSTONE;amount=100;radius=10} @target
-    - delay 60
-    - damage{a=99999} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_HUGE;amount=10} @target
+  - message{m="&6A dark zone is forming... &cMOVE AWAY!"} @PlayersInRadius{r=35}
+  - effect:particles{p=REDSTONE;amount=120;radius=7;y=0.2} @target
+  - sound{s=block.portal.ambient;v=1;p=0.6} @target
+  - delay 30
+  - effect:particles{p=SOUL;amount=160;radius=6;y=0.2} @target
+  - delay 30
+  - damage{a=99999} @PlayersInRadius{r=5}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - sound{s=entity.generic.explode;v=1;p=1} @target
 
 SummonDragon_hell:
-  Cooldown: 60
   Skills:
-    - message{m="&cMortis summons Skeledragon!"} @PlayersInRadius{r=30}
-    - summon{mob=skeledragon_phase1_hell;amount=1;radius=5} @self
+  - message{m="&cMortis joins the fight!"} @PlayersInRadius{r=30}
+  - sound{s=entity.ender_dragon.growl;v=1.2;p=0.8} @self
+  - summon{mob=skeledragon_phase2_hell;amount=1;radius=0} @self
 
 SummonPhase2_hell:
   Skills:
-    # Telegraph: announce Mortis' arrival before spawning phase 2 mobs
-    - message{m="&6Mortis whistles for his steed, preparing phase two!"} @PlayersInRadius{r=30}
-    - effect:particles{p=VILLAGER_HAPPY;amount=50;radius=5} @self
-    - delay 40
-    - message{m="&cMortis joins the battle!"} @PlayersInRadius{r=30}
-    - summon{mob=skeledragon_phase2_hell;amount=1;radius=0} @self
-    - summon{mob=death_archer_hell;amount=3;radius=5} @self
-    - summon{mob=elite_skeleton_archer_hell;amount=10;radius=5} @self
-    - summon{mob=elite_skeleton_warrior_hell;amount=10;radius=5} @self
+  - message{m="&5Murot calls in powerful support!"} @PlayersInRadius{r=30}
+  - sound{s=entity.evoker.prepare_summon;v=1.2;p=0.8} @self
+  - delay 60
+  - summon{mob=skeledragon_phase2_hell;amount=1;radius=0} @self
+  - summon{mob=death_archer_hell;amount=4;radius=5} @self
+  - summon{mob=elite_skeleton_archer_hell;amount=8;radius=6} @self
+  - summon{mob=elite_skeleton_warrior_hell;amount=8;radius=6} @self
 
 SummonPhase3_hell:
   Skills:
-    - message{m="&cMortis breaks free!"} @PlayersInRadius{r=30}
-    - delay 100
-    - summon{mob=mortis_phase3_hell;amount=1;radius=0} @self
+  - message{m="&cMortis unleashes full power!"} @PlayersInRadius{r=30}
+  - sound{s=entity.wither.spawn;v=1.2;p=0.6} @self
+  - delay 80
+  - summon{mob=mortis_phase3_hell;amount=1;radius=0} @self
 
-# Mission 1 Skills - Blood version (5x damage)
 DeathExplosion_blood:
   Cooldown: 1
   Skills:
-    - message{m="&cDeath explosion imminent!"} @PlayersInRadius{r=10}
-    - delay 20
-    - damage{a=1000} @PlayersInRadius{r=3}  # 5x200
-    - effect:particles{p=EXPLOSION_LARGE;amount=20} @self
+  - message{m="&cA &lDeath Explosion&r is coming! &7(Run!)"} @PlayersInRadius{r=12}
+  - sound{s=entity.wither.spawn;v=1;p=0.8} @self
+  - effect:particles{p=SMOKE_LARGE;amount=30;radius=4;y=0.2} @self
+  - delay 10
+  - effect:particles{p=SMOKE_LARGE;amount=40;radius=5;y=0.2} @self
+  - delay 10
+  - effect:particles{p=SMOKE_LARGE;amount=60;radius=6;y=0.2} @self
+  - delay 10
+  - effect:particles{p=DRAGON_BREATH;amount=80;radius=7;y=0.2} @self
+  - delay 10
+  - damage{a=1200} @PlayersInRadius{r=6}
+  - potion{type=WITHER;duration=120;level=1} @PlayersInRadius{r=6}
+  - ignite{ticks=60} @PlayersInRadius{r=6}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @self
+  - sound{s=entity.generic.explode;v=1;p=1} @self
+  - summon{mob=raging_soul_blood;amount=2;radius=3} @self
 
-# Mission 2 Skills
 WitheringShot_blood:
   Cooldown: 10
   Skills:
-    - message{m="&6<mob.name>&f draws a withering arrow!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SMOKE_LARGE;amount=10;radius=1} @self
-    - delay 20
-    - shoot{type=ARROW;velocity=30;damage=1000} @Target  # 5x200
-    - potion{type=WITHER;duration=100;level=3} @Target
+  - message{m="&6<mob.name>&f draws a bowstring tainted with darkness!"} @PlayersInRadius{r=30}
+  - sound{s=entity.skeleton.shoot;v=1;p=1.2} @self
+  - effect:particles{p=SMOKE_LARGE;amount=12;radius=1} @self
+  - delay 15
+  - shoot{type=ARROW;velocity=30;damage=1100;spread=12;amount=5} @Target
+  - potion{type=WITHER;duration=120;level=3} @Target
 
 MeteorStrike_blood:
   Cooldown: 15
   Skills:
-    - message{m="&5Murot calls down a meteor!"} @PlayersInRadius{r=30}
-    - effect:particles{p=FLAME;amount=50} @target
-    - delay 20
-    - damage{a=1500} @PlayersInRadius{r=5}  # 5x300
-    - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - message{m="&5<mob.name>&f summons a &dMeteor!"} @PlayersInRadius{r=30}
+  - sound{s=entity.ender_dragon.growl;v=1;p=0.6} @target
+  - effect:particles{p=FLAME;amount=80} @target
+  - effect:particles{p=SMOKE_LARGE;amount=60} @target
+  - delay 40
+  - damage{a=1600} @PlayersInRadius{r=7}
+  - ignite{ticks=160} @PlayersInRadius{r=7}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - sound{s=entity.generic.explode;v=1;p=1} @target
 
 HomingOrb_blood:
   Cooldown: 10
   Skills:
-    - message{m="&5<mob.name>&f forms a homing orb!"} @PlayersInRadius{r=30}
-    - effect:particles{p=DRAGON_BREATH;amount=20;radius=1} @self
-    - delay 20
-    - projectile{onTick=Orb-Tick-Blood;onHit=Orb-Hit-Blood;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @target
+  - message{m="&5<mob.name>&f forms a &dNecro Orb&f that &ltracks&f its target!"} @PlayersInRadius{r=30}
+  - effect:particles{p=DRAGON_BREATH;amount=30;radius=1} @self
+  - sound{s=block.beacon.ambient;v=1;p=1} @self
+  - delay 10
+  - projectile{onTick=Orb-Tick;onHit=Orb-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @Target
+  - delay 20
+  - projectile{onTick=Orb-Tick;onHit=Orb-Hit-Blood;v=8;i=DRAGON_BREATH;hR=1;vR=1;sF=true} @Target
 
 Orb-Hit-Blood:
   Skills:
-    - damage{a=750} @target  # 5x150
-    - effect:particles{p=SPELL;amount=20} @target
+  - damage{a=900} @target
+  - potion{type=SLOW;duration=100;level=1} @target
+  - potion{type=WEAKNESS;duration=100;level=1} @target
+  - effect:particles{p=SPELL;amount=25} @target
+  - sound{s=entity.witch.celebrate;v=1;p=0.8} @target
 
-# Mission 3 Boss Skills
 DragonBreath_blood:
-  Cooldown: 15
+  Cooldown: 12
   Skills:
-    - message{m="&6Skeledragon inhales deeply, preparing its fiery breath!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SMOKE_LARGE;amount=75;radius=10} @self
-    - delay 40
-    - message{m="&cSkeledragon unleashes its breath!"} @PlayersInRadius{r=30}
-    - effect:particles{p=DRAGON_BREATH;amount=100;radius=10} @Forward{f=20}
-    - damage{a=1000} @Forward{f=20;spread=0}  # 5x200
-    - ignite{ticks=100} @Forward{f=20;spread=0}
+  - message{m="&c<&skull>&f Dragon Breath!"} @PlayersInRadius{r=35}
+  - sound{s=entity.ender_dragon.shoot;v=1.2;p=0.8} @self
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
+  - effect:particles{p=DRAGON_BREATH;amount=120;radius=8;y=0.2} @self
+  - damage{a=220} @PlayersInRadius{r=8}
+  - delay 5
 
 ScytheWhirlwind_blood:
-  Cooldown: 20
+  Cooldown: 16
   Skills:
-    # Telegraph: warn players before the whirlwind starts so they can dodge
-    - message{m="&6Skeledragon raises its scythe, winds swirling!"} @PlayersInRadius{r=30}
-    - effect:particles{p=CLOUD;amount=100;radius=10} @self
-    - delay 40
-    - message{m="&cWhirling scythe attack incoming!"} @PlayersInRadius{r=30}
-    - effect:particles{p=SPELL_WITCH;amount=100;radius=10} @self
-    - delay 60
-    - damage{a=2000} @PlayersInRadius{r=10}  # 5x400
+  - message{m="&7<mob.name>&f whirls its blade!"} @PlayersInRadius{r=25}
+  - sound{s=entity.player.attack.sweep;v=1.2;p=1} @self
+  - effect:particles{p=SWEEP_ATTACK;amount=40;radius=6;y=0.2} @self
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
+  - damage{a=420} @PlayersInRadius{r=5}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
+  - damage{a=420} @PlayersInRadius{r=5}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
+  - damage{a=420} @PlayersInRadius{r=5}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
+  - damage{a=420} @PlayersInRadius{r=5}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
+  - damage{a=420} @PlayersInRadius{r=5}
+  - delay 6
+  - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
+  - damage{a=420} @PlayersInRadius{r=5}
+  - delay 6
 
 DeathDash_blood:
-  Cooldown: 10
+  Cooldown: 12
   Skills:
-    # Telegraph: make the dash clearly visible and give players time to react
-    - message{m="&6Skeledragon fixates on its prey, ready to dash!"} @PlayersInRadius{r=30}
-    - effect:particles{p=VILLAGER_ANGRY;amount=30;radius=5} @self
-    - delay 20
-    - effect:particles{p=SMOKE_LARGE;amount=50} @self
-    - delay 30
-    - teleport @Target
-    - damage{a=2500} @Target
+  - message{m="&8<mob.name>&f vanishes into shadowy snow!"} @PlayersInRadius{r=25}
+  - effect:particles{p=SMOKE_LARGE;amount=40;radius=1} @self
+  - sound{s=entity.enderman.teleport;v=1;p=1} @self
+  - delay 5
+  - teleport @Target
+  - damage{a=1000} @PlayersInRadius{r=2}
+  - effect:particles{p=CRIT_MAGIC;amount=40;radius=2} @self
+  - sound{s=entity.player.attack.strong;v=1;p=1} @self
+
 HealingPulse_blood:
-  Cooldown: 15
+  Cooldown: 20
   Skills:
-    - heal{a=5000} @self  # 10x500 (HP scaling)
-    - effect:particles{p=HEART;amount=20} @self
+  - message{m="&a<&sparkles>&f Healing pulse!"} @PlayersInRadius{r=30}
+  - heal{a=3000} @self
+  - potion{type=REGENERATION;duration=180;level=1} @self
+  - effect:particles{p=HEART;amount=30} @self
+  - sound{s=entity.experience_orb.pickup;v=1;p=1.8} @self
 
 DeathZone_blood:
   Cooldown: 25
   Skills:
-    # Telegraph: give players a clear warning and longer window to escape the Death Zone
-    - message{m="&6A sinister aura gathers... Skeledragon is creating a death zone! Move away!"} @PlayersInRadius{r=30}
-    - effect:particles{p=REDSTONE;amount=100;radius=10} @target
-    - delay 60
-    - damage{a=99999} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_HUGE;amount=10} @target
+  - message{m="&6A dark zone is forming... &cMOVE AWAY!"} @PlayersInRadius{r=35}
+  - effect:particles{p=REDSTONE;amount=120;radius=8;y=0.2} @target
+  - sound{s=block.portal.ambient;v=1;p=0.6} @target
+  - delay 30
+  - effect:particles{p=SOUL;amount=160;radius=7;y=0.2} @target
+  - delay 30
+  - damage{a=99999} @PlayersInRadius{r=6}
+  - effect:particles{p=EXPLOSION_HUGE;amount=1} @target
+  - sound{s=entity.generic.explode;v=1;p=1} @target
 
 SummonDragon_blood:
-  Cooldown: 60
   Skills:
-    - message{m="&cMortis summons Skeledragon!"} @PlayersInRadius{r=30}
-    - summon{mob=skeledragon_phase1_blood;amount=1;radius=5} @self
+  - message{m="&cMortis joins the fight!"} @PlayersInRadius{r=30}
+  - sound{s=entity.ender_dragon.growl;v=1.2;p=0.8} @self
+  - summon{mob=skeledragon_phase2_blood;amount=1;radius=0} @self
 
 SummonPhase2_blood:
   Skills:
-    # Telegraph: announce Mortis' arrival before spawning phase 2 mobs
-    - message{m="&6Mortis whistles for his steed, preparing phase two!"} @PlayersInRadius{r=30}
-    - effect:particles{p=VILLAGER_HAPPY;amount=50;radius=5} @self
-    - delay 40
-    - message{m="&cMortis joins the battle!"} @PlayersInRadius{r=30}
-    - summon{mob=skeledragon_phase2_blood;amount=1;radius=0} @self
-    - summon{mob=death_archer_blood;amount=3;radius=5} @self
-    - summon{mob=elite_skeleton_archer_blood;amount=10;radius=5} @self
-    - summon{mob=elite_skeleton_warrior_blood;amount=10;radius=5} @self
+  - message{m="&4Murot erupts in rage – a horde approaches!"} @PlayersInRadius{r=30}
+  - sound{s=entity.evoker.prepare_summon;v=1.3;p=0.6} @self
+  - delay 60
+  - summon{mob=skeledragon_phase2_blood;amount=1;radius=0} @self
+  - summon{mob=death_archer_blood;amount=5;radius=6} @self
+  - summon{mob=elite_skeleton_archer_blood;amount=10;radius=7} @self
+  - summon{mob=elite_skeleton_warrior_blood;amount=10;radius=7} @self
 
 SummonPhase3_blood:
   Skills:
-    - message{m="&cMortis breaks free!"} @PlayersInRadius{r=30}
-    - delay 100
-    - summon{mob=mortis_phase3_blood;amount=1;radius=0} @self
+  - message{m="&4Mortis transforms the battlefield!"} @PlayersInRadius{r=30}
+  - sound{s=entity.wither.spawn;v=1.2;p=0.5} @self
+  - delay 80
+  - summon{mob=mortis_phase3_blood;amount=1;radius=0} @self

--- a/skills/q7.yml
+++ b/skills/q7.yml
@@ -1,245 +1,360 @@
-# Mission 1 Skills
-FlameAttack:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=FLAME;amount=20} @targetlocation
-    - delay 20
-    - damage{a=150} @PlayersInRadius{r=2} @targetlocation
-    - ignite{ticks=60} @PlayersInRadius{r=2} @targetlocation
+# Mission 1 Skills (improved)
 
-ThunderStrike:
+FlameAttack:
   Cooldown: 12
   Skills:
-    - effect:particles{p=WAX_OFF;amount=30} @targetlocation
+    - sound{s=entity.blaze.shoot;v=1;p=0.8} @self
+    - effect:particles{p=SMOKE_LARGE;amount=25;hS=2.5;vS=0.1;speed=0.01} @targetlocation
+    - effect:particles{p=FLAME;amount=80;hS=2.3;vS=0.1;speed=0.01} @targetlocation
     - delay 20
-    - damage{a=200} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=LEVITATION;duration=40;level=1} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=CONFUSION;duration=60;level=1} @PlayersInRadius{r=2} @targetlocation
+    - damage{a=180} @PlayersInRadius{r=2.5} @targetlocation
+    - ignite{ticks=80} @PlayersInRadius{r=2.5} @targetlocation
+    - knockback{strength=0.8} @PlayersInRadius{r=2.5} @targetlocation
+    - sound{s=entity.generic.explode;v=1.2;p=1} @targetlocation
+
+ThunderStrike:
+  Cooldown: 10
+  Skills:
+    - sound{s=block.bell.use;v=1.2;p=0.5} @self
+    - effect:particles{p=CRIT_MAGIC;amount=60;hS=2.5;vS=0.2;speed=0.1} @targetlocation
+    - lightning{action=STRIKE} @targetlocation
+    - delay 20
+    - damage{a=240} @PlayersInRadius{r=2.5} @targetlocation
+    - potion{type=LEVITATION;duration=50;level=1} @PlayersInRadius{r=2.5} @targetlocation
+    - potion{type=SLOW;duration=80;level=1} @PlayersInRadius{r=2.5} @targetlocation
+    - sound{s=entity.lightning_bolt.thunder;v=2;p=1} @targetlocation
 
 DeathExplosion:
   Cooldown: 1
   Skills:
-    - message{m="&cDark energy builds up..."} @PlayersInRadius{r=5}
-    - delay 40
-    - damage{a=300} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=20} @self
+    - message{m="&4&l! &cEnergy surges... &7(Back away)"} @PlayersInRadius{r=8}
+    - effect:particles{p=SMOKE_NORMAL;amount=80;hS=1.8;vS=0.3;speed=0.02;y=0.2} @self
+    - sound{s=entity.wither.ambient;v=1.2;p=0.6} @self
+    - delay 50
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - sound{s=entity.generic.explode;v=1.5;p=1} @self
+    - damage{a=350} @PlayersInRadius{r=3.2}
+    - potion{type=WEAKNESS;duration=80;level=1} @PlayersInRadius{r=3.2}
 
 LaserBeam:
-  Cooldown: 10
+  Cooldown: 8
   Skills:
-    - effect:particles{p=END_ROD;amount=50} @Forward{f=10}
-    - delay 20
-    - damage{a=100} @Forward{f=10}
+    - message{m="&b&l» &fCharging the laser!"} @PlayersInRadius{r=15}
+    - sound{s=block.beacon.activate;v=0.8;p=1.2} @self
+    - delay 10
+    - effect:particles{p=END_ROD;amount=20} @Forward{f=2}
+    - damage{a=90} @PlayersInRadius{r=1.5} @Forward{f=2}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=20} @Forward{f=4}
+    - damage{a=90} @PlayersInRadius{r=1.5} @Forward{f=4}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=20} @Forward{f=6}
+    - damage{a=90} @PlayersInRadius{r=1.5} @Forward{f=6}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=20} @Forward{f=8}
+    - damage{a=90} @PlayersInRadius{r=1.5} @Forward{f=8}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=30} @Forward{f=10}
+    - sound{s=block.beacon.power_select;v=1.2;p=1.6} @self
+    - damage{a=90} @PlayersInRadius{r=1.5} @Forward{f=10}
 
-# Mission 2 Skills
 SummonFlamespawns:
-  Cooldown: 30
+  Cooldown: 28
   Skills:
-    - message{m="&cCommander Embersword summons reinforcements!"} @PlayersInRadius{r=20}
-    - summon{mob=angry_flamespawn_inf;amount=2;radius=3} @self
+    - message{m="&cThe commander calls for reinforcements!"} @PlayersInRadius{r=30}
+    - sound{s=block.portal.trigger;v=1.2;p=0.6} @self
+    - effect:particles{p=PORTAL;amount=60;hS=1;vS=1;speed=0.2} @self
+    - summon{mob=angry_flamespawn_inf;amount=3;radius=3} @self
 
-# Mission 3 Boss Skills
 FlameStrike:
-  Cooldown: 5
+  Cooldown: 6
   Skills:
-    - message{m="&cThe Herald prepares to strike!"} @PlayersInRadius{r=20}
-    - effect:particles{p=FLAME;amount=30} @targetlocation
-    - delay 20
-    - damage{a=200} @PlayersInRadius{r=2} @targetlocation
-    - ignite{ticks=60} @PlayersInRadius{r=2} @targetlocation
+    - message{m="&c&l! &7Flame strike incoming"} @PlayersInRadius{r=20}
+    - sound{s=entity.blaze.shoot;v=1;p=0.7} @self
+    - effect:particles{p=ASH;amount=40;hS=2.4;vS=0.1} @targetlocation
+    - effect:particles{p=FLAME;amount=100;hS=2.2;vS=0.1} @targetlocation
+    - delay 15
+    - damage{a=220} @PlayersInRadius{r=2.4} @targetlocation
+    - ignite{ticks=80} @PlayersInRadius{r=2.4} @targetlocation
+    - knockback{strength=1.0} @PlayersInRadius{r=2.4} @targetlocation
 
 PoweredFlameStrike:
-  Cooldown: 10
+  Cooldown: 12
   Skills:
-    - message{m="&cThe Herald channels dark flames!"} @PlayersInRadius{r=20}
-    - effect:particles{p=FLAME;amount=50} @targetlocation
-    - delay 20
-    - damage{a=600} @PlayersInRadius{r=2} @targetlocation
-    - ignite{ticks=100} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=2} @targetlocation
+    - message{m="&6&l!! &cChanneling a hellish blow!"} @PlayersInRadius{r=25}
+    - sound{s=block.enchantment_table.use;v=1.2;p=0.8} @self
+    - effect:particles{p=SOUL_FIRE_FLAME;amount=120;hS=3.0;vS=0.2} @targetlocation
+    - delay 25
+    - damage{a=320} @PlayersInRadius{r=3.0} @targetlocation
+    - ignite{ticks=140} @PlayersInRadius{r=3.0} @targetlocation
+    - potion{type=SLOW;duration=60;level=1} @PlayersInRadius{r=3.0} @targetlocation
+    - sound{s=entity.blaze.burn;v=1.4;p=1} @targetlocation
 
 MeteorShower:
-  Cooldown: 15
+  Cooldown: 16
   Skills:
-    - message{m="&cMeteors rain from above!"} @PlayersInRadius{r=30}
-    - projectile{onTick=Meteor-Tick;onHit=Meteor-Hit;v=8;i=MAGMA_BLOCK;hR=1;vR=1;amount=5} @target
+    - message{m="&4&l☄ &7Calling down a meteor shower!"} @PlayersInRadius{r=30}
+    - sound{s=entity.ghast.shoot;v=1.2;p=0.7} @self
+    - projectile{onHit=Meteor-Hit;onTick=Meteor-Tick;v=18;g=1.0;hR=1.2;vR=1.2;amount=6;spread=6;y=3} @targetlocation
 
 Meteor-Tick:
   Skills:
-    - effect:particles{p=FLAME;amount=10} @origin
+    - effect:particles{p=FLAME;amount=6;hS=0.2;vS=0.2;speed=0.01} @origin
 
 Meteor-Hit:
   Skills:
-    - damage{a=300} @PlayersInRadius{r=3}
+    - damage{a=320} @PlayersInRadius{r=3}
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @origin
-    - ignite{ticks=60} @PlayersInRadius{r=3}
+    - ignite{ticks=80} @PlayersInRadius{r=3}
+    - knockback{strength=1.2} @PlayersInRadius{r=3}
+    - sound{s=entity.generic.explode;v=1.5;p=1} @origin
 
 SummonFlamespawnsLarge:
-  Cooldown: 30
+  Cooldown: 28
   Skills:
-    - message{m="&cThe Herald summons its minions!"} @PlayersInRadius{r=30}
+    - message{m="&cThe herald summons its minions!"} @PlayersInRadius{r=30}
+    - sound{s=block.portal.trigger;v=1.2;p=0.6} @self
+    - effect:particles{p=PORTAL;amount=100;hS=1;vS=1;speed=0.2} @self
     - summon{mob=angry_flamespawn_inf;amount=5;radius=5} @self
 
-# Mission 1 Skills - Hell version (2x damage)
+# Mission 1 Skills - Hell version (stronger, flashier)
+
 FlameAttack_hell:
-  Cooldown: 15
+  Cooldown: 10
   Skills:
-    - effect:particles{p=FLAME;amount=20} @targetlocation
+    - sound{s=entity.blaze.shoot;v=1;p=0.8} @self
+    - effect:particles{p=SMOKE_LARGE;amount=35;hS=3.0;vS=0.1;speed=0.01} @targetlocation
+    - effect:particles{p=FLAME;amount=120;hS=2.8;vS=0.1;speed=0.01} @targetlocation
     - delay 20
-    - damage{a=300} @PlayersInRadius{r=2} @targetlocation  # 2x150
-    - ignite{ticks=80} @PlayersInRadius{r=2} @targetlocation
+    - damage{a=360} @PlayersInRadius{r=3.0} @targetlocation
+    - ignite{ticks=120} @PlayersInRadius{r=3.0} @targetlocation
+    - knockback{strength=0.9} @PlayersInRadius{r=3.0} @targetlocation
+    - sound{s=entity.generic.explode;v=1.2;p=1} @targetlocation
+    - potion{type=WEAKNESS;duration=60;level=1} @PlayersInRadius{r=3.0} @targetlocation
 
 ThunderStrike_hell:
-  Cooldown: 12
+  Cooldown: 9
   Skills:
-    - effect:particles{p=WAX_OFF;amount=30} @targetlocation
+    - sound{s=block.bell.use;v=1.2;p=0.5} @self
+    - effect:particles{p=CRIT_MAGIC;amount=80;hS=3.0;vS=0.2;speed=0.1} @targetlocation
+    - lightning{action=STRIKE} @targetlocation
     - delay 20
-    - damage{a=400} @PlayersInRadius{r=2} @targetlocation  # 2x200
-    - potion{type=LEVITATION;duration=60;level=2} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=CONFUSION;duration=80;level=1} @PlayersInRadius{r=2} @targetlocation
+    - damage{a=480} @PlayersInRadius{r=3.0} @targetlocation
+    - potion{type=LEVITATION;duration=60;level=1} @PlayersInRadius{r=3.0} @targetlocation
+    - potion{type=SLOW;duration=100;level=1} @PlayersInRadius{r=3.0} @targetlocation
+    - sound{s=entity.lightning_bolt.thunder;v=2;p=1} @targetlocation
 
 DeathExplosion_hell:
   Cooldown: 1
   Skills:
-    - message{m="&cDark energy builds up..."} @PlayersInRadius{r=5}
-    - delay 40
-    - damage{a=600} @PlayersInRadius{r=3}  # 2x300
-    - effect:particles{p=EXPLOSION_LARGE;amount=20} @self
+    - message{m="&4&l! &cEnergy surges... &7(Back away)"} @PlayersInRadius{r=8}
+    - effect:particles{p=SMOKE_NORMAL;amount=100;hS=1.8;vS=0.3;speed=0.02;y=0.2} @self
+    - sound{s=entity.wither.ambient;v=1.2;p=0.6} @self
+    - delay 45
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - sound{s=entity.generic.explode;v=1.5;p=1} @self
+    - damage{a=700} @PlayersInRadius{r=3.5}
+    - potion{type=WEAKNESS;duration=80;level=1} @PlayersInRadius{r=3.5}
 
 LaserBeam_hell:
-  Cooldown: 10
+  Cooldown: 7
   Skills:
-    - effect:particles{p=END_ROD;amount=50} @Forward{f=10}
-    - delay 20
-    - damage{a=200} @Forward{f=10}  # 2x100
+    - message{m="&b&l» &fCharging the laser!"} @PlayersInRadius{r=15}
+    - sound{s=block.beacon.activate;v=0.8;p=1.2} @self
+    - delay 10
+    - effect:particles{p=END_ROD;amount=25} @Forward{f=2}
+    - damage{a=130} @PlayersInRadius{r=1.5} @Forward{f=2}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=25} @Forward{f=4}
+    - damage{a=130} @PlayersInRadius{r=1.5} @Forward{f=4}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=25} @Forward{f=6}
+    - damage{a=130} @PlayersInRadius{r=1.5} @Forward{f=6}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=25} @Forward{f=8}
+    - damage{a=130} @PlayersInRadius{r=1.5} @Forward{f=8}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=35} @Forward{f=10}
+    - sound{s=block.beacon.power_select;v=1.2;p=1.6} @self
+    - damage{a=130} @PlayersInRadius{r=1.5} @Forward{f=10}
 
-# Mission 2 Skills
 SummonFlamespawns_hell:
-  Cooldown: 30
+  Cooldown: 26
   Skills:
-    - message{m="&cCommander Embersword summons reinforcements!"} @PlayersInRadius{r=20}
-    - summon{mob=angry_flamespawn_hell;amount=2;radius=3} @self
+    - message{m="&c&lHell opens its gates!"} @PlayersInRadius{r=30}
+    - sound{s=block.portal.trigger;v=1.2;p=0.6} @self
+    - effect:particles{p=PORTAL;amount=60;hS=1;vS=1;speed=0.2} @self
+    - summon{mob=angry_flamespawn_hell;amount=3;radius=4} @self
 
-# Mission 3 Boss Skills
 FlameStrike_hell:
   Cooldown: 5
   Skills:
-    - message{m="&cThe Herald prepares to strike!"} @PlayersInRadius{r=20}
-    - effect:particles{p=FLAME;amount=30} @targetlocation
-    - delay 20
-    - damage{a=400} @PlayersInRadius{r=2} @targetlocation  # 2x200
-    - ignite{ticks=80} @PlayersInRadius{r=2} @targetlocation
+    - message{m="&c&l! &7Flame strike incoming"} @PlayersInRadius{r=20}
+    - sound{s=entity.blaze.shoot;v=1;p=0.7} @self
+    - effect:particles{p=ASH;amount=50;hS=2.8;vS=0.1} @targetlocation
+    - effect:particles{p=FLAME;amount=120;hS=2.6;vS=0.1} @targetlocation
+    - delay 15
+    - damage{a=440} @PlayersInRadius{r=2.8} @targetlocation
+    - ignite{ticks=120} @PlayersInRadius{r=2.8} @targetlocation
+    - knockback{strength=1.1} @PlayersInRadius{r=2.8} @targetlocation
 
 PoweredFlameStrike_hell:
   Cooldown: 10
   Skills:
-    - message{m="&cThe Herald channels dark flames!"} @PlayersInRadius{r=20}
-    - effect:particles{p=FLAME;amount=50} @targetlocation
-    - delay 20
-    - damage{a=1200} @PlayersInRadius{r=2} @targetlocation  # 2x600
-    - ignite{ticks=120} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=2} @targetlocation
+    - message{m="&6&l!! &cChanneling a hellish blow!"} @PlayersInRadius{r=25}
+    - sound{s=block.enchantment_table.use;v=1.2;p=0.8} @self
+    - effect:particles{p=SOUL_FIRE_FLAME;amount=140;hS=3.2;vS=0.2} @targetlocation
+    - delay 25
+    - damage{a=640} @PlayersInRadius{r=3.2} @targetlocation
+    - ignite{ticks=140} @PlayersInRadius{r=3.2} @targetlocation
+    - potion{type=SLOW;duration=60;level=1} @PlayersInRadius{r=3.2} @targetlocation
+    - sound{s=entity.blaze.burn;v=1.4;p=1} @targetlocation
 
 MeteorShower_hell:
-  Cooldown: 15
+  Cooldown: 14
   Skills:
-    - message{m="&cMeteors rain from above!"} @PlayersInRadius{r=30}
-    - projectile{onTick=Meteor-Tick-Hell;onHit=Meteor-Hit-Hell;v=8;i=MAGMA_BLOCK;hR=1;vR=1;amount=5} @target
+    - message{m="&4&l☄ &7Calling down a meteor shower!"} @PlayersInRadius{r=30}
+    - sound{s=entity.ghast.shoot;v=1.2;p=0.7} @self
+    - projectile{onHit=Meteor-Hit-Hell;onTick=Meteor-Tick-Hell;v=20;g=1.05;hR=1.2;vR=1.2;amount=8;spread=6;y=3} @targetlocation
 
 Meteor-Tick-Hell:
   Skills:
-    - effect:particles{p=FLAME;amount=10} @origin
+    - effect:particles{p=SOUL_FIRE_FLAME;amount=6;hS=0.2;vS=0.2;speed=0.01} @origin
 
 Meteor-Hit-Hell:
   Skills:
-    - damage{a=600} @PlayersInRadius{r=3}  # 2x300
+    - damage{a=650} @PlayersInRadius{r=3.4}
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @origin
-    - ignite{ticks=80} @PlayersInRadius{r=3}
+    - ignite{ticks=120} @PlayersInRadius{r=3.4}
+    - knockback{strength=1.2} @PlayersInRadius{r=3.4}
+    - sound{s=entity.generic.explode;v=1.5;p=1} @origin
+    - potion{type=SLOW;duration=80;level=1} @PlayersInRadius{r=3.4}
 
 SummonFlamespawnsLarge_hell:
-  Cooldown: 30
+  Cooldown: 28
   Skills:
-    - message{m="&cThe Herald summons its minions!"} @PlayersInRadius{r=30}
-    - summon{mob=angry_flamespawn_hell;amount=5;radius=5} @self
+    - message{m="&cThe herald sends a legion of fire!"} @PlayersInRadius{r=30}
+    - sound{s=block.portal.trigger;v=1.2;p=0.6} @self
+    - effect:particles{p=PORTAL;amount=120;hS=1;vS=1;speed=0.2} @self
+    - summon{mob=angry_flamespawn_hell;amount=6;radius=5} @self
 
-# Mission 1 Skills - Blood version (5x damage)
+# Mission 1 Skills - Blood version (brutal)
+
 FlameAttack_blood:
-  Cooldown: 15
+  Cooldown: 8
   Skills:
-    - effect:particles{p=FLAME;amount=20} @targetlocation
+    - sound{s=entity.blaze.shoot;v=1;p=0.8} @self
+    - effect:particles{p=SMOKE_LARGE;amount=45;hS=3.4;vS=0.1;speed=0.01} @targetlocation
+    - effect:particles{p=FLAME;amount=130;hS=3.2;vS=0.1;speed=0.01} @targetlocation
     - delay 20
-    - damage{a=750} @PlayersInRadius{r=2} @targetlocation  # 5x150
-    - ignite{ticks=100} @PlayersInRadius{r=2} @targetlocation
+    - damage{a=600} @PlayersInRadius{r=3.4} @targetlocation
+    - ignite{ticks=160} @PlayersInRadius{r=3.4} @targetlocation
+    - knockback{strength=1.0} @PlayersInRadius{r=3.4} @targetlocation
+    - sound{s=entity.generic.explode;v=1.2;p=1} @targetlocation
+    - potion{type=BLINDNESS;duration=40;level=1} @PlayersInRadius{r=3.4} @targetlocation
 
 ThunderStrike_blood:
-  Cooldown: 12
+  Cooldown: 8
   Skills:
-    - effect:particles{p=WAX_OFF;amount=30} @targetlocation
+    - sound{s=block.bell.use;v=1.2;p=0.5} @self
+    - effect:particles{p=CRIT_MAGIC;amount=90;hS=3.4;vS=0.2;speed=0.1} @targetlocation
+    - lightning{action=STRIKE} @targetlocation
     - delay 20
-    - damage{a=1000} @PlayersInRadius{r=2} @targetlocation  # 5x200
-    - potion{type=LEVITATION;duration=80;level=3} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=CONFUSION;duration=100;level=2} @PlayersInRadius{r=2} @targetlocation
+    - damage{a=800} @PlayersInRadius{r=3.4} @targetlocation
+    - potion{type=LEVITATION;duration=70;level=1} @PlayersInRadius{r=3.4} @targetlocation
+    - potion{type=SLOW;duration=120;level=1} @PlayersInRadius{r=3.4} @targetlocation
+    - sound{s=entity.lightning_bolt.thunder;v=2;p=1} @targetlocation
 
 DeathExplosion_blood:
   Cooldown: 1
   Skills:
-    - message{m="&cDark energy builds up..."} @PlayersInRadius{r=5}
+    - message{m="&4&l! &cEnergy surges... &7(Back away)"} @PlayersInRadius{r=8}
+    - effect:particles{p=SMOKE_NORMAL;amount=120;hS=1.8;vS=0.3;speed=0.02;y=0.2} @self
+    - sound{s=entity.wither.ambient;v=1.2;p=0.6} @self
     - delay 40
-    - damage{a=1500} @PlayersInRadius{r=3}  # 5x300
-    - effect:particles{p=EXPLOSION_LARGE;amount=20} @self
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - sound{s=entity.generic.explode;v=1.5;p=1} @self
+    - damage{a=1200} @PlayersInRadius{r=3.8}
+    - potion{type=WEAKNESS;duration=100;level=1} @PlayersInRadius{r=3.8}
 
 LaserBeam_blood:
-  Cooldown: 10
+  Cooldown: 6
   Skills:
-    - effect:particles{p=END_ROD;amount=50} @Forward{f=10}
-    - delay 20
-    - damage{a=500} @Forward{f=10}  # 5x100
+    - message{m="&b&l» &fCharging the laser!"} @PlayersInRadius{r=15}
+    - sound{s=block.beacon.activate;v=0.8;p=1.2} @self
+    - delay 10
+    - effect:particles{p=END_ROD;amount=30} @Forward{f=2}
+    - damage{a=180} @PlayersInRadius{r=1.5} @Forward{f=2}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=30} @Forward{f=4}
+    - damage{a=180} @PlayersInRadius{r=1.5} @Forward{f=4}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=30} @Forward{f=6}
+    - damage{a=180} @PlayersInRadius{r=1.5} @Forward{f=6}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=30} @Forward{f=8}
+    - damage{a=180} @PlayersInRadius{r=1.5} @Forward{f=8}
+    - delay 1
+    - effect:particles{p=END_ROD;amount=40} @Forward{f=10}
+    - sound{s=block.beacon.power_select;v=1.2;p=1.6} @self
+    - damage{a=180} @PlayersInRadius{r=1.5} @Forward{f=10}
 
-# Mission 2 Skills
 SummonFlamespawns_blood:
-  Cooldown: 30
+  Cooldown: 24
   Skills:
-    - message{m="&cCommander Embersword summons reinforcements!"} @PlayersInRadius{r=20}
-    - summon{mob=angry_flamespawn_blood;amount=2;radius=3} @self
+    - message{m="&4&lBLOOD CALLS! &7Servants arise."} @PlayersInRadius{r=30}
+    - sound{s=block.portal.trigger;v=1.2;p=0.6} @self
+    - effect:particles{p=PORTAL;amount=80;hS=1;vS=1;speed=0.2} @self
+    - summon{mob=angry_flamespawn_blood;amount=4;radius=4} @self
 
-# Mission 3 Boss Skills
 FlameStrike_blood:
   Cooldown: 5
   Skills:
-    - message{m="&cThe Herald prepares to strike!"} @PlayersInRadius{r=20}
-    - effect:particles{p=FLAME;amount=30} @targetlocation
-    - delay 20
-    - damage{a=1000} @PlayersInRadius{r=2} @targetlocation  # 5x200
-    - ignite{ticks=100} @PlayersInRadius{r=2} @targetlocation
+    - message{m="&c&l! &7Flame strike incoming"} @PlayersInRadius{r=20}
+    - sound{s=entity.blaze.shoot;v=1;p=0.7} @self
+    - effect:particles{p=ASH;amount=60;hS=3.2;vS=0.1} @targetlocation
+    - effect:particles{p=FLAME;amount=140;hS=3.0;vS=0.1} @targetlocation
+    - delay 15
+    - damage{a=750} @PlayersInRadius{r=3.2} @targetlocation
+    - ignite{ticks=160} @PlayersInRadius{r=3.2} @targetlocation
+    - knockback{strength=1.2} @PlayersInRadius{r=3.2} @targetlocation
 
 PoweredFlameStrike_blood:
-  Cooldown: 10
+  Cooldown: 9
   Skills:
-    - message{m="&cThe Herald channels dark flames!"} @PlayersInRadius{r=20}
-    - effect:particles{p=FLAME;amount=50} @targetlocation
-    - delay 20
-    - damage{a=3000} @PlayersInRadius{r=2} @targetlocation  # 5x600
-    - ignite{ticks=140} @PlayersInRadius{r=2} @targetlocation
-    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=2} @targetlocation
+    - message{m="&6&l!! &cChanneling a hellish blow!"} @PlayersInRadius{r=25}
+    - sound{s=block.enchantment_table.use;v=1.2;p=0.8} @self
+    - effect:particles{p=SOUL_FIRE_FLAME;amount=160;hS=3.6;vS=0.2} @targetlocation
+    - delay 25
+    - damage{a=950} @PlayersInRadius{r=3.6} @targetlocation
+    - ignite{ticks=160} @PlayersInRadius{r=3.6} @targetlocation
+    - potion{type=SLOW;duration=80;level=2} @PlayersInRadius{r=3.6} @targetlocation
+    - sound{s=entity.blaze.burn;v=1.4;p=1} @targetlocation
 
 MeteorShower_blood:
-  Cooldown: 15
+  Cooldown: 12
   Skills:
-    - message{m="&cMeteors rain from above!"} @PlayersInRadius{r=30}
-    - projectile{onTick=Meteor-Tick-Blood;onHit=Meteor-Hit-Blood;v=8;i=MAGMA_BLOCK;hR=1;vR=1;amount=5} @target
+    - message{m="&4&l☄ &7Calling down a meteor shower!"} @PlayersInRadius{r=30}
+    - sound{s=entity.ghast.shoot;v=1.2;p=0.7} @self
+    - projectile{onHit=Meteor-Hit-Blood;onTick=Meteor-Tick-Blood;v=22;g=1.1;hR=1.2;vR=1.2;amount=10;spread=6;y=3} @targetlocation
 
 Meteor-Tick-Blood:
   Skills:
-    - effect:particles{p=FLAME;amount=10} @origin
+    - effect:particles{p=CAMPFIRE_COSY_SMOKE;amount=6;hS=0.2;vS=0.2;speed=0.01} @origin
 
 Meteor-Hit-Blood:
   Skills:
-    - damage{a=1500} @PlayersInRadius{r=3}  # 5x300
+    - damage{a=1500} @PlayersInRadius{r=3.8}
     - effect:particles{p=EXPLOSION_LARGE;amount=1} @origin
-    - ignite{ticks=100} @PlayersInRadius{r=3}
+    - ignite{ticks=160} @PlayersInRadius{r=3.8}
+    - knockback{strength=1.2} @PlayersInRadius{r=3.8}
+    - sound{s=entity.generic.explode;v=1.5;p=1} @origin
+    - potion{type=SLOW;duration=120;level=2} @PlayersInRadius{r=3.8}
 
 SummonFlamespawnsLarge_blood:
-  Cooldown: 30
+  Cooldown: 26
   Skills:
-    - message{m="&cThe Herald summons its minions!"} @PlayersInRadius{r=30}
-    - summon{mob=angry_flamespawn_blood;amount=5;radius=5} @self
+    - message{m="&4&lThe Blood Herald summons a horde!"} @PlayersInRadius{r=30}
+    - sound{s=block.portal.trigger;v=1.2;p=0.6} @self
+    - effect:particles{p=PORTAL;amount=120;hS=1;vS=1;speed=0.2} @self
+    - summon{mob=angry_flamespawn_blood;amount=6;radius=5} @self

--- a/skills/q8.yml
+++ b/skills/q8.yml
@@ -1,57 +1,230 @@
-# Mission 1 Skills
+# ===== SHARED FX =====
+FX_Ice_Telegraph_S:
+  Skills:
+    - effect:particlering{p=SNOWFLAKE;r=2.5;points=28;amount=1;y=0.15} @origin
+    - effect:particlering{p=BLOCK_CRACK;material=ICE;r=3;points=36;amount=1;y=0.1} @origin
+    - sound{s=block.amethyst_block.chime;v=0.8;p=1.8} @origin
+
+FX_Ice_Telegraph_M:
+  Skills:
+    - effect:particlering{p=SNOWFLAKE;r=3;points=34;amount=1;y=0.15} @origin
+    - effect:particlering{p=BLOCK_CRACK;material=ICE;r=3.6;points=42;amount=1;y=0.1} @origin
+    - sound{s=block.amethyst_block.chime;v=0.9;p=1.75} @origin
+
+FX_Ice_Shard_Burst:
+  Skills:
+    - effect:particles{p=BLOCK_CRACK;material=ICE;amount=60;hS=0.6;vS=0.35;speed=0.01} @origin
+    - sound{s=block.glass.break;v=0.9;p=1.2} @origin
+
+FX_Electric_Field_Telegraph:
+  Skills:
+    - effect:particlering{p=ELECTRIC_SPARK;r=4.5;points=40;amount=1;y=0.1} @origin
+    - effect:particlering{p=END_ROD;r=5;points=40;amount=1;y=0.12} @origin
+    - sound{s=block.beacon.ambient;v=0.6;p=1.2} @origin
+
+FX_TP_Blink:
+  Skills:
+    - effect:particles{p=PORTAL;amount=25;hS=0.5;vS=0.3} @origin
+    - sound{s=entity.enderman.teleport;v=0.9;p=1.6} @origin
+
+FX_Frost_Ripples:
+  Skills:
+    - effect:particlering{p=SNOWFLAKE;r=2.5;points=26;amount=1;y=0.12} @origin
+    - delay 6
+    - effect:particlering{p=SNOWFLAKE;r=3.5;points=32;amount=1;y=0.12} @origin
+    - delay 6
+    - effect:particlering{p=SNOWFLAKE;r=4.5;points=36;amount=1;y=0.12} @origin
+
+FX_Homing_Orbit:
+  Skills:
+    - effect:particles{p=END_ROD;amount=2;hS=0.08;vS=0.08} @origin
+    - effect:particles{p=SNOWFLAKE;amount=2;hS=0.08;vS=0.08} @origin
+
 LightningBolt:
   Cooldown: 10
   Skills:
-    - effect:particles{p=WAX_OFF;amount=20} @target
+    - effect:particlering{p=ELECTRIC_SPARK;r=2.4;points=24;amount=1;y=0.1} @target
+    - sound{s=entity.lightning_bolt.thunder;v=0.7;p=1.4} @target
     - lightning @target
     - damage{a=50} @target
+
+LightningBolt_hell:
+  Cooldown: 10
+  Skills:
+    - effect:particlering{p=ELECTRIC_SPARK;r=2.6;points=26;amount=1;y=0.1} @target
+    - sound{s=entity.lightning_bolt.thunder;v=0.8;p=1.35} @target
+    - lightning @target
+    - damage{a=100} @target
+
+LightningBolt_blood:
+  Cooldown: 10
+  Skills:
+    - effect:particlering{p=ELECTRIC_SPARK;r=2.8;points=28;amount=1;y=0.1} @target
+    - sound{s=entity.lightning_bolt.thunder;v=0.9;p=1.3} @target
+    - lightning @target
+    - damage{a=450} @target
 
 TeleportToPlayer:
   Cooldown: 15
   Skills:
-    - effect:particles{p=PORTAL;amount=20} @self
+    - skill{s=FX_TP_Blink} @self
     - teleport @target
-    - effect:particles{p=PORTAL;amount=20} @self
+    - skill{s=FX_TP_Blink} @self
+    - effect:particlering{p=SNOWFLAKE;r=1.8;points=20;amount=1;y=0.1} @self
+
+TeleportToPlayer_hell:
+  Cooldown: 15
+  Skills:
+    - skill{s=FX_TP_Blink} @self
+    - teleport @target
+    - skill{s=FX_TP_Blink} @self
+    - effect:particlering{p=SNOWFLAKE;r=2;points=22;amount=1;y=0.1} @self
+
+TeleportToPlayer_blood:
+  Cooldown: 15
+  Skills:
+    - skill{s=FX_TP_Blink} @self
+    - teleport @target
+    - skill{s=FX_TP_Blink} @self
+    - effect:particlering{p=SNOWFLAKE;r=2.2;points=24;amount=1;y=0.1} @self
 
 SummonIceHeaps:
   Skills:
     - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Ice_Telegraph_S} @self
     - summon{mob=heap_of_ice_inf;amount=4;radius=3;noise=2} @self ~onDeath
+
+SummonIceHeaps_hell:
+  Skills:
+    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Ice_Telegraph_S} @self
+    - summon{mob=heap_of_ice_hell;amount=4;radius=3;noise=2} @self ~onDeath
+
+SummonIceHeaps_blood:
+  Skills:
+    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Ice_Telegraph_M} @self
+    - summon{mob=heap_of_ice_blood;amount=4;radius=3;noise=2} @self ~onDeath
 
 SummonSmallIceHeaps:
   Skills:
+    - skill{s=FX_Ice_Telegraph_S} @self
     - summon{mob=big_heap_of_ice_inf;amount=2;radius=2;noise=1} @self ~onDeath
+
+SummonSmallIceHeaps_hell:
+  Skills:
+    - skill{s=FX_Ice_Telegraph_S} @self
+    - summon{mob=big_heap_of_ice_hell;amount=2;radius=2;noise=1} @self ~onDeath
+
+SummonSmallIceHeaps_blood:
+  Skills:
+    - skill{s=FX_Ice_Telegraph_M} @self
+    - summon{mob=big_heap_of_ice_blood;amount=2;radius=2;noise=1} @self ~onDeath
 
 SummonDrones:
   Cooldown: 20
   Skills:
     - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
+    - effect:particlering{p=ELECTRIC_SPARK;r=3;points=28;amount=1;y=0.15} @self
+    - sound{s=block.beacon.activate;v=0.9;p=1.2} @self
     - summon{mob=charged_drone_inf;amount=2;radius=3} @self
+
+SummonDrones_hell:
+  Cooldown: 20
+  Skills:
+    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
+    - effect:particlering{p=ELECTRIC_SPARK;r=3.2;points=30;amount=1;y=0.15} @self
+    - sound{s=block.beacon.activate;v=1;p=1.2} @self
+    - summon{mob=charged_drone_hell;amount=2;radius=3} @self
+
+SummonDrones_blood:
+  Cooldown: 20
+  Skills:
+    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
+    - effect:particlering{p=ELECTRIC_SPARK;r=3.4;points=32;amount=1;y=0.15} @self
+    - sound{s=block.beacon.activate;v=1.1;p=1.2} @self
+    - summon{mob=charged_drone_blood;amount=2;radius=3} @self
 
 LightningZone:
   Cooldown: 15
   Skills:
     - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
-    - effect:particles{p=WAX_OFF;amount=50;radius=5} @target
+    - skill{s=FX_Electric_Field_Telegraph} @target
     - delay 40
+    - lightning @target
     - damage{a=100} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
+
+LightningZone_hell:
+  Cooldown: 15
+  Skills:
+    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Electric_Field_Telegraph} @target
+    - delay 40
+    - lightning @target
+    - damage{a=200} @PlayersInRadius{r=5}
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
+
+LightningZone_blood:
+  Cooldown: 15
+  Skills:
+    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Electric_Field_Telegraph} @target
+    - delay 40
+    - lightning @target
+    - damage{a=500} @PlayersInRadius{r=5}
+    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
 
 TeleportStrike:
   Cooldown: 20
   Skills:
-    - effect:particles{p=PORTAL;amount=20} @self
+    - effect:particleline{p=END_ROD;ys=0.1;d=5;points=18} @self
+    - skill{s=FX_TP_Blink} @self
     - teleport @target
     - damage{a=200} @target
     - lightning @target
 
-# Mission 2 Skills
+TeleportStrike_hell:
+  Cooldown: 20
+  Skills:
+    - effect:particleline{p=END_ROD;ys=0.1;d=5;points=18} @self
+    - skill{s=FX_TP_Blink} @self
+    - teleport @target
+    - damage{a=500} @target
+    - lightning @target
+
+TeleportStrike_blood:
+  Cooldown: 20
+  Skills:
+    - effect:particleline{p=END_ROD;ys=0.1;d=5;points=18} @self
+    - skill{s=FX_TP_Blink} @self
+    - teleport @target
+    - damage{a=1000} @target
+    - lightning @target
+
 DashToPlayer:
   Cooldown: 12
   Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
+    - effect:particles{p=CLOUD;amount=18;hS=0.6;vS=0.12} @self
+    - effect:particleline{p=SWEEP_ATTACK;ys=0.05;d=3;points=14} @self
     - teleport @target
     - damage{a=150} @target
+
+DashToPlayer_hell:
+  Cooldown: 12
+  Skills:
+    - effect:particles{p=CLOUD;amount=20;hS=0.6;vS=0.12} @self
+    - effect:particleline{p=SWEEP_ATTACK;ys=0.05;d=3;points=16} @self
+    - teleport @target
+    - damage{a=300} @target
+
+DashToPlayer_blood:
+  Cooldown: 12
+  Skills:
+    - effect:particles{p=CLOUD;amount=22;hS=0.6;vS=0.12} @self
+    - effect:particleline{p=SWEEP_ATTACK;ys=0.05;d=3;points=18} @self
+    - teleport @target
+    - damage{a=750} @target
 
 ThrowStunningStone:
   Cooldown: 15
@@ -60,57 +233,193 @@ ThrowStunningStone:
 
 Stone-Tick:
   Skills:
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=5} @origin
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=6;hS=0.1;vS=0.1} @origin
 
 Stone-Hit:
   Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
     - damage{a=100} @target
     - potion{type=SLOW;duration=60;level=3} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=20} @target
+
+ThrowStunningStone_hell:
+  Cooldown: 15
+  Skills:
+    - projectile{onTick=Stone-Tick-Hell;onHit=Stone-Hit-Hell;v=8;i=CLAY_BALL;hR=1;vR=1} @target
+
+Stone-Tick-Hell:
+  Skills:
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=8;hS=0.1;vS=0.1} @origin
+
+Stone-Hit-Hell:
+  Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
+    - damage{a=200} @target
+    - potion{type=SLOW;duration=80;level=4} @target
+
+ThrowStunningStone_blood:
+  Cooldown: 15
+  Skills:
+    - projectile{onTick=Stone-Tick-Blood;onHit=Stone-Hit-Blood;v=8;i=CLAY_BALL;hR=1;vR=1} @target
+
+Stone-Tick-Blood:
+  Skills:
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=10;hS=0.12;vS=0.12} @origin
+
+Stone-Hit-Blood:
+  Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
+    - damage{a=500} @target
+    - potion{type=SLOW;duration=100;level=5} @target
 
 FrostBolt:
   Cooldown: 8
   Skills:
+    - skill{s=FX_Ice_Telegraph_S} @self
     - projectile{onTick=Frost-Tick;onHit=Frost-Hit;v=10;i=SNOWBALL;hR=1;vR=1} @target
 
 Frost-Tick:
   Skills:
-    - effect:particles{p=SNOWFLAKE;amount=5} @origin
+    - effect:particles{p=SNOWFLAKE;amount=6;hS=0.05;vS=0.05} @origin
+    - effect:particles{p=END_ROD;amount=1;hS=0.02;vS=0.02} @origin
 
 Frost-Hit:
   Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
     - damage{a=200} @target
     - potion{type=SLOW;duration=40;level=1} @target
+
+FrostBolt_hell:
+  Cooldown: 8
+  Skills:
+    - skill{s=FX_Ice_Telegraph_S} @self
+    - projectile{onTick=Frost-Tick-Hell;onHit=Frost-Hit-Hell;v=10;i=SNOWBALL;hR=1;vR=1} @target
+
+Frost-Tick-Hell:
+  Skills:
+    - effect:particles{p=SNOWFLAKE;amount=7;hS=0.05;vS=0.05} @origin
+    - effect:particles{p=END_ROD;amount=1;hS=0.02;vS=0.02} @origin
+
+Frost-Hit-Hell:
+  Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
+    - damage{a=400} @target
+    - potion{type=SLOW;duration=60;level=2} @target
+
+FrostBolt_blood:
+  Cooldown: 8
+  Skills:
+    - skill{s=FX_Ice_Telegraph_M} @self
+    - projectile{onTick=Frost-Tick-Blood;onHit=Frost-Hit-Blood;v=10;i=SNOWBALL;hR=1;vR=1} @target
+
+Frost-Tick-Blood:
+  Skills:
+    - effect:particles{p=SNOWFLAKE;amount=8;hS=0.06;vS=0.06} @origin
+    - effect:particles{p=END_ROD;amount=2;hS=0.02;vS=0.02} @origin
+
+Frost-Hit-Blood:
+  Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
+    - damage{a=1000} @target
+    - potion{type=SLOW;duration=80;level=3} @target
 
 IceStorm:
   Cooldown: 15
   Skills:
-    - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
+    - skill{s=FX_Frost_Ripples} @target
     - delay 40
+    - sound{s=block.snow.break;v=0.8;p=1.6} @target
     - damage{a=150} @PlayersInRadius{r=5}
     - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
+
+IceStorm_hell:
+  Cooldown: 15
+  Skills:
+    - skill{s=FX_Frost_Ripples} @target
+    - delay 40
+    - sound{s=block.snow.break;v=0.9;p=1.55} @target
+    - damage{a=300} @PlayersInRadius{r=5}
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
+
+IceStorm_blood:
+  Cooldown: 15
+  Skills:
+    - skill{s=FX_Frost_Ripples} @target
+    - delay 40
+    - sound{s=block.snow.break;v=1;p=1.5} @target
+    - damage{a=750} @PlayersInRadius{r=5}
+    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
 
 SummonPillagers:
   Cooldown: 30
   Skills:
     - message{m="&bEnforcer calls for backup!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Ice_Telegraph_S} @self
     - summon{mob=pale_pillager_inf;amount=3;radius=3} @self
 
-# Mission 3 Boss Skills
+SummonPillagers_hell:
+  Cooldown: 30
+  Skills:
+    - message{m="&bEnforcer calls for backup!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Ice_Telegraph_S} @self
+    - summon{mob=pale_pillager_hell;amount=3;radius=3} @self
+
+SummonPillagers_blood:
+  Cooldown: 30
+  Skills:
+    - message{m="&bEnforcer calls for backup!"} @PlayersInRadius{r=20}
+    - skill{s=FX_Ice_Telegraph_M} @self
+    - summon{mob=pale_pillager_blood;amount=3;radius=3} @self
+
 TripleIceBolt:
   Cooldown: 10
   Skills:
     - message{m="&bSigrismarr launches frozen projectiles!"} @PlayersInRadius{r=30}
+    - effect:particlering{p=SNOWFLAKE;r=2.4;points=22;amount=1;y=0.1} @self
     - projectile{onTick=Ice-Tick;onHit=Ice-Hit;v=8;i=SNOWBALL;hR=1;vR=1;amount=3} @target
 
 Ice-Tick:
   Skills:
-    - effect:particles{p=SNOWFLAKE;amount=5} @origin
+    - effect:particles{p=SNOWFLAKE;amount=5;hS=0.05;vS=0.05} @origin
+    - effect:particles{p=END_ROD;amount=1;hS=0.02;vS=0.02} @origin
 
 Ice-Hit:
   Skills:
     - damage{a=150} @target
     - potion{type=SLOW;duration=40;level=1} @target
+
+TripleIceBolt_hell:
+  Cooldown: 10
+  Skills:
+    - message{m="&bSigrismarr launches frozen projectiles!"} @PlayersInRadius{r=30}
+    - effect:particlering{p=SNOWFLAKE;r=2.6;points=24;amount=1;y=0.1} @self
+    - projectile{onTick=Ice-Tick-Hell;onHit=Ice-Hit-Hell;v=8;i=SNOWBALL;hR=1;vR=1;amount=3} @target
+
+Ice-Tick-Hell:
+  Skills:
+    - effect:particles{p=SNOWFLAKE;amount=6;hS=0.05;vS=0.05} @origin
+    - effect:particles{p=END_ROD;amount=1;hS=0.02;vS=0.02} @origin
+
+Ice-Hit-Hell:
+  Skills:
+    - damage{a=300} @target
+    - potion{type=SLOW;duration=60;level=2} @target
+
+TripleIceBolt_blood:
+  Cooldown: 10
+  Skills:
+    - message{m="&bSigrismarr launches frozen projectiles!"} @PlayersInRadius{r=30}
+    - effect:particlering{p=SNOWFLAKE;r=2.8;points=26;amount=1;y=0.1} @self
+    - projectile{onTick=Ice-Tick-Blood;onHit=Ice-Hit-Blood;v=8;i=SNOWBALL;hR=1;vR=1;amount=3} @target
+
+Ice-Tick-Blood:
+  Skills:
+    - effect:particles{p=SNOWFLAKE;amount=7;hS=0.06;vS=0.06} @origin
+    - effect:particles{p=END_ROD;amount=2;hS=0.02;vS=0.02} @origin
+
+Ice-Hit-Blood:
+  Skills:
+    - damage{a=750} @target
+    - potion{type=SLOW;duration=80;level=3} @target
 
 HomingIceSphere:
   Cooldown: 15
@@ -120,123 +429,12 @@ HomingIceSphere:
 
 Sphere-Tick:
   Skills:
-    - effect:particles{p=SNOWFLAKE;amount=10} @origin
+    - skill{s=FX_Homing_Orbit} @origin
 
 Sphere-Hit:
   Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
     - damage{a=300} @target
-    - potion{type=SLOW;duration=60;level=2} @target
-
-ImmunityPhase:
-  Conditions:
-    - offgcd
-  Skills:
-    - message{m="&bSigrismarr channels ancient frost magic!"} @PlayersInRadius{r=30}
-    - potion{type=DAMAGE_RESISTANCE;duration=200;level=4} @self
-    - summon{mob=frost_magician_inf;amount=5;radius=5} @self
-    - summon{mob=frost_bringer_inf;amount=5;radius=5} @self
-    - GCD{ticks=1200} # 1 minute cooldown
-
-# Mission 1 Skills - Hell version (2x damage)
-LightningBolt_hell:
-  Cooldown: 10
-  Skills:
-    - effect:particles{p=WAX_OFF;amount=20} @target
-    - lightning @target
-    - damage{a=100} @target  # 2x150
-
-TeleportToPlayer_hell:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=PORTAL;amount=20} @self
-    - teleport @target
-    - effect:particles{p=PORTAL;amount=20} @self
-
-SummonIceHeaps_hell:
-  Skills:
-    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
-    - summon{mob=heap_of_ice_hell;amount=4;radius=3;noise=2} @self ~onDeath
-
-SummonSmallIceHeaps_hell:
-  Skills:
-    - summon{mob=big_heap_of_ice_hell;amount=2;radius=2;noise=1} @self ~onDeath
-
-SummonDrones_hell:
-  Cooldown: 20
-  Skills:
-    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
-    - summon{mob=charged_drone_hell;amount=2;radius=3} @self
-
-LightningZone_hell:
-  Cooldown: 15
-  Skills:
-    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
-    - effect:particles{p=WAX_OFF;amount=50;radius=5} @target
-    - delay 40
-    - damage{a=200} @PlayersInRadius{r=5}  # 2x100
-    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
-
-TeleportStrike_hell:
-  Cooldown: 20
-  Skills:
-    - effect:particles{p=PORTAL;amount=20} @self
-    - teleport @target
-    - damage{a=400} @target  # 2x200
-    - lightning @target
-
-# Mission 2 Skills
-DashToPlayer_hell:
-  Cooldown: 12
-  Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
-    - teleport @target
-    - damage{a=300} @target  # 2x150
-
-ThrowStunningStone_hell:
-  Cooldown: 15
-  Skills:
-    - projectile{onTick=Stone-Tick-Hell;onHit=Stone-Hit-Hell;v=8;i=CLAY_BALL;hR=1;vR=1} @target
-
-Stone-Hit-Hell:
-  Skills:
-    - damage{a=200} @target  # 2x100
-    - potion{type=SLOW;duration=80;level=4} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=20} @target
-
-FrostBolt_hell:
-  Cooldown: 8
-  Skills:
-    - projectile{onTick=Frost-Tick-Hell;onHit=Frost-Hit-Hell;v=10;i=SNOWBALL;hR=1;vR=1} @target
-
-Frost-Hit-Hell:
-  Skills:
-    - damage{a=400} @target  # 2x200
-    - potion{type=SLOW;duration=60;level=2} @target
-
-IceStorm_hell:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
-    - delay 40
-    - damage{a=300} @PlayersInRadius{r=5}  # 2x150
-    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
-
-SummonPillagers_hell:
-  Cooldown: 30
-  Skills:
-    - message{m="&bEnforcer calls for backup!"} @PlayersInRadius{r=20}
-    - summon{mob=pale_pillager_hell;amount=3;radius=3} @self
-
-# Mission 3 Boss Skills
-TripleIceBolt_hell:
-  Cooldown: 10
-  Skills:
-    - message{m="&bSigrismarr launches frozen projectiles!"} @PlayersInRadius{r=30}
-    - projectile{onTick=Ice-Tick-Hell;onHit=Ice-Hit-Hell;v=8;i=SNOWBALL;hR=1;vR=1;amount=3} @target
-
-Ice-Hit-Hell:
-  Skills:
-    - damage{a=300} @target  # 2x150
     - potion{type=SLOW;duration=60;level=2} @target
 
 HomingIceSphere_hell:
@@ -245,118 +443,14 @@ HomingIceSphere_hell:
     - message{m="&bA sphere of pure frost manifests!"} @PlayersInRadius{r=30}
     - projectile{onTick=Sphere-Tick-Hell;onHit=Sphere-Hit-Hell;v=5;i=SNOWBALL;hR=1;vR=1;sF=true} @target
 
+Sphere-Tick-Hell:
+  Skills:
+    - skill{s=FX_Homing_Orbit} @origin
+
 Sphere-Hit-Hell:
   Skills:
-    - damage{a=600} @target  # 2x300
-    - potion{type=SLOW;duration=80;level=3} @target
-
-ImmunityPhase_hell:
-  Conditions:
-    - offgcd
-  Skills:
-    - message{m="&bSigrismarr channels ancient frost magic!"} @PlayersInRadius{r=30}
-    - potion{type=DAMAGE_RESISTANCE;duration=200;level=4} @self
-    - summon{mob=frost_magician_hell;amount=5;radius=5} @self
-    - summon{mob=frost_bringer_hell;amount=5;radius=5} @self
-    - GCD{ticks=1200}
-
-LightningBolt_blood:
-  Cooldown: 10
-  Skills:
-    - effect:particles{p=WAX_OFF;amount=20} @target
-    - lightning @target
-    - damage{a=450} @target
-
-TeleportToPlayer_blood:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=PORTAL;amount=20} @self
-    - teleport @target
-    - effect:particles{p=PORTAL;amount=20} @self
-
-SummonIceHeaps_blood:
-  Skills:
-    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
-    - summon{mob=heap_of_ice_blood;amount=4;radius=3;noise=2} @self ~onDeath
-
-SummonSmallIceHeaps_blood:
-  Skills:
-    - summon{mob=big_heap_of_ice_blood;amount=2;radius=2;noise=1} @self ~onDeath
-
-SummonDrones_blood:
-  Cooldown: 20
-  Skills:
-    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
-    - summon{mob=charged_drone_blood;amount=2;radius=3} @self
-
-LightningZone_blood:
-  Cooldown: 15
-  Skills:
-    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
-    - effect:particles{p=WAX_OFF;amount=50;radius=5} @target
-    - delay 40
-    - damage{a=500} @PlayersInRadius{r=5}
-    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
-
-TeleportStrike_blood:
-  Cooldown: 20
-  Skills:
-    - effect:particles{p=PORTAL;amount=20} @self
-    - teleport @target
-    - damage{a=1000} @target
-    - lightning @target
-
-DashToPlayer_blood:
-  Cooldown: 12
-  Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
-    - teleport @target
-    - damage{a=750} @target
-
-ThrowStunningStone_blood:
-  Cooldown: 15
-  Skills:
-    - projectile{onTick=Stone-Tick-Blood;onHit=Stone-Hit-Blood;v=8;i=CLAY_BALL;hR=1;vR=1} @target
-
-Stone-Hit-Blood:
-  Skills:
-    - damage{a=500} @target
-    - potion{type=SLOW;duration=100;level=5} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=20} @target
-
-FrostBolt_blood:
-  Cooldown: 8
-  Skills:
-    - projectile{onTick=Frost-Tick-Blood;onHit=Frost-Hit-Blood;v=10;i=SNOWBALL;hR=1;vR=1} @target
-
-Frost-Hit-Blood:
-  Skills:
-    - damage{a=1000} @target
-    - potion{type=SLOW;duration=80;level=3} @target
-
-IceStorm_blood:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=SNOWFLAKE;amount=50;radius=5} @target
-    - delay 40
-    - damage{a=750} @PlayersInRadius{r=5}
-    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
-
-SummonPillagers_blood:
-  Cooldown: 30
-  Skills:
-    - message{m="&bEnforcer calls for backup!"} @PlayersInRadius{r=20}
-    - summon{mob=pale_pillager_blood;amount=3;radius=3} @self
-
-TripleIceBolt_blood:
-  Cooldown: 10
-  Skills:
-    - message{m="&bSigrismarr launches frozen projectiles!"} @PlayersInRadius{r=30}
-    - projectile{onTick=Ice-Tick-Blood;onHit=Ice-Hit-Blood;v=8;i=SNOWBALL;hR=1;vR=1;amount=3} @target
-
-Ice-Hit-Blood:
-  Skills:
-    - damage{a=750} @target
+    - skill{s=FX_Ice_Shard_Burst} @origin
+    - damage{a=600} @target
     - potion{type=SLOW;duration=80;level=3} @target
 
 HomingIceSphere_blood:
@@ -365,16 +459,44 @@ HomingIceSphere_blood:
     - message{m="&bA sphere of pure frost manifests!"} @PlayersInRadius{r=30}
     - projectile{onTick=Sphere-Tick-Blood;onHit=Sphere-Hit-Blood;v=5;i=SNOWBALL;hR=1;vR=1;sF=true} @target
 
+Sphere-Tick-Blood:
+  Skills:
+    - skill{s=FX_Homing_Orbit} @origin
+
 Sphere-Hit-Blood:
   Skills:
+    - skill{s=FX_Ice_Shard_Burst} @origin
     - damage{a=1500} @target
     - potion{type=SLOW;duration=100;level=4} @target
+
+ImmunityPhase:
+  Conditions:
+    - offgcd
+  Skills:
+    - message{m="&bSigrismarr channels ancient frost magic!"} @PlayersInRadius{r=30}
+    - skill{s=FX_Ice_Telegraph_M} @self
+    - potion{type=DAMAGE_RESISTANCE;duration=200;level=4} @self
+    - summon{mob=frost_magician_inf;amount=5;radius=5} @self
+    - summon{mob=frost_bringer_inf;amount=5;radius=5} @self
+    - GCD{ticks=1200}
+
+ImmunityPhase_hell:
+  Conditions:
+    - offgcd
+  Skills:
+    - message{m="&bSigrismarr channels ancient frost magic!"} @PlayersInRadius{r=30}
+    - skill{s=FX_Ice_Telegraph_M} @self
+    - potion{type=DAMAGE_RESISTANCE;duration=200;level=4} @self
+    - summon{mob=frost_magician_hell;amount=5;radius=5} @self
+    - summon{mob=frost_bringer_hell;amount=5;radius=5} @self
+    - GCD{ticks=1200}
 
 ImmunityPhase_blood:
   Conditions:
     - offgcd
   Skills:
     - message{m="&bSigrismarr channels ancient frost magic!"} @PlayersInRadius{r=30}
+    - skill{s=FX_Ice_Telegraph_M} @self
     - potion{type=DAMAGE_RESISTANCE;duration=200;level=255} @self
     - summon{mob=frost_magician_blood;amount=5;radius=5} @self
     - summon{mob=frost_bringer_blood;amount=5;radius=5} @self

--- a/skills/q9.yml
+++ b/skills/q9.yml
@@ -1,311 +1,351 @@
-# Mission 1 Skills
+#########################
+# WSPÓŁDZIELONE POD-SKILLE FX
+#########################
+
+FX_Serpent_Telegraph:
+  Skills:
+    - sound{s=entity.elder_guardian.curse;v=1.2;p=0.6} @self
+    - effect:particlering{p=SPELL_WITCH;r=3;points=40;amount=1;y=0.2} @self
+    - effect:particlering{p=BLOCK_CRACK;material=STONE;r=3.4;points=40;amount=1;y=0.1} @self
+
+FX_Poison_Pool_Small:
+  Skills:
+    - effect:particles{p=SLIME;amount=40;hS=0.7;vS=0.05;speed=0.01} @origin
+    - effect:particlering{p=SPELL_MOB;r=2.6;points=36;amount=1;y=0.1} @origin
+    - sound{s=block.brewing_stand.brew;v=0.8;p=1.8} @origin
+    - potion{type=POISON;duration=60;level=1} @PlayersInRadius{r=2.6}
+
+FX_Poison_Pool_Medium:
+  Skills:
+    - effect:particles{p=SLIME;amount=70;hS=1;vS=0.07;speed=0.01} @origin
+    - effect:particlering{p=SPELL_MOB;r=3.2;points=42;amount=1;y=0.1} @origin
+    - sound{s=block.brewing_stand.brew;v=1;p=1.8} @origin
+    - potion{type=POISON;duration=90;level=2} @PlayersInRadius{r=3.2}
+
+FX_Poison_Pool_Large:
+  Skills:
+    - effect:particles{p=SLIME;amount=120;hS=1.3;vS=0.1;speed=0.01} @origin
+    - effect:particlering{p=SPELL_MOB;r=3.8;points=50;amount=1;y=0.1} @origin
+    - sound{s=block.brewing_stand.brew;v=1.1;p=1.8} @origin
+    - potion{type=POISON;duration=120;level=3} @PlayersInRadius{r=3.8}
+
+FX_Ground_Ripples:
+  Skills:
+    - effect:particlering{p=BLOCK_CRACK;material=STONE;r=2.5;points=30;amount=1;y=0.1} @self
+    - delay 6
+    - effect:particlering{p=BLOCK_CRACK;material=STONE;r=3.5;points=40;amount=1;y=0.08} @self
+    - delay 6
+    - effect:particlering{p=BLOCK_CRACK;material=STONE;r=4.5;points=50;amount=1;y=0.06} @self
+
+FX_Shard_Burst:
+  Skills:
+    - sound{s=block.stone.break;v=1.2;p=0.8} @origin
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=60;hS=0.6;vS=0.3;speed=0.01} @origin
+
+#########################
+# ULEPSZONE WERSJE ISTNIEJĄCYCH SKILLI
+#########################
+
+# === HEALING PULSE (ładniejszy telegraph + puls serc) ===
 HealingPulse:
-  Cooldown: 5
+  Cooldown: 6
   Skills:
+    - effect:particlering{p=HEART;r=2.8;points=28;amount=1;y=0.2} @self
+    - sound{s=entity.evoker.prepare_summon;v=0.8;p=1.5} @self
+    - delay 8
     - heal{a=100} @self
-    - effect:particles{p=HEART;amount=10} @self
+    - effect:particles{p=HEART;amount=16;hS=0.5;vS=0.3} @self
 
+HealingPulse_hell:
+  Cooldown: 6
+  Skills:
+    - effect:particlering{p=HEART;r=3.2;points=32;amount=1;y=0.2} @self
+    - sound{s=entity.evoker.prepare_summon;v=0.9;p=1.5} @self
+    - delay 8
+    - heal{a=200} @self
+    - effect:particles{p=HEART;amount=22;hS=0.6;vS=0.35} @self
+
+HealingPulse_blood:
+  Cooldown: 6
+  Skills:
+    - effect:particlering{p=HEART;r=3.6;points=36;amount=1;y=0.2} @self
+    - sound{s=entity.evoker.prepare_summon;v=1;p=1.5} @self
+    - delay 8
+    - heal{a=300} @self
+    - effect:particles{p=HEART;amount=28;hS=0.7;vS=0.4} @self
+
+# === THROW BOULDER (dodatkowe FX, kruszenie przy trafieniu) ===
 ThrowBoulder:
-  Cooldown: 10
+  Cooldown: 9
   Skills:
-    - projectile{onTick=Boulder-Tick;onHit=Boulder-Hit;v=8;i=CLAY_BALL;hR=1;vR=1} @target
+    - sound{s=block.stone.place;v=1;p=0.6} @self
+    - projectile{onTick=Boulder-Tick-VFX;onHit=Boulder-Hit-VFX;v=9;i=CLAY_BALL;hR=1;vR=1} @target
 
-Boulder-Tick:
+ThrowBoulder_hell:
+  Cooldown: 9
   Skills:
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=5} @origin
+    - sound{s=block.stone.place;v=1;p=0.6} @self
+    - projectile{onTick=Boulder-Tick-VFX;onHit=Boulder-Hit-VFX;v=9;i=CLAY_BALL;hR=1;vR=1} @target
 
-Boulder-Hit:
+ThrowBoulder_blood:
+  Cooldown: 8
   Skills:
-    - damage{a=200} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=20} @target
+    - sound{s=block.stone.place;v=1;p=0.6} @self
+    - projectile{onTick=Boulder-Tick-VFX;onHit=Boulder-Hit-VFX;v=10;i=CLAY_BALL;hR=1;vR=1} @target
 
-ChargeAttack:
-  Cooldown: 12
+Boulder-Tick-VFX:
   Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
-    - jump{velocity=2;height=0.5;heim=0} @target
-    - damage{a=200} @target
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=10;hS=0.25;vS=0.1;speed=0.02} @origin
+    - effect:particles{p=CLOUD;amount=1;hS=0;vS=0;speed=0.02} @origin
 
+Boulder-Hit-VFX:
+  Skills:
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @origin
+    - skill{s=FX_Shard_Burst} @origin
+    - damage{a=150} @PlayersInRadius{r=2.8}
+    - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=2.8}
+    - sound{s=entity.generic.explode;v=0.9;p=0.8} @origin
+
+# === GROUND SLAM (telegraphed 3-fala) ===
 GroundSlam:
-  Cooldown: 15
+  Cooldown: 14
   Skills:
-    - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
-    - delay 40
-    - damage{a=150} @PlayersInRadius{r=5}
-    - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=5}
+    - sound{s=entity.iron_golem.attack;v=1.2;p=0.7} @self
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - skill{s=FX_Ground_Ripples} @self
+    - delay 20
+    - damage{a=150} @PlayersInRadius{r=4.5}
+    - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=4.5}
 
-# Mission 2 Skills
+GroundSlam_hell:
+  Cooldown: 14
+  Skills:
+    - sound{s=entity.iron_golem.attack;v=1.2;p=0.7} @self
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - skill{s=FX_Ground_Ripples} @self
+    - delay 20
+    - damage{a=200} @PlayersInRadius{r=5}
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
+
+GroundSlam_blood:
+  Cooldown: 14
+  Skills:
+    - sound{s=entity.iron_golem.attack;v=1.2;p=0.7} @self
+    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - skill{s=FX_Ground_Ripples} @self
+    - delay 20
+    - damage{a=300} @PlayersInRadius{r=5.5}
+    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5.5}
+
+# === STUNNING BLOW (bardziej czytelny efekt) ===
 StunningBlow:
-  Cooldown: 12
+  Cooldown: 11
   Skills:
+    - effect:particles{p=CRIT;amount=20;hS=0.5;vS=0.5} @target
+    - sound{s=entity.player.attack.crit;v=0.9;p=1.2} @target
     - damage{a=150} @target
-    - potion{type=SLOW;duration=40;level=5} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - stun{d=40} @target
 
+StunningBlow_hell:
+  Cooldown: 11
+  Skills:
+    - effect:particles{p=CRIT;amount=26;hS=0.5;vS=0.5} @target
+    - sound{s=entity.player.attack.crit;v=1;p=1.2} @target
+    - damage{a=300} @target
+    - stun{d=50} @target
+
+StunningBlow_blood:
+  Cooldown: 11
+  Skills:
+    - effect:particles{p=CRIT;amount=32;hS=0.5;vS=0.5} @target
+    - sound{s=entity.player.attack.crit;v=1.1;p=1.2} @target
+    - damage{a=450} @target
+    - stun{d=60} @target
+
+# === POISON BOLT / ACID SPIT (telegraphed, tworzy kałużę jadu) ===
 PoisonBolt:
   Cooldown: 8
   Skills:
-    - projectile{onTick=Poison-Tick;onHit=Poison-Hit;v=10;i=ARROW;hR=1;vR=1} @target
-
-Poison-Tick:
-  Skills:
-    - effect:particles{p=SPELL_MOB;amount=5} @origin
-
-Poison-Hit:
-  Skills:
-    - damage{a=100} @target
-    - potion{type=POISON;duration=100;level=2} @target
-
-Petrify:
-  Cooldown: 15
-  Skills:
-    - potion{type=SLOW;duration=40;level=10} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=30} @target
-
-GroundPound:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
-    - delay 40
-    - damage{a=100} @PlayersInRadius{r=5}
-    - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=5}
-
-PowerfulStrike:
-  Cooldown: 10
-  Skills:
-    - damage{a=300} @target
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @target
-
-# Mission 3 Boss Skills
-PetrifyingGaze:
-  Cooldown: 15
-  Skills:
-    - message{m="&cMedusa's gaze turns you to stone!"} @PlayersInRadius{r=10}
-    - potion{type=SLOW;duration=60;level=10} @PlayersInRadius{r=10}
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=50} @PlayersInRadius{r=10}
-
-AcidSpit:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Acid-Tick;onHit=Acid-Hit;v=8;i=DRAGON_BREATH;hR=1;vR=1} @target
-
-Acid-Tick:
-  Skills:
-    - effect:particles{p=SPELL_WITCH;amount=5} @origin
-
-Acid-Hit:
-  Skills:
-    - damage{a=200} @target
-    - potion{type=POISON;duration=60;level=2} @target
-
-SummonSnakes:
-  Cooldown: 20
-  Skills:
-    - message{m="&cMedusa summons her serpentine minions!"} @PlayersInRadius{r=20}
-    - summon{mob=snake_minion_inf;amount=4;radius=3} @self
-
-SnakeExplosion:
-  Skills:
-    - damage{a=150} @PlayersInRadius{r=3}
-    - potion{type=SLOW;duration=40;level=2} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
-
-# Mission 1 Skills
-HealingPulse_hell:
-  Cooldown: 5
-  Skills:
-    - heal{a=200} @self  # 2x healing
-    - effect:particles{p=HEART;amount=10} @self
-
-ThrowBoulder_hell:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Boulder-Tick-Hell;onHit=Boulder-Hit-Hell;v=8;i=CLAY_BALL;hR=1;vR=1} @target
-
-Boulder-Hit-Hell:
-  Skills:
-    - damage{a=400} @target  # 2x200
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=20} @target
-
-ChargeAttack_hell:
-  Cooldown: 12
-  Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
-    - jump{velocity=2;height=0.5;heim=0} @target
-    - damage{a=400} @target
-
-GroundSlam_hell:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
-    - delay 40
-    - damage{a=300} @PlayersInRadius{r=5}  # 2x150
-    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=5}
-
-# Mission 2 Skills
-StunningBlow_hell:
-  Cooldown: 12
-  Skills:
-    - damage{a=300} @target  # 2x150
-    - potion{type=SLOW;duration=60;level=6} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particlering{p=SPELL_MOB;r=1.6;points=20;amount=1;y=0.1} @self
+    - projectile{onTick=Poison-Tick-VFX;onHit=Poison-Hit-Pool-S;v=10;i=ARROW;hR=1;vR=1} @target
 
 PoisonBolt_hell:
   Cooldown: 8
   Skills:
-    - projectile{onTick=Poison-Tick-Hell;onHit=Poison-Hit-Hell;v=10;i=ARROW;hR=1;vR=1} @target
-
-Poison-Hit-Hell:
-  Skills:
-    - damage{a=200} @target  # 2x100
-    - potion{type=POISON;duration=120;level=3} @target
-
-Petrify_hell:
-  Cooldown: 15
-  Skills:
-    - potion{type=SLOW;duration=60;level=10} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=30} @target
-
-GroundPound_hell:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
-    - delay 40
-    - damage{a=200} @PlayersInRadius{r=5}  # 2x100
-    - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=5}
-
-PowerfulStrike_hell:
-  Cooldown: 10
-  Skills:
-    - damage{a=600} @target  # 2x300
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @target
-
-# Mission 3 Boss Skills
-PetrifyingGaze_hell:
-  Cooldown: 15
-  Skills:
-    - message{m="&cMedusa's gaze turns you to stone!"} @PlayersInRadius{r=10}
-    - potion{type=SLOW;duration=80;level=10} @PlayersInRadius{r=10}
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=50} @PlayersInRadius{r=10}
-
-AcidSpit_hell:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Acid-Tick-Hell;onHit=Acid-Hit-Hell;v=8;i=DRAGON_BREATH;hR=1;vR=1} @target
-
-Acid-Hit-Hell:
-  Skills:
-    - damage{a=400} @target  # 2x200
-    - potion{type=POISON;duration=80;level=3} @target
-
-SummonSnakes_hell:
-  Cooldown: 20
-  Skills:
-    - message{m="&cMedusa summons her serpentine minions!"} @PlayersInRadius{r=20}
-    - summon{mob=snake_minion_hell;amount=4;radius=3} @self
-
-SnakeExplosion_hell:
-  Skills:
-    - damage{a=300} @PlayersInRadius{r=3}  # 2x150
-    - potion{type=SLOW;duration=60;level=3} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
-
-# Mission 1 Skills - Blood Version (5x damage)
-HealingPulse_blood:
-  Cooldown: 5
-  Skills:
-    - heal{a=500} @self  # 5x healing
-    - effect:particles{p=HEART;amount=10} @self
-
-ThrowBoulder_blood:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Boulder-Tick-Blood;onHit=Boulder-Hit-Blood;v=8;i=CLAY_BALL;hR=1;vR=1} @target
-
-Boulder-Hit-Blood:
-  Skills:
-    - damage{a=1000} @target  # 5x200
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=20} @target
-
-ChargeAttack_blood:
-  Cooldown: 12
-  Skills:
-    - effect:particles{p=CLOUD;amount=20} @self
-    - jump{velocity=2;height=0.5;heim=0} @target
-    - damage{a=1000} @target
-
-GroundSlam_blood:
-  Cooldown: 15
-  Skills:
-    - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
-    - delay 40
-    - damage{a=750} @PlayersInRadius{r=5}  # 5x150
-    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=5}
-
-# Mission 2 Skills
-StunningBlow_blood:
-  Cooldown: 12
-  Skills:
-    - damage{a=750} @target  # 5x150
-    - potion{type=SLOW;duration=80;level=7} @target
-    - effect:particles{p=CRIT;amount=20} @target
+    - effect:particlering{p=SPELL_MOB;r=1.8;points=22;amount=1;y=0.1} @self
+    - projectile{onTick=Poison-Tick-VFX;onHit=Poison-Hit-Pool-M;v=10;i=ARROW;hR=1;vR=1} @target
 
 PoisonBolt_blood:
   Cooldown: 8
   Skills:
-    - projectile{onTick=Poison-Tick-Blood;onHit=Poison-Hit-Blood;v=10;i=ARROW;hR=1;vR=1} @target
+    - effect:particlering{p=SPELL_MOB;r=2;points=24;amount=1;y=0.1} @self
+    - projectile{onTick=Poison-Tick-VFX;onHit=Poison-Hit-Pool-L;v=11;i=ARROW;hR=1;vR=1} @target
 
-Poison-Hit-Blood:
+Poison-Tick-VFX:
   Skills:
-    - damage{a=500} @target  # 5x100
-    - potion{type=POISON;duration=140;level=4} @target
+    - effect:particles{p=SPELL_WITCH;amount=3;hS=0.05;vS=0.05} @origin
+    - effect:particles{p=SLIME;amount=1;hS=0.03;vS=0.03} @origin
+
+Poison-Hit-Pool-S:
+  Skills:
+    - damage{a=100} @target
+    - sound{s=entity.sniffer.hurt;v=0.7;p=1.6} @origin
+    - skill{s=FX_Poison_Pool_Small} @origin
+
+Poison-Hit-Pool-M:
+  Skills:
+    - damage{a=200} @target
+    - sound{s=entity.sniffer.hurt;v=0.8;p=1.6} @origin
+    - skill{s=FX_Poison_Pool_Medium} @origin
+
+Poison-Hit-Pool-L:
+  Skills:
+    - damage{a=300} @target
+    - sound{s=entity.sniffer.hurt;v=0.9;p=1.6} @origin
+    - skill{s=FX_Poison_Pool_Large} @origin
+
+# === PETRIFYING GAZE (czytelny stożek + narastanie do skamienienia) ===
+PetrifyingGaze:
+  Cooldown: 16
+  Skills:
+    - skill{s=FX_Serpent_Telegraph}
+    - effect:cone{p=BLOCK_CRACK;material=STONE;angle=35;range=10;points=50;amount=1} @self
+    - sound{s=entity.warden.sonic_boom;v=0.5;p=1.8} @self
+    - potion{type=SLOW;duration=40;level=6} @PlayersInCone{angle=35;range=10}
+    - delay 10
+    - stun{d=30} @PlayersInCone{angle=35;range=10}
+
+Petrify_hell:
+  Cooldown: 15
+  Skills:
+    - skill{s=FX_Serpent_Telegraph}
+    - effect:cone{p=BLOCK_CRACK;material=STONE;angle=40;range=11;points=60;amount=1} @self
+    - sound{s=entity.warden.sonic_boom;v=0.6;p=1.8} @self
+    - potion{type=SLOW;duration=60;level=8} @PlayersInCone{angle=40;range=11}
+    - delay 12
+    - stun{d=40} @PlayersInCone{angle=40;range=11}
 
 Petrify_blood:
-  Cooldown: 15
+  Cooldown: 14
   Skills:
-    - potion{type=SLOW;duration=80;level=10} @target
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=30} @target
+    - skill{s=FX_Serpent_Telegraph}
+    - effect:cone{p=BLOCK_CRACK;material=STONE;angle=45;range=12;points=70;amount=1} @self
+    - sound{s=entity.warden.sonic_boom;v=0.7;p=1.8} @self
+    - potion{type=SLOW;duration=80;level=10} @PlayersInCone{angle=45;range=12}
+    - delay 14
+    - stun{d=60} @PlayersInCone{angle=45;range=12}
 
-GroundPound_blood:
-  Cooldown: 15
+# === SUMMON SNAKES (spirala + efekty) ===
+SummonSnakes:
+  Cooldown: 20
   Skills:
-    - effect:particles{p=EXPLOSION_LARGE;amount=10;radius=5} @self
-    - delay 40
-    - damage{a=500} @PlayersInRadius{r=5}  # 5x100
-    - potion{type=SLOW;duration=80;level=4} @PlayersInRadius{r=5}
+    - message{m="&a&lSssss... &7Węże pełzną spod ziemi!"} @PlayersInRadius{r=20}
+    - sound{s=entity.witch.celebrate;v=0.8;p=1.6} @self
+    - effect:spiral{p=SLIME;radius=3.5;turns=3;height=2;points=80} @self
+    - summon{mob=poisonous_snake_inf;amount=3;radius=3} @self
 
-PowerfulStrike_blood:
-  Cooldown: 10
+SummonSnakes_hell:
+  Cooldown: 20
   Skills:
-    - damage{a=1500} @target  # 5x300
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @target
-
-# Mission 3 Boss Skills
-PetrifyingGaze_blood:
-  Cooldown: 15
-  Skills:
-    - message{m="&cMedusa's gaze turns you to stone!"} @PlayersInRadius{r=10}
-    - potion{type=SLOW;duration=100;level=10} @PlayersInRadius{r=10}
-    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=50} @PlayersInRadius{r=10}
-
-AcidSpit_blood:
-  Cooldown: 10
-  Skills:
-    - projectile{onTick=Acid-Tick-Blood;onHit=Acid-Hit-Blood;v=8;i=DRAGON_BREATH;hR=1;vR=1} @target
-
-Acid-Hit-Blood:
-  Skills:
-    - damage{a=1000} @target  # 5x200
-    - potion{type=POISON;duration=100;level=4} @target
+    - message{m="&a&lSssss... &7Gniazdo jadu budzi się!"} @PlayersInRadius{r=20}
+    - sound{s=entity.witch.celebrate;v=0.9;p=1.6} @self
+    - effect:spiral{p=SLIME;radius=4;turns=3;height=2;points=90} @self
+    - summon{mob=poisonous_snake_hell;amount=4;radius=3} @self
 
 SummonSnakes_blood:
   Cooldown: 20
   Skills:
-    - message{m="&cMedusa summons her serpentine minions!"} @PlayersInRadius{r=20}
-    - summon{mob=snake_minion_blood;amount=4;radius=3} @self
+    - message{m="&a&lSssss... &7Legowisko węży otwiera się!"} @PlayersInRadius{r=20}
+    - sound{s=entity.witch.celebrate;v=1;p=1.6} @self
+    - effect:spiral{p=SLIME;radius=4.5;turns=3;height=2;points=100} @self
+    - summon{mob=poisonous_snake_blood;amount=5;radius=3} @self
+
+# === SNAKE EXPLOSION (czytelny radius + wspólne FX) ===
+SnakeExplosion:
+  Skills:
+    - effect:particlering{p=SLIME;r=3;points=40;amount=1;y=0.1} @self
+    - sound{s=entity.generic.explode;v=0.7;p=1.4} @self
+    - damage{a=150} @PlayersInRadius{r=3}
+    - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=3}
+
+SnakeExplosion_hell:
+  Skills:
+    - effect:particlering{p=SLIME;r=3.2;points=44;amount=1;y=0.1} @self
+    - sound{s=entity.generic.explode;v=0.8;p=1.4} @self
+    - damage{a=300} @PlayersInRadius{r=3.2}
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=3.2}
 
 SnakeExplosion_blood:
   Skills:
-    - damage{a=750} @PlayersInRadius{r=3}  # 5x150
-    - potion{type=SLOW;duration=80;level=4} @PlayersInRadius{r=3}
-    - effect:particles{p=EXPLOSION_LARGE;amount=1} @self
+    - effect:particlering{p=SLIME;r=3.5;points=48;amount=1;y=0.1} @self
+    - sound{s=entity.generic.explode;v=0.9;p=1.4} @self
+    - damage{a=450} @PlayersInRadius{r=3.5}
+    - potion{type=SLOW;duration=100;level=4} @PlayersInRadius{r=3.5}
+
+# === CHARGE ATTACK (szarża ze smugą) ===
+ChargeAttack:
+  Cooldown: 11
+  Skills:
+    - sound{s=entity.goat.screaming.ambient;v=0.9;p=1.5} @self
+    - effect:particles{p=CLOUD;amount=20;hS=0.6;vS=0.1} @self
+    - leap{velocity=2;height=0.5} @target
+    - effect:particleline{p=SWEEP_ATTACK;ys=0.1;d=3;points=15} @self
+    - damage{a=200} @target
+
+ChargeAttack_hell:
+  Cooldown: 11
+  Skills:
+    - sound{s=entity.goat.screaming.ambient;v=1;p=1.5} @self
+    - effect:particles{p=CLOUD;amount=24;hS=0.6;vS=0.1} @self
+    - leap{velocity=2.2;height=0.5} @target
+    - effect:particleline{p=SWEEP_ATTACK;ys=0.1;d=3.2;points=16} @self
+    - damage{a=400} @target
+
+ChargeAttack_blood:
+  Cooldown: 10
+  Skills:
+    - sound{s=entity.goat.screaming.ambient;v=1.1;p=1.5} @self
+    - effect:particles{p=CLOUD;amount=28;hS=0.6;vS=0.1} @self
+    - leap{velocity=2.4;height=0.5} @target
+    - effect:particleline{p=SWEEP_ATTACK;ys=0.1;d=3.4;points=17} @self
+    - damage{a=600} @target
+
+# === OPCJONALNE DODATKI ===
+SatyrWarCry:
+  Skills:
+    - sound{s=entity.goat.screaming.angry;v=1;p=0.9} @self
+    - effect:particlering{p=VILLAGER_ANGRY;r=2;points=20;amount=1;y=0.2} @self
+    - potion{type=INCREASE_DAMAGE;duration=100;level=1} @self
+
+SatyrWarCry_hell:
+  Skills:
+    - sound{s=entity.goat.screaming.angry;v=1.1;p=0.9} @self
+    - effect:particlering{p=VILLAGER_ANGRY;r=2.3;points=22;amount=1;y=0.2} @self
+    - potion{type=INCREASE_DAMAGE;duration=120;level=2} @self
+
+SatyrWarCry_blood:
+  Skills:
+    - sound{s=entity.goat.screaming.angry;v=1.2;p=0.9} @self
+    - effect:particlering{p=VILLAGER_ANGRY;r=2.6;points=24;amount=1;y=0.2} @self
+    - potion{type=INCREASE_DAMAGE;duration=140;level=3} @self
+
+StoneShatter:
+  Skills:
+    - sound{s=block.stone.break;v=1.2;p=0.8} @self
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=40;hS=0.6;vS=0.2;speed=0.05} @self
+    - damage{a=150} @PlayersInRadius{r=3}
+    - potion{type=SLOW;duration=40;level=1} @PlayersInRadius{r=3}
+
+StoneShatter_hell:
+  Skills:
+    - sound{s=block.stone.break;v=1.3;p=0.8} @self
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=60;hS=0.7;vS=0.25;speed=0.05} @self
+    - damage{a=300} @PlayersInRadius{r=3.2}
+    - potion{type=SLOW;duration=60;level=2} @PlayersInRadius{r=3.2}
+
+StoneShatter_blood:
+  Skills:
+    - sound{s=block.stone.break;v=1.4;p=0.8} @self
+    - effect:particles{p=BLOCK_CRACK;material=STONE;amount=80;hS=0.8;vS=0.3;speed=0.05} @self
+    - damage{a=450} @PlayersInRadius{r=3.5}
+    - potion{type=SLOW;duration=80;level=3} @PlayersInRadius{r=3.5}


### PR DESCRIPTION
## Summary
- Replace remaining Polish strings in Q6/Q7 skill packs with English telegraphs and warnings
- Rewire Q6 mobs across all difficulties to call DeathDash, WitheringShot and other restored abilities
- Regenerate skill documentation for the updated Q6 roster

## Testing
- `yamllint skills/q6.yml skills/q7.yml mobs/q6_inf.yml mobs/q6_hell.yml mobs/q6_blood.yml` *(errors: line-length & indentation)*
- `python3 generate_stats.py` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_689d9b085500832a9a97b2fbe11400da