### PR TITLE
Fix invalid projectile and targeter configs

### DIFF
--- a/skills/70-80.yml
+++ b/skills/70-80.yml
@@ -58,7 +58,7 @@ ShadeCrawler_Ambush:
     - effect:particles{p=smoke;amount=30;hS=0.6;vS=0.4} @self
     - sound{s=entity.enderman.teleport;v=0.8;p=1.2} @self
     - delay 8
-    - teleport{spreadh=1;spreadv=0.1} @BackstabTarget
+    - teleport{spreadh=1;spreadv=0.1} @target
     - potion{type=GLOWING;duration=30;level=1} @self
 
 ShadowGazer_Glare:

--- a/skills/91-100.yml
+++ b/skills/91-100.yml
@@ -43,7 +43,7 @@ ColdSkeletonArcher_Volley:
   Skills:
     - message{m="&bVolley! &7Take cover!"} @PIR{r=20}
     - delay 20
-    - projectile{type=ARROW;amount=6;spread=10;v=3;g=0.05} @target
+    - projectile{i=ARROW;amount=6;spread=10;v=3;g=0.05} @target
 
 DeathKnight_Taunt:
   Cooldown: 18


### PR DESCRIPTION
## Summary
- use item parameter for ColdSkeletonArcher arrow volley
- replace custom BackstabTarget with standard targeter

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable, comments: disable, document-start: disable}}' skills/91-100.yml skills/70-80.yml`


------
https://chatgpt.com/codex/tasks/task_e_689dd47cc200832a9e1bbc8e044dcb8e