### PR TITLE
Remove messages from normal mob skills

### DIFF
--- a/skills/70-80.yml
+++ b/skills/70-80.yml
@@ -67,7 +67,6 @@ ShadowGazer_Glare:
     - lineofsight{}
     - targetwithin{d=18}
   Skills:
-    - message{m="&8&lShadow Gazer&r fixes its stare on you..."} @target
     - effect:particles{p=witch;amount=25;hS=0.4;vS=0.2} @target
     - delay 16
     - potion{type=SLOW;duration=40;level=1} @target ?targetwithin{d=3}

--- a/skills/81-90.yml
+++ b/skills/81-90.yml
@@ -10,7 +10,6 @@ RootGrasp:
 SpawnLeechbeasts:
   Cooldown: 16
   Skills:
-    - message{m="&5<caster.name>&r splits into Leechbeasts!"} @PIR{r=30}
     - effect:particles{particle=slime;amount=60;speed=0.15;hS=1;vS=0.6} @self
     - sound{s=entity.slime.jump;v=1.1;p=0.8} @self
     - delay 30

--- a/skills/q2.yml
+++ b/skills/q2.yml
@@ -117,7 +117,6 @@ Q2-CatapultHit-500:
 VineChase_inf:
   Cooldown: 12
   Skills:
-    - message{m="&2Roots creep along the ground!"} @PlayersInRadius{r=40}
     - effect:particles{p=HAPPY_VILLAGER;amount=10;hS=0.6;vS=0.02} @target
     - delay 12
     - projectile{onTick=Catapult-Tick;onHit=Q2-CatapultHit-100;v=20;g=0.05;hs=false;i=3;hnp=true;oh=TRUE;ot=TRUE;hR=1.2;vR=1.2} @PlayersInRadius{r=25;limit=1;sort=NEAREST}
@@ -126,7 +125,6 @@ VineChase_inf:
 VineChase_hell:
   Cooldown: 12
   Skills:
-    - message{m="&2Vines surge forward!"} @PlayersInRadius{r=40}
     - delay 10
     - projectile{onTick=Catapult-Tick;onHit=Q2-CatapultHit-200;v=22;g=0.05;hs=false;i=2;hnp=true;oh=TRUE;ot=TRUE;hR=1.2;vR=1.2} @PlayersInRadius{r=26;limit=1;sort=NEAREST}
     - GCD{ticks=50}
@@ -134,7 +132,6 @@ VineChase_hell:
 VineChase_blood:
   Cooldown: 12
   Skills:
-    - message{m="&2The ground cracks with thorny roots!"} @PlayersInRadius{r=40}
     - delay 10
     - projectile{onTick=Catapult-Tick;onHit=Q2-CatapultHit-500;v=24;g=0.05;hs=false;i=2;hnp=true;oh=TRUE;ot=TRUE;hR=1.25;vR=1.25} @PlayersInRadius{r=28;limit=1;sort=NEAREST}
     - GCD{ticks=50}
@@ -181,7 +178,6 @@ Q2-PoisonHit-Inf:
 FallingPoisonSphere_inf:
   Cooldown: 16
   Skills:
-    - message{m="&aToxic orb forming above you!"} @target
     - effect:particles{p=SPELL_MOB;amount=20;hS=0.4;vS=0.1;color=#00ff00} @targetlocation
     - delay 18
     - damage{a=<caster.mhp>*0.1} @PlayersInRadius{r=5} @targetlocation
@@ -226,7 +222,6 @@ Q2-PoisonHit-Hell:
 FallingPoisonSphere_hell:
   Cooldown: 16
   Skills:
-    - message{m="&aToxic orb forming!"} @PlayersInRadius{r=40}
     - effect:particles{p=SOUL;amount=20;hS=0.4;vS=0.1} @targetlocation
     - delay 16
     - damage{a=<caster.mhp>*0.1} @PlayersInRadius{r=5} @targetlocation
@@ -271,7 +266,6 @@ Q2-PoisonHit-Blood:
 FallingPoisonSphere_blood:
   Cooldown: 18
   Skills:
-    - message{m="&aToxic orb overhead! Move!"} @target
     - effect:particles{p=ASH;amount=26;hS=0.5;vS=0.12} @targetlocation
     - delay 18
     - damage{a=<caster.mhp>*0.1} @PlayersInRadius{r=5} @targetlocation

--- a/skills/q4.yml
+++ b/skills/q4.yml
@@ -6,7 +6,6 @@
 SummonHounds_inf:
   Cooldown: 28
   Skills:
-    - message{m="&cThe hunter whistles — hounds incoming!"} @PlayersInRadius{r=28}
     - summon{mob=raging_hunting_hound_inf;amount=2;radius=3;noise=2} @self
 
 SummonHoundPack_inf:
@@ -61,7 +60,6 @@ BearachRotation_inf:
 LightningStrike_inf:
   Cooldown: 9
   Skills:
-    - message{m="&b⚡ Lightning marks the ground!"} @PlayersInRadius{r=24}
     - effect:particles{p=crit;amount=120;radius=3} @target
     - delay 20
     - damage{a=150} @PlayersInRadius{r=3}
@@ -77,7 +75,6 @@ SummonLightningWolves_inf:
 BeeSwarm_inf:
   Cooldown: 16
   Skills:
-    - message{m="&eBees swarm a target!"} @NearestPlayer{r=24}
     - projectile{onTick=BeeSwarm-Tick;onHit=BeeSwarm-Hit;v=8;i=BEE_SPAWN_EGG;hR=1;vR=1;amount=5;spread=18} @NearestPlayer{r=24}
 
 BeeSwarm-Tick:

--- a/skills/q8.yml
+++ b/skills/q8.yml
@@ -90,19 +90,16 @@ TeleportToPlayer_blood:
 
 SummonIceHeaps:
   Skills:
-    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
     - skill{s=FX_Ice_Telegraph_S} @self
     - summon{mob=heap_of_ice_inf;amount=4;radius=3;noise=2} @self ~onDeath
 
 SummonIceHeaps_hell:
   Skills:
-    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
     - skill{s=FX_Ice_Telegraph_S} @self
     - summon{mob=heap_of_ice_hell;amount=4;radius=3;noise=2} @self ~onDeath
 
 SummonIceHeaps_blood:
   Skills:
-    - message{m="&bThe ice shatters into smaller pieces!"} @PlayersInRadius{r=20}
     - skill{s=FX_Ice_Telegraph_M} @self
     - summon{mob=heap_of_ice_blood;amount=4;radius=3;noise=2} @self ~onDeath
 
@@ -148,7 +145,6 @@ SummonDrones_blood:
 LightningZone:
   Cooldown: 15
   Skills:
-    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
     - skill{s=FX_Electric_Field_Telegraph} @target
     - delay 40
     - lightning @target
@@ -158,7 +154,6 @@ LightningZone:
 LightningZone_hell:
   Cooldown: 15
   Skills:
-    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
     - skill{s=FX_Electric_Field_Telegraph} @target
     - delay 40
     - lightning @target
@@ -168,7 +163,6 @@ LightningZone_hell:
 LightningZone_blood:
   Cooldown: 15
   Skills:
-    - message{m="&bElectric field materializes!"} @PlayersInRadius{r=20}
     - skill{s=FX_Electric_Field_Telegraph} @target
     - delay 40
     - lightning @target
@@ -424,7 +418,6 @@ Ice-Hit-Blood:
 HomingIceSphere:
   Cooldown: 15
   Skills:
-    - message{m="&bA sphere of pure frost manifests!"} @PlayersInRadius{r=30}
     - projectile{onTick=Sphere-Tick;onHit=Sphere-Hit;v=5;i=SNOWBALL;hR=1;vR=1;sF=true} @target
 
 Sphere-Tick:
@@ -440,7 +433,6 @@ Sphere-Hit:
 HomingIceSphere_hell:
   Cooldown: 15
   Skills:
-    - message{m="&bA sphere of pure frost manifests!"} @PlayersInRadius{r=30}
     - projectile{onTick=Sphere-Tick-Hell;onHit=Sphere-Hit-Hell;v=5;i=SNOWBALL;hR=1;vR=1;sF=true} @target
 
 Sphere-Tick-Hell:
@@ -456,7 +448,6 @@ Sphere-Hit-Hell:
 HomingIceSphere_blood:
   Cooldown: 15
   Skills:
-    - message{m="&bA sphere of pure frost manifests!"} @PlayersInRadius{r=30}
     - projectile{onTick=Sphere-Tick-Blood;onHit=Sphere-Hit-Blood;v=5;i=SNOWBALL;hR=1;vR=1;sF=true} @target
 
 Sphere-Tick-Blood:

--- a/skills/q9.yml
+++ b/skills/q9.yml
@@ -245,7 +245,6 @@ Petrify_blood:
 SummonSnakes:
   Cooldown: 20
   Skills:
-    - message{m="&a&lSssss... &7Snakes slither from the ground!"} @PlayersInRadius{r=20}
     - sound{s=entity.witch.celebrate;v=0.8;p=1.6} @self
     - effect:particlering{p=SLIME;r=3.5;points=80;amount=1;y=0.1} @self 
     - effect:particlering{p=SLIME;r=2;points=40;amount=1;y=0.3} @self
@@ -255,7 +254,6 @@ SummonSnakes:
 SummonSnakes_hell:
   Cooldown: 20
   Skills:
-    - message{m="&a&lSssss... &7A venomous nest awakens!"} @PlayersInRadius{r=20}
     - sound{s=entity.witch.celebrate;v=0.9;p=1.6} @self
     - effect:particlering{p=SLIME;r=4;points=90;amount=1;y=0.1} @self 
     - effect:particlering{p=SLIME;r=2.5;points=45;amount=1;y=0.3} @self
@@ -265,7 +263,6 @@ SummonSnakes_hell:
 SummonSnakes_blood:
   Cooldown: 20
   Skills:
-    - message{m="&a&lSssss... &7The snake lair opens!"} @PlayersInRadius{r=20}
     - sound{s=entity.witch.celebrate;v=1;p=1.6} @self
     - effect:particlering{p=SLIME;r=4.5;points=100;amount=1;y=0.1} @self 
     - effect:particlering{p=SLIME;r=3;points=50;amount=1;y=0.3} @self


### PR DESCRIPTION
## Summary
- drop broadcast messages from q-series skills used by normal mobs
- keep callouts for named bosses like Mortis and Murot

## Testing
- `pip install pyyaml`
- `python - <<'PY'
import yaml, glob
files = ['skills/70-80.yml','skills/81-90.yml'] + sorted(glob.glob('skills/q*.yml'))
for f in files:
    with open(f) as fh:
        yaml.safe_load(fh)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a1cfe98d28832a99f705b42cdba3df