### PR TITLE
Rename mob display names to avoid copyright

### DIFF
--- a/mobs/Map_Great_Desert_46-50.yml
+++ b/mobs/Map_Great_Desert_46-50.yml
@@ -63,7 +63,7 @@ serpent_spitter:
 scarab_knephre:
   Type: ZOMBIE
   Disguise: COW
-  Display: '&5&l Knephres Scarabeus&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&l Kenphros Scarabeus&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 4000
   Damage: 400
   Options:

--- a/mobs/Map_Stalgard_36-40.yml
+++ b/mobs/Map_Stalgard_36-40.yml
@@ -121,7 +121,7 @@ t_1000:
 
 high_priest_danzo:
   Type: ZOMBIE
-  Display: '&5&l High Priest Danzo&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&l High Priest Danru&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2500
   Damage: 375
   Options:

--- a/mobs/Map_Temple_sector_31-35.yml
+++ b/mobs/Map_Temple_sector_31-35.yml
@@ -89,7 +89,7 @@ gorgon_heretic:
 
 high_priest_baran:
   Type: ZOMBIE
-  Display: '&5&l High Priest Gorgon B`aran&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&l High Priest Gorgon Barun&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 1000
   Damage: 250
   Options:

--- a/mobs/Tetaconetl_61-70.yml
+++ b/mobs/Tetaconetl_61-70.yml
@@ -93,7 +93,7 @@ obstinate_toltec_shaman:
 quacking_orbax:
   Type: ZOMBIE
   Disguise: SLIME
-  Display: '&5&l Quacking Orbax&r &l[&4<caster.hp{round=2}>&r&l/&4&l<caster.mhp>&r&l]&r &4<&heart>'
+  Display: '&5&l Quarling Orbax&r &l[&4<caster.hp{round=2}>&r&l/&4&l<caster.mhp>&r&l]&r &4<&heart>'
   Health: 2500
   Damage: 100
   Armor: 0

--- a/mobs/fishing.yml
+++ b/mobs/fishing.yml
@@ -1,11 +1,11 @@
 Kraken_AbyssalTerror:
   Type: ZOMBIE
-  Display: '&4<&skull> &lKraken, Abyssal Terror &4<&skull>'
+  Display: '&4<&skull> &lKrakar, Abyssal Horror &4<&skull>'
   Health: 90000          # ~70–100k
   Damage: 2000           # bazowy kontaktowy
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Kraken, Abyssal Terror - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Krakar, Abyssal Horror - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: RED
     Style: SEGMENTED_12

--- a/mobs/mine_mobs.yml
+++ b/mobs/mine_mobs.yml
@@ -29,7 +29,7 @@ cursed_miner_mine:
 
 deepmine_overseer_kragg:
   Type: WITHER_SKELETON
-  Display: '&4<&skull> &lOverseer Kragg &r&4<&skull>'
+  Display: '&4<&skull> &lOverseer Kraggar &r&4<&skull>'
   Health: 20000
   Damage: 500
   BossBar:

--- a/mobs/q10_blood.yml
+++ b/mobs/q10_blood.yml
@@ -113,7 +113,7 @@ combat_ready_zorlobb_blood:
 
 melas_the_swift_footed_blood:
   Type: ZOMBIE
-  Display: '&5&lMelas the Swift-Footed &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMelan the Swiftstride &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 750    # 5x150
   Faction: q10_blood
@@ -266,7 +266,7 @@ mordacious_khaross_blood:
 
 akheilos_blood:
   Type: ZOMBIE
-  Display: '&5&lAkheilos &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAkhelion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 1000   # 5x200
   Faction: q10_blood
@@ -299,14 +299,14 @@ akheilos_blood:
 # Mission 3 Boss
 parallel_world_gorga_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lGorga &r&4<&skull>'
+  Display: '&4<&skull> &lGorgra &r&4<&skull>'
   Health: 50000  # 10x5000
   Damage: 1000   # 5x200
   Faction: q10_blood
   Group: q10_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Gorga - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Gorgra - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q10_hell.yml
+++ b/mobs/q10_hell.yml
@@ -113,7 +113,7 @@ combat_ready_zorlobb_hell:
 
 melas_the_swift_footed_hell:
   Type: ZOMBIE
-  Display: '&5&lMelas the Swift-Footed &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMelan the Swiftstride &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # 3x2000
   Damage: 300   # 2x150
   Faction: q10_hell
@@ -266,7 +266,7 @@ mordacious_khaross_hell:
 
 akheilos_hell:
   Type: ZOMBIE
-  Display: '&5&lAkheilos &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAkhelion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # 3x2000
   Damage: 400   # 2x200
   Faction: q10_hell
@@ -299,14 +299,14 @@ akheilos_hell:
 # Mission 3 Boss
 parallel_world_gorga_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lGorga &r&4<&skull>'
+  Display: '&4<&skull> &lGorgra &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 400    # 2x200
   Faction: q10_hell
   Group: q10_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Gorga - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Gorgra - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q10_inf.yml
+++ b/mobs/q10_inf.yml
@@ -113,7 +113,7 @@ combat_ready_zorlobb_inf:
 
 melas_the_swift_footed_inf:
   Type: ZOMBIE
-  Display: '&5&lMelas the Swift-Footed &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMelan the Swiftstride &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000  # Mini-boss HP
   Damage: 150   # Medium damage
   Faction: q10_inf
@@ -266,7 +266,7 @@ mordacious_khaross_inf:
 
 akheilos_inf:
   Type: ZOMBIE
-  Display: '&5&lAkheilos &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAkhelion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000  # Mini-boss HP
   Damage: 200   # High damage
   Faction: q10_inf
@@ -299,14 +299,14 @@ akheilos_inf:
 # Mission 3 Boss
 parallel_world_gorga_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lGorga &r&4<&skull>'
+  Display: '&4<&skull> &lGorgra &r&4<&skull>'
   Health: 5000  # Boss HP
   Damage: 200   # Base damage
   Faction: q10_inf
   Group: q10_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Gorga - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Gorgra - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q1_blood.yml
+++ b/mobs/q1_blood.yml
@@ -93,7 +93,7 @@ flamecult_worshipper_blood:
 
 perral_world_dragonknight_blood:
   Type: SKELETON
-  Display: '&5&lPerral World Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000
   Damage: 750
   Options:
@@ -128,7 +128,7 @@ perral_world_dragonknight_blood:
 
 raazghul_the_corruptor_blood:
   Type: ZOMBIE
-  Display: '&5&lRaazghul the Corruptor&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lRaazgor the Corrupter&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000
   Damage: 1250
   Options:
@@ -162,12 +162,12 @@ raazghul_the_corruptor_blood:
 
 grimmag_blood:
   Type: ZOMBIE
-  Display: '&4 <&skull> &l Grimmag the Risen&r&4 <&skull>'
+  Display: '&4 <&skull> &l Grimmor the Risen&r&4 <&skull>'
   Health: 50000
   Damage: 1500
   BossBar:
     Enabled: true
-    Title: ' &c<&skull> Grimmag the Risen - <mob.hp{round=0}> <&skull>'
+    Title: ' &c<&skull> Grimmor the Risen - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: RED
     Style: SEGMENTED_12

--- a/mobs/q1_hell.yml
+++ b/mobs/q1_hell.yml
@@ -93,7 +93,7 @@ flamecult_worshipper_hell:
 
 perral_world_dragonknight_hell:
   Type: SKELETON
-  Display: '&5&lPerral World Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000
   Damage: 300
   Options:
@@ -128,7 +128,7 @@ perral_world_dragonknight_hell:
 
 raazghul_the_corruptor_hell:
   Type: ZOMBIE
-  Display: '&5&lRaazghul the Corruptor&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lRaazgor the Corrupter&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000
   Damage: 500
   Options:
@@ -162,12 +162,12 @@ raazghul_the_corruptor_hell:
 
 grimmag_hell:
   Type: ZOMBIE
-  Display: '&4 <&skull> &l Grimmag the Risen&r&4 <&skull>'
+  Display: '&4 <&skull> &l Grimmor the Risen&r&4 <&skull>'
   Health: 15000
   Damage: 600
   BossBar:
     Enabled: true
-    Title: ' &c<&skull> Grimmag the Risen - <mob.hp{round=0}> <&skull>'
+    Title: ' &c<&skull> Grimmor the Risen - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: PURPLE
     Style: SEGMENTED_12

--- a/mobs/q1_inf.yml
+++ b/mobs/q1_inf.yml
@@ -93,7 +93,7 @@ flamecult_worshipper_inf:
 
 perral_world_dragonknight_inf:
   Type: SKELETON
-  Display: '&5&lPerral World Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 150
   Options:
@@ -127,7 +127,7 @@ perral_world_dragonknight_inf:
 
 raazghul_the_corruptor_inf:
   Type: ZOMBIE
-  Display: '&5&lRaazghul the Corruptor&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lRaazgor the Corrupter&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000
   Damage: 250
   Options:
@@ -161,12 +161,12 @@ raazghul_the_corruptor_inf:
 
 grimmag_inf:
   Type: ZOMBIE
-  Display: '&4 <&skull> &l Grimmag the Risen&r&4 <&skull>'
+  Display: '&4 <&skull> &l Grimmor the Risen&r&4 <&skull>'
   Health: 5000
   Damage: 300
   BossBar:
     Enabled: true
-    Title: ' &c<&skull> Grimmag the Risen - <mob.hp{round=0}> <&skull>'
+    Title: ' &c<&skull> Grimmor the Risen - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: BLUE
     Style: SEGMENTED_12

--- a/mobs/q2_blood.yml
+++ b/mobs/q2_blood.yml
@@ -114,7 +114,7 @@ corrupted_root_creature_blood:
     - leather_boots{color=green} FEET
 xerib_the_hunchback_blood:
   Type: WITCH
-  Display: '&5&lXerib the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lXerath the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # x10 Zdrowie
   Damage: 300    # x5 Obrażenia
   Faction: q2_blood
@@ -143,7 +143,7 @@ xerib_the_hunchback_blood:
 archus_the_mad_blood:
   Type: ZOMBIE
   Disguise: HUSK
-  Display: '&5&lArchus the Mad &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lArchaz the Madcap &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # x10 Zdrowie
   Damage: 400    # x5 Obrażenia
   Faction: q2_blood
@@ -172,14 +172,14 @@ archus_the_mad_blood:
 arachna_scourge_of_duria_blood:
   Type: ZOMBIE
   Disguise: SPIDER
-  Display: '&4<&skull> &lArachna, Scourge of Duria&r &4<&skull>'
+  Display: '&4<&skull> &lAraksha, Bane of Durion&r &4<&skull>'
   Health: 50000  # x10 Zdrowie
   Damage: 500
   Faction: q2_blood
   Group: q2_blood # x5 Obrażenia
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Arachna - &c<mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Araksha - &c<mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q2_hell.yml
+++ b/mobs/q2_hell.yml
@@ -115,7 +115,7 @@ corrupted_root_creature_hell:
 
 xerib_the_hunchback_hell:
   Type: WITCH
-  Display: '&5&lXerib the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lXerath the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # x3 Zdrowie
   Damage: 120   # x2 Obrażenia
   Faction: q2_hell
@@ -144,7 +144,7 @@ xerib_the_hunchback_hell:
 archus_the_mad_hell:
   Type: ZOMBIE
   Disguise: HUSK
-  Display: '&5&lArchus the Mad &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lArchaz the Madcap &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # x3 Zdrowie
   Damage: 160   # x2 Obrażenia
   Faction: q2_hell
@@ -173,14 +173,14 @@ archus_the_mad_hell:
 arachna_scourge_of_duria_hell:
   Type: ZOMBIE
   Disguise: SPIDER
-  Display: '&4<&skull> &lArachna, Scourge of Duria &r&4<&skull>'
+  Display: '&4<&skull> &lAraksha, Bane of Durion &r&4<&skull>'
   Health: 15000  # x3 Zdrowie
   Damage: 200    # x2 Obrażenia
   Faction: q2_hell
   Group: q2_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Arachna - &c<mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Araksha - &c<mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q2_inf.yml
+++ b/mobs/q2_inf.yml
@@ -115,7 +115,7 @@ corrupted_root_creature_inf:
 
 xerib_the_hunchback_inf:
   Type: WITCH
-  Display: '&5&lXerib the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lXerath the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000
   Damage: 60
   Faction: q2_inf
@@ -145,7 +145,7 @@ xerib_the_hunchback_inf:
 archus_the_mad_inf:
   Type: ZOMBIE
   Disguise: HUSK
-  Display: '&5&lArchus the Mad &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lArchaz the Madcap &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 80
   Faction: q2_inf
@@ -173,14 +173,14 @@ archus_the_mad_inf:
 arachna_scourge_of_duria_inf:
   Type: ZOMBIE
   Disguise: SPIDER
-  Display: '&4<&skull> &lArachna, Scourge of Duria &r&4<&skull>'
+  Display: '&4<&skull> &lAraksha, Bane of Durion &r&4<&skull>'
   Health: 5000
   Damage: 100
   Faction: q2_inf
   Group: q2_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Arachna - &c<mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Araksha - &c<mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q3_blood.yml
+++ b/mobs/q3_blood.yml
@@ -96,7 +96,7 @@ cursed_archer_blood:
 
 parallel_world_evil_miller_blood:
   Type: ZOMBIE
-  Display: '&5&lParallel World Evil Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dire Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 750    # 5x150
   Faction: q3_blood
@@ -225,7 +225,7 @@ slain_archer_blood:
 
 the_bloody_arrow_blood:
   Type: SKELETON
-  Display: '&5&lThe Bloody Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lThe Crimson Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 15000  # 10x1500
   Damage: 900    # 5x180
   Faction: q3_blood
@@ -259,14 +259,14 @@ the_bloody_arrow_blood:
 
 undead_parallel_world_king_heredur_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lUndead King Heredur &r&4<&skull>'
+  Display: '&4<&skull> &lUndead King Heredorn &r&4<&skull>'
   Health: 60000  # 10x3000
   Damage: 1000   # 5x200
   Faction: q3_blood
   Group: q3_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> King Heredur - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> King Heredorn - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q3_hell.yml
+++ b/mobs/q3_hell.yml
@@ -96,7 +96,7 @@ cursed_archer_hell:
 
 parallel_world_evil_miller_hell:
   Type: ZOMBIE
-  Display: '&5&lParallel World Evil Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dire Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000   # 3x2000
   Damage: 300    # 2x150
   Faction: q3_hell
@@ -225,7 +225,7 @@ slain_archer_hell:
 
 the_bloody_arrow_hell:
   Type: SKELETON
-  Display: '&5&lThe Bloody Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lThe Crimson Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 4500   # 3x1500
   Damage: 360    # 2x180
   Faction: q3_hell
@@ -259,14 +259,14 @@ the_bloody_arrow_hell:
 
 undead_parallel_world_king_heredur_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lUndead King Heredur &r&4<&skull>'
+  Display: '&4<&skull> &lUndead King Heredorn &r&4<&skull>'
   Health: 9000
   Damage: 400
   Faction: q3_hell
   Group: q3_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> King Heredur - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> King Heredorn - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q3_inf.yml
+++ b/mobs/q3_inf.yml
@@ -96,7 +96,7 @@ cursed_archer_inf:
 
 parallel_world_evil_miller_inf:
   Type: ZOMBIE
-  Display: '&5&lParallel World Evil Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dire Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000
   Damage: 150
   Faction: q3_inf
@@ -225,7 +225,7 @@ slain_archer_inf:
 
 the_bloody_arrow_inf:
   Type: SKELETON
-  Display: '&5&lThe Bloody Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lThe Crimson Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 1500
   Damage: 180
   Faction: q3_inf
@@ -259,14 +259,14 @@ the_bloody_arrow_inf:
 
 undead_parallel_world_king_heredur_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lUndead King Heredur &r&4<&skull>'
+  Display: '&4<&skull> &lUndead King Heredorn &r&4<&skull>'
   Health: 3000
   Damage: 200
   Faction: q3_inf
   Group: q3_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> King Heredur - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> King Heredorn - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q4_blood.yml
+++ b/mobs/q4_blood.yml
@@ -264,7 +264,7 @@ eternal_hunting_hound_blood:
 ulgar_the_master_butcher_phase1_blood:
   Type: ZOMBIE
   Disguise: PIGLIN
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 1500   # 5x300
   Faction: q4_blood
@@ -291,7 +291,7 @@ ulgar_the_master_butcher_phase1_blood:
 ulgar_the_master_butcher_phase2_blood:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 25000  # 10x2500
   Damage: 1750   # 5x350
   Faction: q4_blood
@@ -318,7 +318,7 @@ ulgar_the_master_butcher_phase2_blood:
 ulgar_the_master_butcher_phase3_blood:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 2000   # 5x400
   Faction: q4_blood
@@ -346,14 +346,14 @@ ulgar_the_master_butcher_phase3_blood:
 
 bearach_champion_of_wilds_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lBearach, Champion of the Wilds &r&4<&skull>'
+  Display: '&4<&skull> &lBearok, Guardian of the Wilds &r&4<&skull>'
   Health: 30000  # 10x3000
   Damage: 1250   # 5x250
   Faction: q4_blood
   Group: q4_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Bearach - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Bearok - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q4_hell.yml
+++ b/mobs/q4_hell.yml
@@ -262,7 +262,7 @@ eternal_hunting_hound_hell:
 ulgar_the_master_butcher_phase1_hell:
   Type: ZOMBIE
   Disguise: PIGLIN
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # 3x2000
   Damage: 600   # 2x300
   Faction: q4_hell
@@ -289,7 +289,7 @@ ulgar_the_master_butcher_phase1_hell:
 ulgar_the_master_butcher_phase2_hell:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 7500  # 3x2500
   Damage: 700   # 2x350
   Faction: q4_hell
@@ -316,7 +316,7 @@ ulgar_the_master_butcher_phase2_hell:
 ulgar_the_master_butcher_phase3_hell:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 800   # 2x400
   Faction: q4_hell
@@ -344,14 +344,14 @@ ulgar_the_master_butcher_phase3_hell:
 
 bearach_champion_of_wilds_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lBearach, Champion of the Wilds &r&4<&skull>'
+  Display: '&4<&skull> &lBearok, Guardian of the Wilds &r&4<&skull>'
   Health: 9000  # 3x3000
   Damage: 500   # 2x250
   Faction: q4_hell
   Group: q4_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Bearach - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Bearok - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q4_inf.yml
+++ b/mobs/q4_inf.yml
@@ -262,7 +262,7 @@ eternal_hunting_hound_inf:
 ulgar_the_master_butcher_phase1_inf:
   Type: ZOMBIE
   Disguise: PIGLIN
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000  # Mini-boss phase 1
   Damage: 300
   Faction: q4_inf
@@ -289,7 +289,7 @@ ulgar_the_master_butcher_phase1_inf:
 ulgar_the_master_butcher_phase2_inf:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2500  # Mini-boss phase 2
   Damage: 350
   Faction: q4_inf
@@ -316,7 +316,7 @@ ulgar_the_master_butcher_phase2_inf:
 ulgar_the_master_butcher_phase3_inf:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000  # Mini-boss phase 3
   Damage: 400
   Faction: q4_inf
@@ -344,14 +344,14 @@ ulgar_the_master_butcher_phase3_inf:
 
 bearach_champion_of_wilds_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lBearach, Champion of the Wilds &r&4<&skull>'
+  Display: '&4<&skull> &lBearok, Guardian of the Wilds &r&4<&skull>'
   Health: 3000
   Damage: 250
   Faction: q4_inf
   Group: q4_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Bearach - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Bearok - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q5_blood.yml
+++ b/mobs/q5_blood.yml
@@ -286,14 +286,14 @@ wandering_experiment_blood:
 khalys_leader_of_cultists_blood:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4<&skull> &lKhalys, Leader of the Cultists &r&4<&skull>'
+  Display: '&4<&skull> &lKalith, Matriarch of the Cult &r&4<&skull>'
   Health: 30000 # 10x3000
   Damage: 1000 # 5x200
   Faction: q5_blood
   Group: q5_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Khalys - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Kalith - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:
@@ -326,7 +326,7 @@ khalys_leader_of_cultists_blood:
 khalys_clone_blood:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4Khalys Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
+  Display: '&4Kalith Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
   Health: 3000 # 10x300
   Damage: 500 # 5x100
   Faction: q5_blood

--- a/mobs/q5_hell.yml
+++ b/mobs/q5_hell.yml
@@ -286,14 +286,14 @@ wandering_experiment_hell:
 khalys_leader_of_cultists_hell:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4<&skull> &lKhalys, Leader of the Cultists &r&4<&skull>'
+  Display: '&4<&skull> &lKalith, Matriarch of the Cult &r&4<&skull>'
   Health: 9000 # 3x3000
   Damage: 400 # 2x200
   Faction: q5_hell
   Group: q5_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Khalys - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Kalith - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:
@@ -326,7 +326,7 @@ khalys_leader_of_cultists_hell:
 khalys_clone_hell:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4Khalys Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
+  Display: '&4Kalith Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
   Health: 900 # 3x300
   Damage: 200 # 2x100
   Faction: q5_hell

--- a/mobs/q5_inf.yml
+++ b/mobs/q5_inf.yml
@@ -286,14 +286,14 @@ wandering_experiment_inf:
 khalys_leader_of_cultists_inf:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4<&skull> &lKhalys, Leader of the Cultists &r&4<&skull>'
+  Display: '&4<&skull> &lKalith, Matriarch of the Cult &r&4<&skull>'
   Health: 3000
   Damage: 200
   Faction: q5_inf
   Group: q5_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Khalys - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Kalith - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -326,7 +326,7 @@ khalys_leader_of_cultists_inf:
 khalys_clone_inf:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4Khalys Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
+  Display: '&4Kalith Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
   Health: 300 # 10% of original
   Damage: 100 # 50% of original
   Faction: q5_inf

--- a/mobs/q6_blood.yml
+++ b/mobs/q6_blood.yml
@@ -93,7 +93,7 @@ death_knight_blood:
 
 mortis_death_knight_blood:
   Type: SKELETON
-  Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMortrix Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1500  # 5x300
   Faction: q6_blood
@@ -251,7 +251,7 @@ elite_skeleton_warrior_blood:
 
 murot_high_priest_blood:
   Type: SKELETON
-  Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMurond, High Priest of Mortrix &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000
   Damage: 1000
   Faction: q6_blood
@@ -287,14 +287,14 @@ murot_high_priest_blood:
 skeledragon_phase1_blood:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lBonewyrm &r&4<&skull>'
   Health: 50000
   Damage: 1500
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
+    Title: '&c<&skull> Bonewyrm - Phase 1 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -319,14 +319,14 @@ skeledragon_phase1_blood:
 skeledragon_phase2_blood:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix & Bonewyrm &r&4<&skull>'
   Health: 70000
   Damage: 2000
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
+    Title: '&c<&skull> Mortrix & Bonewyrm - Phase 2 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -352,14 +352,14 @@ skeledragon_phase2_blood:
 
 mortis_phase3_blood:
   Type: SKELETON
-  Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix, Unbound God of Death &r&4<&skull>'
   Health: 100000
   Damage: 2500
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis - Final Phase <&skull>'
+    Title: '&c<&skull> Mortrix - Final Phase <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q6_hell.yml
+++ b/mobs/q6_hell.yml
@@ -93,7 +93,7 @@ death_knight_hell:
 
 mortis_death_knight_hell:
   Type: SKELETON
-  Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMortrix Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 600   # 2x300
   Faction: q6_hell
@@ -251,7 +251,7 @@ elite_skeleton_warrior_hell:
 
 murot_high_priest_hell:
   Type: SKELETON
-  Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMurond, High Priest of Mortrix &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000
   Damage: 400
   Faction: q6_hell
@@ -287,14 +287,14 @@ murot_high_priest_hell:
 skeledragon_phase1_hell:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lBonewyrm &r&4<&skull>'
   Health: 15000
   Damage: 600
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
+    Title: '&c<&skull> Bonewyrm - Phase 1 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -319,14 +319,14 @@ skeledragon_phase1_hell:
 skeledragon_phase2_hell:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix & Bonewyrm &r&4<&skull>'
   Health: 21000
   Damage: 800
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
+    Title: '&c<&skull> Mortrix & Bonewyrm - Phase 2 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -352,14 +352,14 @@ skeledragon_phase2_hell:
 
 mortis_phase3_hell:
   Type: SKELETON
-  Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix, Unbound God of Death &r&4<&skull>'
   Health: 30000
   Damage: 1000
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis - Final Phase <&skull>'
+    Title: '&c<&skull> Mortrix - Final Phase <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q6_inf.yml
+++ b/mobs/q6_inf.yml
@@ -93,7 +93,7 @@ death_knight_inf:
 
 mortis_death_knight_inf:
   Type: SKELETON
-  Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMortrix Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 300
   Faction: q6_inf
@@ -251,7 +251,7 @@ elite_skeleton_warrior_inf:
 
 murot_high_priest_inf:
   Type: SKELETON
-  Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMurond, High Priest of Mortrix &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 200
   Faction: q6_inf
@@ -287,14 +287,14 @@ murot_high_priest_inf:
 skeledragon_phase1_inf:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lBonewyrm &r&4<&skull>'
   Health: 5000
   Damage: 300
   Faction: q6_inf
   Group: q6_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
+    Title: '&c<&skull> Bonewyrm - Phase 1 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -319,14 +319,14 @@ skeledragon_phase1_inf:
 skeledragon_phase2_inf:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix & Bonewyrm &r&4<&skull>'
   Health: 7000
   Damage: 400
   Faction: q6_inf
   Group: q6_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
+    Title: '&c<&skull> Mortrix & Bonewyrm - Phase 2 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -352,14 +352,14 @@ skeledragon_phase2_inf:
 
 mortis_phase3_inf:
   Type: SKELETON
-  Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix, Unbound God of Death &r&4<&skull>'
   Health: 10000
   Damage: 500
   Faction: q6_inf
   Group: q6_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis - Final Phase <&skull>'
+    Title: '&c<&skull> Mortrix - Final Phase <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q7_blood.yml
+++ b/mobs/q7_blood.yml
@@ -252,7 +252,7 @@ angry_flamespawn_blood:
 
 commander_embersword_blood:
   Type: ZOMBIE
-  Display: '&5&lCommander Embersword &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lCommander Emberblade &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1250   # 5x250
   Faction: q7_blood
@@ -286,14 +286,14 @@ commander_embersword_blood:
 # Mission 3 Boss
 herald_of_anderworld_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lHerald of the Anderworld &r&4<&skull>'
+  Display: '&4<&skull> &lHarbinger of the Anderrealm &r&4<&skull>'
   Health: 50000  # 10x5000
   Damage: 0      # Uses skills for damage
   Faction: q7_blood
   Group: q7_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Herald of the Anderworld - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Harbinger of the Anderrealm - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q7_hell.yml
+++ b/mobs/q7_hell.yml
@@ -252,7 +252,7 @@ angry_flamespawn_hell:
 
 commander_embersword_hell:
   Type: ZOMBIE
-  Display: '&5&lCommander Embersword &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lCommander Emberblade &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 500   # 2x250
   Faction: q7_hell
@@ -286,14 +286,14 @@ commander_embersword_hell:
 # Mission 3 Boss
 herald_of_anderworld_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lHerald of the Anderworld &r&4<&skull>'
+  Display: '&4<&skull> &lHarbinger of the Anderrealm &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 0      # Uses skills for damage
   Faction: q7_hell
   Group: q7_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Herald of the Anderworld - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Harbinger of the Anderrealm - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q7_inf.yml
+++ b/mobs/q7_inf.yml
@@ -252,7 +252,7 @@ angry_flamespawn_inf:
 
 commander_embersword_inf:
   Type: ZOMBIE
-  Display: '&5&lCommander Embersword &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lCommander Emberblade &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 250
   Faction: q7_inf
@@ -286,14 +286,14 @@ commander_embersword_inf:
 # Mission 3 Boss
 herald_of_anderworld_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lHerald of the Anderworld &r&4<&skull>'
+  Display: '&4<&skull> &lHarbinger of the Anderrealm &r&4<&skull>'
   Health: 5000
   Damage: 0
   Faction: q7_inf
   Group: q7_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Herald of the Anderworld - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Harbinger of the Anderrealm - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q8_blood.yml
+++ b/mobs/q8_blood.yml
@@ -334,14 +334,14 @@ pale_enforcer_blood:
 
 sigrismarr_priest_of_fjalnir_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lSigrismarr, Twisted Priest of Fjalnir &r&4<&skull>'
+  Display: '&4<&skull> &lSigrosmar, Twisted Priest of Fjolnar &r&4<&skull>'
   Health: 50000
   Damage: 0
   Faction: q8_blood
   Group: q8_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Sigrismarr - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Sigrosmar - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q8_hell.yml
+++ b/mobs/q8_hell.yml
@@ -337,14 +337,14 @@ pale_enforcer_hell:
 # Mission 3 Boss
 sigrismarr_priest_of_fjalnir_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lSigrismarr, Twisted Priest of Fjalnir &r&4<&skull>'
+  Display: '&4<&skull> &lSigrosmar, Twisted Priest of Fjolnar &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 0      # Uses skills for damage
   Faction: q8_hell
   Group: q8_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Sigrismarr - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Sigrosmar - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q8_inf.yml
+++ b/mobs/q8_inf.yml
@@ -337,14 +337,14 @@ pale_enforcer_inf:
 # Mission 3 Boss
 sigrismarr_priest_of_fjalnir_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lSigrismarr, Twisted Priest of Fjalnir &r&4<&skull>'
+  Display: '&4<&skull> &lSigrosmar, Twisted Priest of Fjolnar &r&4<&skull>'
   Health: 5000
   Damage: 0  # Only uses skills for damage
   Faction: q8_inf
   Group: q8_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Sigrismarr - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Sigrosmar - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q9_blood.yml
+++ b/mobs/q9_blood.yml
@@ -122,7 +122,7 @@ stone_golem_blood:
 asterion_blood:
   Type: ZOMBIE
   Disguise: VINDICATOR
-  Display: '&5&lAsterion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAsteron &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1500   # 5x300
   Faction: q9_blood
@@ -276,7 +276,7 @@ minotaur_blood:
 
 ebicarus_blood:
   Type: ZOMBIE
-  Display: '&5&lEbicarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lEbidarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1500   # 5x300
   Faction: q9_blood
@@ -308,14 +308,14 @@ ebicarus_blood:
 
 medusa_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lM`Edusa &r&4<&skull>'
+  Display: '&4<&skull> &lM`Edara &r&4<&skull>'
   Health: 50000  # 10x5000
   Damage: 1000   # 5x200
   Faction: q9_blood
   Group: q9_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> M`Edusa - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> M`Edara - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q9_hell.yml
+++ b/mobs/q9_hell.yml
@@ -122,7 +122,7 @@ stone_golem_hell:
 asterion_hell:
   Type: ZOMBIE
   Disguise: VINDICATOR
-  Display: '&5&lAsterion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAsteron &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 600   # 2x300
   Faction: q9_hell
@@ -276,7 +276,7 @@ minotaur_hell:
 
 ebicarus_hell:
   Type: ZOMBIE
-  Display: '&5&lEbicarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lEbidarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 600   # 2x300
   Faction: q9_hell
@@ -308,14 +308,14 @@ ebicarus_hell:
 
 medusa_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lM`Edusa &r&4<&skull>'
+  Display: '&4<&skull> &lM`Edara &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 400    # 2x200
   Faction: q9_hell
   Group: q9_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> M`Edusa - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> M`Edara - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q9_inf.yml
+++ b/mobs/q9_inf.yml
@@ -123,7 +123,7 @@ stone_golem_inf:
 asterion_inf:
   Type: ZOMBIE
   Disguise: VINDICATOR
-  Display: '&5&lAsterion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAsteron &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000  # Mini-boss HP
   Damage: 300   # High damage
   Faction: q9_inf
@@ -278,7 +278,7 @@ minotaur_inf:
 
 ebicarus_inf:
   Type: ZOMBIE
-  Display: '&5&lEbicarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lEbidarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000  # Mini-boss HP
   Damage: 300   # High damage
   Faction: q9_inf
@@ -311,14 +311,14 @@ ebicarus_inf:
 # Mission 3 Boss
 medusa_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lM`Edusa &r&4<&skull>'
+  Display: '&4<&skull> &lM`Edara &r&4<&skull>'
   Health: 5000  # Boss HP
   Damage: 200   # Base damage
   Faction: q9_inf
   Group: q9_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> M`Edusa - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> M`Edara - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:


### PR DESCRIPTION
## Summary
- rename unique boss and mini-boss display strings across Q1–Q10 to new thematic variants and update their boss bars accordingly
- adjust display names for special map encounters and the fishing boss to alternate lore-friendly names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d4a66884832a9cf74366db94afce