### PR TITLE
Remove message components from normal mob skills

### DIFF
--- a/skills/41-45.yml
+++ b/skills/41-45.yml
@@ -13,7 +13,6 @@ RainOfDestruction:
   Skills:
     - effect:particles{p=smoke_large;amount=20;hS=1;vS=1} @Self
     - sound{s=entity.blaze.shoot;v=1;p=1} @Self
-    - message{m="&c&l>> &r&7A rain of fire is coming! Move!";a=true} @PlayersInRadius{r=18}
     - delay 16
     - projectile{onTick=RainTick;onHit=RainHit;v=0.5;i=10;hR=10;vR=5;hnp=true;dir=[0,1,0]} @PlayersInRadius{r=15}
 

--- a/skills/81-90.yml
+++ b/skills/81-90.yml
@@ -22,7 +22,6 @@ ThunderStrike:
     - targetwithin{d=24}
   Skills:
     - effect:particles{particle=electric_spark;amount=24;hS=1;vS=1} @target
-    - message{m="&b⚡ &7You feel static gathering..."} @target
     - sound{s=entity.warden.sonic_charge;v=1;p=1} @target
     - delay 28
     - effect:lightning @target

--- a/skills/91-100.yml
+++ b/skills/91-100.yml
@@ -3,7 +3,6 @@ PosthumousAttack:
   Skills:
     - effect:sound{s=entity.wither.death;v=2;p=1} @self
     - effect:particles{particle=explosion_large;amount=5} @self
-    - message{m="&7(&c!&7) &fCorpse is about to explode!"} @PIR{r=14}
     - delay 20
     - damage{amount=250;radius=5} @LivingEntitiesInRadius{r=5}
 

--- a/skills/q1.yml
+++ b/skills/q1.yml
@@ -46,7 +46,6 @@ Catapult-Hit:
 SummonServants:
   Cooldown: 30
   Skills:
-    - message{m="&6<mob.name>&f summons help!"} @PlayersInRadius{r=40}
     - sound{s=entity.evoker.prepare_summon;v=1.2;p=1.0} @self
     - effect:particles{p=FLAME;amount=80;hS=1.2;vS=0.4;y=0.1} @self
     - delay 20
@@ -57,7 +56,6 @@ SummonServants:
 SummonServants_hell:
   Cooldown: 30
   Skills:
-    - message{m="&6<mob.name>&f calls more zealots!"} @PlayersInRadius{r=40}
     - sound{s=entity.evoker.prepare_summon;v=1.2;p=1.0} @self
     - effect:particles{p=SOUL_FIRE_FLAME;amount=90;hS=1.2;vS=0.4;y=0.1} @self
     - delay 20
@@ -68,7 +66,6 @@ SummonServants_hell:
 SummonServants_blood:
   Cooldown: 35
   Skills:
-    - message{m="&4<mob.name>&f tears open a rift!"} @PlayersInRadius{r=40}
     - sound{s=entity.zombie_villager.converted;v=1.2;p=0.7} @self
     - effect:particles{p=ASH;amount=120;hS=1.4;vS=0.5;y=0.1} @self
     - delay 25
@@ -79,7 +76,6 @@ SummonServants_blood:
 SummonFlamecultServants:
   Cooldown: 28
   Skills:
-    - message{m="&cFlamecult reinforcements incoming!"} @PlayersInRadius{r=40}
     - sound{s=entity.blaze.ambient;v=1.0;p=0.9} @self
     - effect:particles{p=FLAME;amount=70;hS=1.1;vS=0.3} @self
     - delay 16
@@ -89,7 +85,6 @@ SummonFlamecultServants:
 SummonFlamecultServants_hell:
   Cooldown: 28
   Skills:
-    - message{m="&cMore cultists join the fray!"} @PlayersInRadius{r=40}
     - sound{s=entity.blaze.ambient;v=1.0;p=0.9} @self
     - effect:particles{p=SOUL_FIRE_FLAME;amount=80;hS=1.1;vS=0.3} @self
     - delay 16
@@ -99,7 +94,6 @@ SummonFlamecultServants_hell:
 SummonFlamecultServants_blood:
   Cooldown: 32
   Skills:
-    - message{m="&4Bloodbound cultists appear!"} @PlayersInRadius{r=40}
     - sound{s=entity.blaze.ambient;v=1.0;p=0.8} @self
     - effect:particles{p=ASH;amount=100;hS=1.1;vS=0.3} @self
     - delay 18
@@ -132,7 +126,6 @@ TeleportToPlayer:
   Conditions:
     - targetwithin{d=24} true
   Skills:
-    - message{m="&7&m&m&m&m &e<mob.name> vanishes..."} @PlayersInRadius{r=30}
     - sound{s=entity.enderman.teleport;v=0.9;p=0.7} @self
     - effect:particles{p=PORTAL;amount=70;hS=0.7;vS=0.5} @self
     - delay 6

--- a/skills/q10.yml
+++ b/skills/q10.yml
@@ -150,7 +150,6 @@ LeapAttack:
 SummonJabbax:
   Cooldown: 15
   Skills:
-    - message{m="&cJabbax calls for reinforcements!"} @PlayersInRadius{r=20}
     - summon{mob=anderworld_jabbax_inf;amount=10;radius=5} @self
 
 FlamingShot:
@@ -313,7 +312,6 @@ LeapAttack_hell:
 SummonJabbax_hell:
   Cooldown: 15
   Skills:
-    - message{m="&cJabbax calls for reinforcements!"} @PlayersInRadius{r=20}
     - summon{mob=anderworld_jabbax_hell;amount=10;radius=5} @self
 
 FlamingShot_hell:
@@ -478,7 +476,6 @@ LeapAttack_blood:
 SummonJabbax_blood:
   Cooldown: 15
   Skills:
-    - message{m="&cJabbax calls for reinforcements!"} @PlayersInRadius{r=20}
     - summon{mob=anderworld_jabbax_blood;amount=10;radius=5} @self
 
 FlamingShot_blood:

--- a/skills/q2.yml
+++ b/skills/q2.yml
@@ -32,7 +32,6 @@ Q2-ProjectileHit-200:
 MagicProjectile_inf:
   Cooldown: 6
   Skills:
-    - message{m="&5Death Witch&f traces dark energy..."} @PlayersInRadius{r=40}
     - sound{s=entity.witch.celebrate;v=1.0;p=0.7} @self
     - effect:particles{p=SPELL_WITCH;amount=30;hS=0.8;vS=0.25;y=1} @self
     - delay 10
@@ -42,7 +41,6 @@ MagicProjectile_inf:
 SummonSphere_inf:
   Cooldown: 18
   Skills:
-    - message{m="&5Death Witch&f conjures a soul sphere!"} @PlayersInRadius{r=40}
     - sound{s=entity.illusioner.prepare_mirror;v=1.0;p=1.2} @self
     - effect:particles{p=ENCHANT;amount=80;hS=0.9;vS=0.4;y=1} @self
     - delay 18
@@ -52,7 +50,6 @@ SummonSphere_inf:
 MagicProjectile_hell:
   Cooldown: 6
   Skills:
-    - message{m="&5Death Witch&f channels a curse!"} @PlayersInRadius{r=40}
     - sound{s=entity.witch.ambient;v=1.0;p=0.9} @self
     - effect:particles{p=SOUL;amount=30;hS=0.7;vS=0.25;y=1} @self
     - delay 10
@@ -62,7 +59,6 @@ MagicProjectile_hell:
 SummonSphere_hell:
   Cooldown: 18
   Skills:
-    - message{m="&5Death Witch&f summons a torment sphere!"} @PlayersInRadius{r=40}
     - sound{s=entity.illusioner.prepare_blindness;v=1.0;p=1.0} @self
     - effect:particles{p=SOUL;amount=90;hS=0.9;vS=0.4;y=1} @self
     - delay 18
@@ -72,7 +68,6 @@ SummonSphere_hell:
 MagicProjectile_blood:
   Cooldown: 7
   Skills:
-    - message{m="&4Blood Witch&f weaves a lethal bolt!"} @PlayersInRadius{r=40}
     - sound{s=entity.witch.celebrate;v=1.0;p=0.6} @self
     - effect:particles{p=ASH;amount=35;hS=0.9;vS=0.3;y=1} @self
     - delay 12
@@ -82,7 +77,6 @@ MagicProjectile_blood:
 SummonSphere_blood:
   Cooldown: 20
   Skills:
-    - message{m="&4A blood sphere takes form!"} @PlayersInRadius{r=40}
     - sound{s=entity.illusioner.prepare_mirror;v=1.0;p=0.8} @self
     - effect:particles{p=ASH;amount=100;hS=1.0;vS=0.45;y=1} @self
     - delay 20

--- a/skills/q5.yml
+++ b/skills/q5.yml
@@ -69,7 +69,6 @@ SummonCopy_inf:
 MagicMissile_inf:
   Cooldown: 9
   Skills:
-    - message{m="&4Khalys launches arcane missiles!"} @PlayersInRadius{r=26}
     - projectile{onTick=Magic-Tick-Inf;onHit=Magic-Hit-Inf;v=11;i=DRAGON_BREATH;hR=1;vR=1;amount=3;spread=14} @NearestPlayer{r=30}
 
 Magic-Tick-Inf:

--- a/skills/q6.yml
+++ b/skills/q6.yml
@@ -2,7 +2,6 @@
 DeathExplosion:
   Cooldown: 1
   Skills:
-  - message{m="&cA &lDeath Explosion&r is coming! &7(Run!)"} @PlayersInRadius{r=12}
   - sound{s=entity.wither.spawn;v=1;p=0.8} @self
   - effect:particles{p=SMOKE_LARGE;amount=30;radius=2;y=0.2} @self
   - delay 10
@@ -22,7 +21,6 @@ DeathExplosion:
 WitheringShot:
   Cooldown: 10
   Skills:
-  - message{m="&6<mob.name>&f draws a bowstring tainted with darkness!"} @PlayersInRadius{r=30}
   - sound{s=entity.skeleton.shoot;v=1;p=1.2} @self
   - effect:particles{p=SMOKE_LARGE;amount=12;radius=1} @self
   - delay 15
@@ -45,7 +43,6 @@ MeteorStrike:
 HomingOrb:
   Cooldown: 10
   Skills:
-  - message{m="&5<mob.name>&f forms a &dNecro Orb&f that &ltracks&f its target!"} @PlayersInRadius{r=30}
   - effect:particles{p=DRAGON_BREATH;amount=30;radius=1} @self
   - sound{s=block.beacon.ambient;v=1;p=1} @self
   - delay 10
@@ -93,7 +90,6 @@ DragonBreath:
 ScytheWhirlwind:
   Cooldown: 16
   Skills:
-  - message{m="&7<mob.name>&f whirls its blade!"} @PlayersInRadius{r=25}
   - sound{s=entity.player.attack.sweep;v=1.2;p=1} @self
   - effect:particles{p=SWEEP_ATTACK;amount=40;radius=5;y=0.2} @self
   - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
@@ -112,7 +108,6 @@ ScytheWhirlwind:
 DeathDash:
   Cooldown: 12
   Skills:
-  - message{m="&8<mob.name>&f vanishes into shadowy snow!"} @PlayersInRadius{r=25}
   - effect:particles{p=SMOKE_LARGE;amount=40;radius=1} @self
   - sound{s=entity.enderman.teleport;v=1;p=1} @self
   - delay 5
@@ -124,7 +119,6 @@ DeathDash:
 HealingPulse:
   Cooldown: 20
   Skills:
-  - message{m="&a<&sparkles>&f Healing pulse!"} @PlayersInRadius{r=30}
   - heal{a=600} @self
   - potion{type=REGENERATION;duration=100;level=1} @self
   - effect:particles{p=HEART;amount=30} @self
@@ -170,7 +164,6 @@ SummonPhase3:
 DeathExplosion_hell:
   Cooldown: 1
   Skills:
-  - message{m="&cA &lDeath Explosion&r is coming! &7(Run!)"} @PlayersInRadius{r=12}
   - sound{s=entity.wither.spawn;v=1;p=0.8} @self
   - effect:particles{p=SMOKE_LARGE;amount=30;radius=3;y=0.2} @self
   - delay 10
@@ -191,7 +184,6 @@ DeathExplosion_hell:
 WitheringShot_hell:
   Cooldown: 10
   Skills:
-  - message{m="&6<mob.name>&f draws a bowstring tainted with darkness!"} @PlayersInRadius{r=30}
   - sound{s=entity.skeleton.shoot;v=1;p=1.2} @self
   - effect:particles{p=SMOKE_LARGE;amount=12;radius=1} @self
   - delay 15
@@ -214,7 +206,6 @@ MeteorStrike_hell:
 HomingOrb_hell:
   Cooldown: 10
   Skills:
-  - message{m="&5<mob.name>&f forms a &dNecro Orb&f that &ltracks&f its target!"} @PlayersInRadius{r=30}
   - effect:particles{p=DRAGON_BREATH;amount=30;radius=1} @self
   - sound{s=block.beacon.ambient;v=1;p=1} @self
   - delay 10
@@ -258,7 +249,6 @@ DragonBreath_hell:
 ScytheWhirlwind_hell:
   Cooldown: 16
   Skills:
-  - message{m="&7<mob.name>&f whirls its blade!"} @PlayersInRadius{r=25}
   - sound{s=entity.player.attack.sweep;v=1.2;p=1} @self
   - effect:particles{p=SWEEP_ATTACK;amount=40;radius=5;y=0.2} @self
   - effect:particles{p=SWEEP_ATTACK;amount=60;radius=4;y=0.2} @self
@@ -280,7 +270,6 @@ ScytheWhirlwind_hell:
 DeathDash_hell:
   Cooldown: 12
   Skills:
-  - message{m="&8<mob.name>&f vanishes into shadowy snow!"} @PlayersInRadius{r=25}
   - effect:particles{p=SMOKE_LARGE;amount=40;radius=1} @self
   - sound{s=entity.enderman.teleport;v=1;p=1} @self
   - delay 5
@@ -292,7 +281,6 @@ DeathDash_hell:
 HealingPulse_hell:
   Cooldown: 20
   Skills:
-  - message{m="&a<&sparkles>&f Healing pulse!"} @PlayersInRadius{r=30}
   - heal{a=1600} @self
   - potion{type=REGENERATION;duration=140;level=1} @self
   - effect:particles{p=HEART;amount=30} @self
@@ -337,7 +325,6 @@ SummonPhase3_hell:
 DeathExplosion_blood:
   Cooldown: 1
   Skills:
-  - message{m="&cA &lDeath Explosion&r is coming! &7(Run!)"} @PlayersInRadius{r=12}
   - sound{s=entity.wither.spawn;v=1;p=0.8} @self
   - effect:particles{p=SMOKE_LARGE;amount=30;radius=4;y=0.2} @self
   - delay 10
@@ -357,7 +344,6 @@ DeathExplosion_blood:
 WitheringShot_blood:
   Cooldown: 10
   Skills:
-  - message{m="&6<mob.name>&f draws a bowstring tainted with darkness!"} @PlayersInRadius{r=30}
   - sound{s=entity.skeleton.shoot;v=1;p=1.2} @self
   - effect:particles{p=SMOKE_LARGE;amount=12;radius=1} @self
   - delay 15
@@ -380,7 +366,6 @@ MeteorStrike_blood:
 HomingOrb_blood:
   Cooldown: 10
   Skills:
-  - message{m="&5<mob.name>&f forms a &dNecro Orb&f that &ltracks&f its target!"} @PlayersInRadius{r=30}
   - effect:particles{p=DRAGON_BREATH;amount=30;radius=1} @self
   - sound{s=block.beacon.ambient;v=1;p=1} @self
   - delay 10
@@ -426,7 +411,6 @@ DragonBreath_blood:
 ScytheWhirlwind_blood:
   Cooldown: 16
   Skills:
-  - message{m="&7<mob.name>&f whirls its blade!"} @PlayersInRadius{r=25}
   - sound{s=entity.player.attack.sweep;v=1.2;p=1} @self
   - effect:particles{p=SWEEP_ATTACK;amount=40;radius=6;y=0.2} @self
   - effect:particles{p=SWEEP_ATTACK;amount=60;radius=5;y=0.2} @self
@@ -451,7 +435,6 @@ ScytheWhirlwind_blood:
 DeathDash_blood:
   Cooldown: 12
   Skills:
-  - message{m="&8<mob.name>&f vanishes into shadowy snow!"} @PlayersInRadius{r=25}
   - effect:particles{p=SMOKE_LARGE;amount=40;radius=1} @self
   - sound{s=entity.enderman.teleport;v=1;p=1} @self
   - delay 5
@@ -463,7 +446,6 @@ DeathDash_blood:
 HealingPulse_blood:
   Cooldown: 20
   Skills:
-  - message{m="&a<&sparkles>&f Healing pulse!"} @PlayersInRadius{r=30}
   - heal{a=3000} @self
   - potion{type=REGENERATION;duration=180;level=1} @self
   - effect:particles{p=HEART;amount=30} @self

--- a/skills/q7.yml
+++ b/skills/q7.yml
@@ -26,7 +26,6 @@ ThunderStrike:
 DeathExplosion:
   Cooldown: 1
   Skills:
-    - message{m="&4&l! &cEnergy surges... &7(Back away)"} @PlayersInRadius{r=8}
     - effect:particles{p=SMOKE_NORMAL;amount=80;hS=1.8;vS=0.3;speed=0.02;y=0.2} @self
     - sound{s=entity.wither.ambient;v=1.2;p=0.6} @self
     - delay 50
@@ -146,7 +145,6 @@ ThunderStrike_hell:
 DeathExplosion_hell:
   Cooldown: 1
   Skills:
-    - message{m="&4&l! &cEnergy surges... &7(Back away)"} @PlayersInRadius{r=8}
     - effect:particles{p=SMOKE_NORMAL;amount=100;hS=1.8;vS=0.3;speed=0.02;y=0.2} @self
     - sound{s=entity.wither.ambient;v=1.2;p=0.6} @self
     - delay 45
@@ -267,7 +265,6 @@ ThunderStrike_blood:
 DeathExplosion_blood:
   Cooldown: 1
   Skills:
-    - message{m="&4&l! &cEnergy surges... &7(Back away)"} @PlayersInRadius{r=8}
     - effect:particles{p=SMOKE_NORMAL;amount=120;hS=1.8;vS=0.3;speed=0.02;y=0.2} @self
     - sound{s=entity.wither.ambient;v=1.2;p=0.6} @self
     - delay 40

--- a/skills/q8.yml
+++ b/skills/q8.yml
@@ -121,7 +121,6 @@ SummonSmallIceHeaps_blood:
 SummonDrones:
   Cooldown: 20
   Skills:
-    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
     - effect:particlering{p=ELECTRIC_SPARK;r=3;points=28;amount=1;y=0.15} @self
     - sound{s=block.beacon.activate;v=0.9;p=1.2} @self
     - summon{mob=charged_drone_inf;amount=2;radius=3} @self
@@ -129,7 +128,6 @@ SummonDrones:
 SummonDrones_hell:
   Cooldown: 20
   Skills:
-    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
     - effect:particlering{p=ELECTRIC_SPARK;r=3.2;points=30;amount=1;y=0.15} @self
     - sound{s=block.beacon.activate;v=1;p=1.2} @self
     - summon{mob=charged_drone_hell;amount=2;radius=3} @self
@@ -137,7 +135,6 @@ SummonDrones_hell:
 SummonDrones_blood:
   Cooldown: 20
   Skills:
-    - message{m="&bFrostwolf calls for reinforcements!"} @PlayersInRadius{r=20}
     - effect:particlering{p=ELECTRIC_SPARK;r=3.4;points=32;amount=1;y=0.15} @self
     - sound{s=block.beacon.activate;v=1.1;p=1.2} @self
     - summon{mob=charged_drone_blood;amount=2;radius=3} @self

--- a/skills/tetanocetl.yml
+++ b/skills/tetanocetl.yml
@@ -20,7 +20,6 @@ applyBlindness:
 ResurrectToltecWarrior:
   Cooldown: 20
   Skills:
-    - message{m="&2&lShaman&r calls a warrior soul..."} @PIR{r=28}
     - effect:particles{p=totem_of_undying;amount=40;hS=0.7;vS=0.2} @self
     - sound{s=entity.evoker.cast_spell;v=1;p=1} @self
     - delay 30


### PR DESCRIPTION
## Summary
- strip chat messages from normal mob skills so only special mobs with `&4<&skull>` or `&5&l` retain warnings

## Testing
- `python - <<'PY'
import os, yaml
for root, dirs, files in os.walk('skills'):
    for fname in files:
        if fname.endswith('.yml'):
            yaml.safe_load(open(os.path.join(root,fname)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a2c9485160832aabe7264b61150e52