### PR TITLE
Retheme boss crafting drops and souls

### DIFF
--- a/items/boss_souls.yml
+++ b/items/boss_souls.yml
@@ -1,6 +1,6 @@
 q1_soul:
   Id: DRAGON_BREATH
-  Display: '&c☀ Grimmag’s Burning Soul'
+  Display: '&c☀ Grimmor’s Burning Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -17,7 +17,7 @@ q1_soul:
 
 q2_soul:
   Id: DRAGON_BREATH
-  Display: '&2☠ Arachna’s Venomous Soul'
+  Display: '&2☠ Araksha’s Venomous Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -34,7 +34,7 @@ q2_soul:
 
 q3_soul:
   Id: DRAGON_BREATH
-  Display: '&b❄ King Heredur’s Frostbound Soul'
+  Display: '&b❄ King Heredorn’s Frostbound Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -51,7 +51,7 @@ q3_soul:
 
 q4_soul:
   Id: DRAGON_BREATH
-  Display: '&a🌿 Bearach’s Wildheart Soul'
+  Display: '&a🌿 Bearok’s Wildheart Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -68,7 +68,7 @@ q4_soul:
 
 q5_soul:
   Id: DRAGON_BREATH
-  Display: '&5⚙ Khalys’s Shadowbound Soul'
+  Display: '&5⚙ Kalith’s Shadowbound Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -85,7 +85,7 @@ q5_soul:
 
 q6_soul:
   Id: DRAGON_BREATH
-  Display: '&8⚔ Mortis’s Unchained Soul'
+  Display: '&8⚔ Mortrix’s Unchained Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -102,7 +102,7 @@ q6_soul:
 
 q7_soul:
   Id: DRAGON_BREATH
-  Display: '&6🔥 Herald’s Molten Soul'
+  Display: '&6🔥 Harbinger’s Molten Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -119,7 +119,7 @@ q7_soul:
 
 q8_soul:
   Id: DRAGON_BREATH
-  Display: '&b🌨 Sigrismar’s Blizzard Soul'
+  Display: '&b🌨 Sigrosmar’s Blizzard Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -136,7 +136,7 @@ q8_soul:
 
 q9_soul:
   Id: DRAGON_BREATH
-  Display: '&2🪨 Medusa’s Petrifying Soul'
+  Display: '&2🪨 M`Edara’s Petrifying Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10
@@ -153,7 +153,7 @@ q9_soul:
 
 q10_soul:
   Id: DRAGON_BREATH
-  Display: '&3🐍 Gorga’s Abyssal Soul'
+  Display: '&3🐍 Gorgra’s Abyssal Soul'
   Group: Souls
   Enchantments:
     - DURABILITY:10

--- a/items/crafting_currency_materials.yml
+++ b/items/crafting_currency_materials.yml
@@ -453,7 +453,7 @@ elite_heart_III_1000x:
 
 grimmag_frag_I:
   Id: leather
-  Display: '&9[ I ] Grimmage Burned Cape'
+  Display: '&9[ I ] Grimmor`s Cindered Cape'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -465,7 +465,7 @@ grimmag_frag_I:
     Unbreakable: true
 grimmag_frag_II:
   Id: leather
-  Display: '&5[ II ] Grimmage Burned Cape'
+  Display: '&5[ II ] Grimmor`s Cindered Cape'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -477,7 +477,7 @@ grimmag_frag_II:
     Unbreakable: true
 grimmag_frag_III:
   Id: leather
-  Display: '&6&6[ III ] Grimmage Burned Cape'
+  Display: '&6&6[ III ] Grimmor`s Cindered Cape'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -490,7 +490,7 @@ grimmag_frag_III:
 
 arachna_frag_I:
   Id: phantom_membrane
-  Display: '&9[ I ] Arachana Poisonous Skeleton'
+  Display: '&9[ I ] Araksha`s Venom Husk'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -502,7 +502,7 @@ arachna_frag_I:
     Unbreakable: true
 arachna_frag_II:
   Id: phantom_membrane
-  Display: '&5[ II ] Arachana Poisonous Skeleton'
+  Display: '&5[ II ] Araksha`s Venom Husk'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -514,7 +514,7 @@ arachna_frag_II:
     Unbreakable: true
 arachna_frag_III:
   Id: phantom_membrane
-  Display: '&6&6[ III ] Arachana Poisonous Skeleton'
+  Display: '&6&6[ III ] Araksha`s Venom Husk'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -527,7 +527,7 @@ arachna_frag_III:
 
 heredur_frag_I:
   Id: PRISMARINE_CRYSTALS
-  Display: '&9[ I ] Heredur`s Glacial Armor'
+  Display: '&9[ I ] Heredorn`s Glacial Armor'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -539,7 +539,7 @@ heredur_frag_I:
     Unbreakable: true
 heredur_frag_II:
   Id: PRISMARINE_CRYSTALS
-  Display: '&5[ II ] Heredur`s Glacial Armor'
+  Display: '&5[ II ] Heredorn`s Glacial Armor'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -551,7 +551,7 @@ heredur_frag_II:
     Unbreakable: true
 heredur_frag_III:
   Id: PRISMARINE_CRYSTALS
-  Display: '&6&6[ III ] Heredur`s Glacial Armor'
+  Display: '&6&6[ III ] Heredorn`s Glacial Armor'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -564,7 +564,7 @@ heredur_frag_III:
 
 bearach_frag_I:
   Id: HONEYCOMB
-  Display: '&9[ I ] Bearach Honey Hide'
+  Display: '&9[ I ] Bearok Honey Hide'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -576,7 +576,7 @@ bearach_frag_I:
     Unbreakable: true
 bearach_frag_II:
   Id: HONEYCOMB
-  Display: '&5[ II ] Bearach Honey Hide'
+  Display: '&5[ II ] Bearok Honey Hide'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -588,7 +588,7 @@ bearach_frag_II:
     Unbreakable: true
 bearach_frag_III:
   Id: HONEYCOMB
-  Display: '&6&6[ III ] Bearach Honey Hide'
+  Display: '&6&6[ III ] Bearok Honey Hide'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -601,7 +601,7 @@ bearach_frag_III:
 
 khalys_frag_I:
   Id: black_dye
-  Display: '&9[ I ] Khalys Magic Robe'
+  Display: '&9[ I ] Kalith`s Ritual Robe'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -613,7 +613,7 @@ khalys_frag_I:
     Unbreakable: true
 khalys_frag_II:
   Id: black_dye
-  Display: '&5[ II ] Khalys Magic Robe'
+  Display: '&5[ II ] Kalith`s Ritual Robe'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -625,7 +625,7 @@ khalys_frag_II:
     Unbreakable: true
 khalys_frag_III:
   Id: black_dye
-  Display: '&6&6[ III ] Khalys Magic Robe'
+  Display: '&6&6[ III ] Kalith`s Ritual Robe'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -638,7 +638,7 @@ khalys_frag_III:
 
 heralds_frag_I:
   Id: netherite_scrap
-  Display: '&9[ I ] Heralds Dragon Skin'
+  Display: '&9[ I ] Harbinger`s Dragon Skin'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -650,7 +650,7 @@ heralds_frag_I:
     Unbreakable: true
 heralds_frag_II:
   Id: netherite_scrap
-  Display: '&5[ II ] Heralds Dragon Skin'
+  Display: '&5[ II ] Harbinger`s Dragon Skin'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -662,7 +662,7 @@ heralds_frag_II:
     Unbreakable: true
 heralds_frag_III:
   Id: netherite_scrap
-  Display: '&6&6[ III ] Heralds Dragon Skin'
+  Display: '&6&6[ III ] Harbinger`s Dragon Skin'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -675,7 +675,7 @@ heralds_frag_III:
 
 sigrismar_frag_I:
   Id: amethyst_shard
-  Display: '&9[ I ] Sigrismarr`s Eternal Ice'
+  Display: '&9[ I ] Sigrosmar`s Eternal Ice'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -687,7 +687,7 @@ sigrismar_frag_I:
     Unbreakable: true
 sigrismar_frag_II:
   Id: amethyst_shard
-  Display: '&5[ II ] Sigrismarr`s Eternal Ice'
+  Display: '&5[ II ] Sigrosmar`s Eternal Ice'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -699,7 +699,7 @@ sigrismar_frag_II:
     Unbreakable: true
 sigrismar_frag_III:
   Id: amethyst_shard
-  Display: '&6&6[ III ] Sigrismarr`s Eternal Ice'
+  Display: '&6&6[ III ] Sigrosmar`s Eternal Ice'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -712,7 +712,7 @@ sigrismar_frag_III:
 
 medusa_frag_I:
   Id: scute
-  Display: '&9[ I ] M`Edusa Stone Scales'
+  Display: '&9[ I ] M`Edara Stone Scales'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -724,7 +724,7 @@ medusa_frag_I:
     Unbreakable: true
 medusa_frag_II:
   Id: scute
-  Display: '&5[ II ] M`Edusa Stone Scales'
+  Display: '&5[ II ] M`Edara Stone Scales'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -736,7 +736,7 @@ medusa_frag_II:
     Unbreakable: true
 medusa_frag_III:
   Id: scute
-  Display: '&6&6[ III ] M`Edusa Stone Scales'
+  Display: '&6&6[ III ] M`Edara Stone Scales'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -749,7 +749,7 @@ medusa_frag_III:
 
 gorga_frag_I:
   Id: lightning_rod
-  Display: '&9[ I ] Gorga`s Broken Tooth'
+  Display: '&9[ I ] Gorgra`s Broken Tooth'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -761,7 +761,7 @@ gorga_frag_I:
     Unbreakable: true
 gorga_frag_II:
   Id: lightning_rod
-  Display: '&5[ II ] Gorga`s Broken Tooth'
+  Display: '&5[ II ] Gorgra`s Broken Tooth'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -773,7 +773,7 @@ gorga_frag_II:
     Unbreakable: true
 gorga_frag_III:
   Id: lightning_rod
-  Display: '&6&6[ III ] Gorga`s Broken Tooth'
+  Display: '&6&6[ III ] Gorgra`s Broken Tooth'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -786,7 +786,7 @@ gorga_frag_III:
 
 mortis_frag_I:
   Id: bone
-  Display: '&9[ I ] Mortis Sacrificial Bones'
+  Display: '&9[ I ] Mortrix Sacrificial Bones'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -798,7 +798,7 @@ mortis_frag_I:
     Unbreakable: true
 mortis_frag_II:
   Id: bone
-  Display: '&5[ II ] Mortis Sacrificial Bones'
+  Display: '&5[ II ] Mortrix Sacrificial Bones'
   Group: Crafting
   Enchantments:
     - DURABILITY:10
@@ -810,7 +810,7 @@ mortis_frag_II:
     Unbreakable: true
 mortis_frag_III:
   Id: bone
-  Display: '&6&6[ III ] Mortis Sacrificial Bones'
+  Display: '&6&6[ III ] Mortrix Sacrificial Bones'
   Group: Crafting
   Enchantments:
     - DURABILITY:10

--- a/mobs/Map_Great_Desert_46-50.yml
+++ b/mobs/Map_Great_Desert_46-50.yml
@@ -63,7 +63,7 @@ serpent_spitter:
 scarab_knephre:
   Type: ZOMBIE
   Disguise: COW
-  Display: '&5&l Knephres Scarabeus&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&l Kenphros Scarabeus&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 4000
   Damage: 400
   Options:

--- a/mobs/Map_Stalgard_36-40.yml
+++ b/mobs/Map_Stalgard_36-40.yml
@@ -121,7 +121,7 @@ t_1000:
 
 high_priest_danzo:
   Type: ZOMBIE
-  Display: '&5&l High Priest Danzo&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&l High Priest Danru&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2500
   Damage: 375
   Options:

--- a/mobs/Map_Temple_sector_31-35.yml
+++ b/mobs/Map_Temple_sector_31-35.yml
@@ -89,7 +89,7 @@ gorgon_heretic:
 
 high_priest_baran:
   Type: ZOMBIE
-  Display: '&5&l High Priest Gorgon B`aran&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&l High Priest Gorgon Barun&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 1000
   Damage: 250
   Options:

--- a/mobs/Tetaconetl_61-70.yml
+++ b/mobs/Tetaconetl_61-70.yml
@@ -93,7 +93,7 @@ obstinate_toltec_shaman:
 quacking_orbax:
   Type: ZOMBIE
   Disguise: SLIME
-  Display: '&5&l Quacking Orbax&r &l[&4<caster.hp{round=2}>&r&l/&4&l<caster.mhp>&r&l]&r &4<&heart>'
+  Display: '&5&l Quarling Orbax&r &l[&4<caster.hp{round=2}>&r&l/&4&l<caster.mhp>&r&l]&r &4<&heart>'
   Health: 2500
   Damage: 100
   Armor: 0

--- a/mobs/fishing.yml
+++ b/mobs/fishing.yml
@@ -1,11 +1,11 @@
 Kraken_AbyssalTerror:
   Type: ZOMBIE
-  Display: '&4<&skull> &lKraken, Abyssal Terror &4<&skull>'
+  Display: '&4<&skull> &lKrakar, Abyssal Horror &4<&skull>'
   Health: 90000          # ~70–100k
   Damage: 2000           # bazowy kontaktowy
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Kraken, Abyssal Terror - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Krakar, Abyssal Horror - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: RED
     Style: SEGMENTED_12

--- a/mobs/mine_mobs.yml
+++ b/mobs/mine_mobs.yml
@@ -29,7 +29,7 @@ cursed_miner_mine:
 
 deepmine_overseer_kragg:
   Type: WITHER_SKELETON
-  Display: '&4<&skull> &lOverseer Kragg &r&4<&skull>'
+  Display: '&4<&skull> &lOverseer Kraggar &r&4<&skull>'
   Health: 20000
   Damage: 500
   BossBar:

--- a/mobs/q10_blood.yml
+++ b/mobs/q10_blood.yml
@@ -113,7 +113,7 @@ combat_ready_zorlobb_blood:
 
 melas_the_swift_footed_blood:
   Type: ZOMBIE
-  Display: '&5&lMelas the Swift-Footed &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMelan the Swiftstride &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 750    # 5x150
   Faction: q10_blood
@@ -266,7 +266,7 @@ mordacious_khaross_blood:
 
 akheilos_blood:
   Type: ZOMBIE
-  Display: '&5&lAkheilos &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAkhelion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 1000   # 5x200
   Faction: q10_blood
@@ -299,14 +299,14 @@ akheilos_blood:
 # Mission 3 Boss
 parallel_world_gorga_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lGorga &r&4<&skull>'
+  Display: '&4<&skull> &lGorgra &r&4<&skull>'
   Health: 50000  # 10x5000
   Damage: 1000   # 5x200
   Faction: q10_blood
   Group: q10_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Gorga - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Gorgra - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q10_hell.yml
+++ b/mobs/q10_hell.yml
@@ -113,7 +113,7 @@ combat_ready_zorlobb_hell:
 
 melas_the_swift_footed_hell:
   Type: ZOMBIE
-  Display: '&5&lMelas the Swift-Footed &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMelan the Swiftstride &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # 3x2000
   Damage: 300   # 2x150
   Faction: q10_hell
@@ -266,7 +266,7 @@ mordacious_khaross_hell:
 
 akheilos_hell:
   Type: ZOMBIE
-  Display: '&5&lAkheilos &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAkhelion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # 3x2000
   Damage: 400   # 2x200
   Faction: q10_hell
@@ -299,14 +299,14 @@ akheilos_hell:
 # Mission 3 Boss
 parallel_world_gorga_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lGorga &r&4<&skull>'
+  Display: '&4<&skull> &lGorgra &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 400    # 2x200
   Faction: q10_hell
   Group: q10_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Gorga - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Gorgra - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q10_inf.yml
+++ b/mobs/q10_inf.yml
@@ -113,7 +113,7 @@ combat_ready_zorlobb_inf:
 
 melas_the_swift_footed_inf:
   Type: ZOMBIE
-  Display: '&5&lMelas the Swift-Footed &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMelan the Swiftstride &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000  # Mini-boss HP
   Damage: 150   # Medium damage
   Faction: q10_inf
@@ -266,7 +266,7 @@ mordacious_khaross_inf:
 
 akheilos_inf:
   Type: ZOMBIE
-  Display: '&5&lAkheilos &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAkhelion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000  # Mini-boss HP
   Damage: 200   # High damage
   Faction: q10_inf
@@ -299,14 +299,14 @@ akheilos_inf:
 # Mission 3 Boss
 parallel_world_gorga_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lGorga &r&4<&skull>'
+  Display: '&4<&skull> &lGorgra &r&4<&skull>'
   Health: 5000  # Boss HP
   Damage: 200   # Base damage
   Faction: q10_inf
   Group: q10_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Gorga - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Gorgra - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q1_blood.yml
+++ b/mobs/q1_blood.yml
@@ -93,7 +93,7 @@ flamecult_worshipper_blood:
 
 perral_world_dragonknight_blood:
   Type: SKELETON
-  Display: '&5&lPerral World Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000
   Damage: 750
   Options:
@@ -128,7 +128,7 @@ perral_world_dragonknight_blood:
 
 raazghul_the_corruptor_blood:
   Type: ZOMBIE
-  Display: '&5&lRaazghul the Corruptor&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lRaazgor the Corrupter&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000
   Damage: 1250
   Options:
@@ -162,12 +162,12 @@ raazghul_the_corruptor_blood:
 
 grimmag_blood:
   Type: ZOMBIE
-  Display: '&4 <&skull> &l Grimmag the Risen&r&4 <&skull>'
+  Display: '&4 <&skull> &l Grimmor the Risen&r&4 <&skull>'
   Health: 50000
   Damage: 1500
   BossBar:
     Enabled: true
-    Title: ' &c<&skull> Grimmag the Risen - <mob.hp{round=0}> <&skull>'
+    Title: ' &c<&skull> Grimmor the Risen - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: RED
     Style: SEGMENTED_12

--- a/mobs/q1_hell.yml
+++ b/mobs/q1_hell.yml
@@ -93,7 +93,7 @@ flamecult_worshipper_hell:
 
 perral_world_dragonknight_hell:
   Type: SKELETON
-  Display: '&5&lPerral World Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000
   Damage: 300
   Options:
@@ -128,7 +128,7 @@ perral_world_dragonknight_hell:
 
 raazghul_the_corruptor_hell:
   Type: ZOMBIE
-  Display: '&5&lRaazghul the Corruptor&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lRaazgor the Corrupter&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000
   Damage: 500
   Options:
@@ -162,12 +162,12 @@ raazghul_the_corruptor_hell:
 
 grimmag_hell:
   Type: ZOMBIE
-  Display: '&4 <&skull> &l Grimmag the Risen&r&4 <&skull>'
+  Display: '&4 <&skull> &l Grimmor the Risen&r&4 <&skull>'
   Health: 15000
   Damage: 600
   BossBar:
     Enabled: true
-    Title: ' &c<&skull> Grimmag the Risen - <mob.hp{round=0}> <&skull>'
+    Title: ' &c<&skull> Grimmor the Risen - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: PURPLE
     Style: SEGMENTED_12

--- a/mobs/q1_inf.yml
+++ b/mobs/q1_inf.yml
@@ -93,7 +93,7 @@ flamecult_worshipper_inf:
 
 perral_world_dragonknight_inf:
   Type: SKELETON
-  Display: '&5&lPerral World Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dragonknight&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 150
   Options:
@@ -127,7 +127,7 @@ perral_world_dragonknight_inf:
 
 raazghul_the_corruptor_inf:
   Type: ZOMBIE
-  Display: '&5&lRaazghul the Corruptor&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lRaazgor the Corrupter&r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000
   Damage: 250
   Options:
@@ -161,12 +161,12 @@ raazghul_the_corruptor_inf:
 
 grimmag_inf:
   Type: ZOMBIE
-  Display: '&4 <&skull> &l Grimmag the Risen&r&4 <&skull>'
+  Display: '&4 <&skull> &l Grimmor the Risen&r&4 <&skull>'
   Health: 5000
   Damage: 300
   BossBar:
     Enabled: true
-    Title: ' &c<&skull> Grimmag the Risen - <mob.hp{round=0}> <&skull>'
+    Title: ' &c<&skull> Grimmor the Risen - <mob.hp{round=0}> <&skull>'
     Range: 50
     Color: BLUE
     Style: SEGMENTED_12

--- a/mobs/q2_blood.yml
+++ b/mobs/q2_blood.yml
@@ -114,7 +114,7 @@ corrupted_root_creature_blood:
     - leather_boots{color=green} FEET
 xerib_the_hunchback_blood:
   Type: WITCH
-  Display: '&5&lXerib the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lXerath the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # x10 Zdrowie
   Damage: 300    # x5 Obrażenia
   Faction: q2_blood
@@ -143,7 +143,7 @@ xerib_the_hunchback_blood:
 archus_the_mad_blood:
   Type: ZOMBIE
   Disguise: HUSK
-  Display: '&5&lArchus the Mad &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lArchaz the Madcap &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # x10 Zdrowie
   Damage: 400    # x5 Obrażenia
   Faction: q2_blood
@@ -172,14 +172,14 @@ archus_the_mad_blood:
 arachna_scourge_of_duria_blood:
   Type: ZOMBIE
   Disguise: SPIDER
-  Display: '&4<&skull> &lArachna, Scourge of Duria&r &4<&skull>'
+  Display: '&4<&skull> &lAraksha, Bane of Durion&r &4<&skull>'
   Health: 50000  # x10 Zdrowie
   Damage: 500
   Faction: q2_blood
   Group: q2_blood # x5 Obrażenia
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Arachna - &c<mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Araksha - &c<mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q2_hell.yml
+++ b/mobs/q2_hell.yml
@@ -115,7 +115,7 @@ corrupted_root_creature_hell:
 
 xerib_the_hunchback_hell:
   Type: WITCH
-  Display: '&5&lXerib the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lXerath the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # x3 Zdrowie
   Damage: 120   # x2 Obrażenia
   Faction: q2_hell
@@ -144,7 +144,7 @@ xerib_the_hunchback_hell:
 archus_the_mad_hell:
   Type: ZOMBIE
   Disguise: HUSK
-  Display: '&5&lArchus the Mad &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lArchaz the Madcap &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # x3 Zdrowie
   Damage: 160   # x2 Obrażenia
   Faction: q2_hell
@@ -173,14 +173,14 @@ archus_the_mad_hell:
 arachna_scourge_of_duria_hell:
   Type: ZOMBIE
   Disguise: SPIDER
-  Display: '&4<&skull> &lArachna, Scourge of Duria &r&4<&skull>'
+  Display: '&4<&skull> &lAraksha, Bane of Durion &r&4<&skull>'
   Health: 15000  # x3 Zdrowie
   Damage: 200    # x2 Obrażenia
   Faction: q2_hell
   Group: q2_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Arachna - &c<mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Araksha - &c<mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q2_inf.yml
+++ b/mobs/q2_inf.yml
@@ -115,7 +115,7 @@ corrupted_root_creature_inf:
 
 xerib_the_hunchback_inf:
   Type: WITCH
-  Display: '&5&lXerib the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lXerath the Hunchback &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000
   Damage: 60
   Faction: q2_inf
@@ -145,7 +145,7 @@ xerib_the_hunchback_inf:
 archus_the_mad_inf:
   Type: ZOMBIE
   Disguise: HUSK
-  Display: '&5&lArchus the Mad &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lArchaz the Madcap &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 80
   Faction: q2_inf
@@ -173,14 +173,14 @@ archus_the_mad_inf:
 arachna_scourge_of_duria_inf:
   Type: ZOMBIE
   Disguise: SPIDER
-  Display: '&4<&skull> &lArachna, Scourge of Duria &r&4<&skull>'
+  Display: '&4<&skull> &lAraksha, Bane of Durion &r&4<&skull>'
   Health: 5000
   Damage: 100
   Faction: q2_inf
   Group: q2_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Arachna - &c<mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Araksha - &c<mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q3_blood.yml
+++ b/mobs/q3_blood.yml
@@ -96,7 +96,7 @@ cursed_archer_blood:
 
 parallel_world_evil_miller_blood:
   Type: ZOMBIE
-  Display: '&5&lParallel World Evil Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dire Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 750    # 5x150
   Faction: q3_blood
@@ -225,7 +225,7 @@ slain_archer_blood:
 
 the_bloody_arrow_blood:
   Type: SKELETON
-  Display: '&5&lThe Bloody Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lThe Crimson Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 15000  # 10x1500
   Damage: 900    # 5x180
   Faction: q3_blood
@@ -259,14 +259,14 @@ the_bloody_arrow_blood:
 
 undead_parallel_world_king_heredur_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lUndead King Heredur &r&4<&skull>'
+  Display: '&4<&skull> &lUndead King Heredorn &r&4<&skull>'
   Health: 60000  # 10x3000
   Damage: 1000   # 5x200
   Faction: q3_blood
   Group: q3_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> King Heredur - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> King Heredorn - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q3_hell.yml
+++ b/mobs/q3_hell.yml
@@ -96,7 +96,7 @@ cursed_archer_hell:
 
 parallel_world_evil_miller_hell:
   Type: ZOMBIE
-  Display: '&5&lParallel World Evil Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dire Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000   # 3x2000
   Damage: 300    # 2x150
   Faction: q3_hell
@@ -225,7 +225,7 @@ slain_archer_hell:
 
 the_bloody_arrow_hell:
   Type: SKELETON
-  Display: '&5&lThe Bloody Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lThe Crimson Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 4500   # 3x1500
   Damage: 360    # 2x180
   Faction: q3_hell
@@ -259,14 +259,14 @@ the_bloody_arrow_hell:
 
 undead_parallel_world_king_heredur_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lUndead King Heredur &r&4<&skull>'
+  Display: '&4<&skull> &lUndead King Heredorn &r&4<&skull>'
   Health: 9000
   Damage: 400
   Faction: q3_hell
   Group: q3_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> King Heredur - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> King Heredorn - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q3_inf.yml
+++ b/mobs/q3_inf.yml
@@ -96,7 +96,7 @@ cursed_archer_inf:
 
 parallel_world_evil_miller_inf:
   Type: ZOMBIE
-  Display: '&5&lParallel World Evil Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lParallel Realm Dire Miller &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000
   Damage: 150
   Faction: q3_inf
@@ -225,7 +225,7 @@ slain_archer_inf:
 
 the_bloody_arrow_inf:
   Type: SKELETON
-  Display: '&5&lThe Bloody Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lThe Crimson Arrow &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 1500
   Damage: 180
   Faction: q3_inf
@@ -259,14 +259,14 @@ the_bloody_arrow_inf:
 
 undead_parallel_world_king_heredur_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lUndead King Heredur &r&4<&skull>'
+  Display: '&4<&skull> &lUndead King Heredorn &r&4<&skull>'
   Health: 3000
   Damage: 200
   Faction: q3_inf
   Group: q3_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> King Heredur - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> King Heredorn - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q4_blood.yml
+++ b/mobs/q4_blood.yml
@@ -264,7 +264,7 @@ eternal_hunting_hound_blood:
 ulgar_the_master_butcher_phase1_blood:
   Type: ZOMBIE
   Disguise: PIGLIN
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 20000  # 10x2000
   Damage: 1500   # 5x300
   Faction: q4_blood
@@ -291,7 +291,7 @@ ulgar_the_master_butcher_phase1_blood:
 ulgar_the_master_butcher_phase2_blood:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 25000  # 10x2500
   Damage: 1750   # 5x350
   Faction: q4_blood
@@ -318,7 +318,7 @@ ulgar_the_master_butcher_phase2_blood:
 ulgar_the_master_butcher_phase3_blood:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 2000   # 5x400
   Faction: q4_blood
@@ -346,14 +346,14 @@ ulgar_the_master_butcher_phase3_blood:
 
 bearach_champion_of_wilds_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lBearach, Champion of the Wilds &r&4<&skull>'
+  Display: '&4<&skull> &lBearok, Guardian of the Wilds &r&4<&skull>'
   Health: 30000  # 10x3000
   Damage: 1250   # 5x250
   Faction: q4_blood
   Group: q4_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Bearach - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Bearok - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q4_hell.yml
+++ b/mobs/q4_hell.yml
@@ -262,7 +262,7 @@ eternal_hunting_hound_hell:
 ulgar_the_master_butcher_phase1_hell:
   Type: ZOMBIE
   Disguise: PIGLIN
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 6000  # 3x2000
   Damage: 600   # 2x300
   Faction: q4_hell
@@ -289,7 +289,7 @@ ulgar_the_master_butcher_phase1_hell:
 ulgar_the_master_butcher_phase2_hell:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 7500  # 3x2500
   Damage: 700   # 2x350
   Faction: q4_hell
@@ -316,7 +316,7 @@ ulgar_the_master_butcher_phase2_hell:
 ulgar_the_master_butcher_phase3_hell:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 800   # 2x400
   Faction: q4_hell
@@ -344,14 +344,14 @@ ulgar_the_master_butcher_phase3_hell:
 
 bearach_champion_of_wilds_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lBearach, Champion of the Wilds &r&4<&skull>'
+  Display: '&4<&skull> &lBearok, Guardian of the Wilds &r&4<&skull>'
   Health: 9000  # 3x3000
   Damage: 500   # 2x250
   Faction: q4_hell
   Group: q4_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Bearach - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Bearok - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q4_inf.yml
+++ b/mobs/q4_inf.yml
@@ -262,7 +262,7 @@ eternal_hunting_hound_inf:
 ulgar_the_master_butcher_phase1_inf:
   Type: ZOMBIE
   Disguise: PIGLIN
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2000  # Mini-boss phase 1
   Damage: 300
   Faction: q4_inf
@@ -289,7 +289,7 @@ ulgar_the_master_butcher_phase1_inf:
 ulgar_the_master_butcher_phase2_inf:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 2500  # Mini-boss phase 2
   Damage: 350
   Faction: q4_inf
@@ -316,7 +316,7 @@ ulgar_the_master_butcher_phase2_inf:
 ulgar_the_master_butcher_phase3_inf:
   Type: ZOMBIE
   Disguise: PIGLIN_BRUTE
-  Display: '&5&lUlgar the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lUlgrom the Master Butcher &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000  # Mini-boss phase 3
   Damage: 400
   Faction: q4_inf
@@ -344,14 +344,14 @@ ulgar_the_master_butcher_phase3_inf:
 
 bearach_champion_of_wilds_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lBearach, Champion of the Wilds &r&4<&skull>'
+  Display: '&4<&skull> &lBearok, Guardian of the Wilds &r&4<&skull>'
   Health: 3000
   Damage: 250
   Faction: q4_inf
   Group: q4_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Bearach - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Bearok - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q5_blood.yml
+++ b/mobs/q5_blood.yml
@@ -286,14 +286,14 @@ wandering_experiment_blood:
 khalys_leader_of_cultists_blood:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4<&skull> &lKhalys, Leader of the Cultists &r&4<&skull>'
+  Display: '&4<&skull> &lKalith, Matriarch of the Cult &r&4<&skull>'
   Health: 30000 # 10x3000
   Damage: 1000 # 5x200
   Faction: q5_blood
   Group: q5_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Khalys - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Kalith - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:
@@ -326,7 +326,7 @@ khalys_leader_of_cultists_blood:
 khalys_clone_blood:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4Khalys Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
+  Display: '&4Kalith Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
   Health: 3000 # 10x300
   Damage: 500 # 5x100
   Faction: q5_blood

--- a/mobs/q5_hell.yml
+++ b/mobs/q5_hell.yml
@@ -286,14 +286,14 @@ wandering_experiment_hell:
 khalys_leader_of_cultists_hell:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4<&skull> &lKhalys, Leader of the Cultists &r&4<&skull>'
+  Display: '&4<&skull> &lKalith, Matriarch of the Cult &r&4<&skull>'
   Health: 9000 # 3x3000
   Damage: 400 # 2x200
   Faction: q5_hell
   Group: q5_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Khalys - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Kalith - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:
@@ -326,7 +326,7 @@ khalys_leader_of_cultists_hell:
 khalys_clone_hell:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4Khalys Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
+  Display: '&4Kalith Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
   Health: 900 # 3x300
   Damage: 200 # 2x100
   Faction: q5_hell

--- a/mobs/q5_inf.yml
+++ b/mobs/q5_inf.yml
@@ -286,14 +286,14 @@ wandering_experiment_inf:
 khalys_leader_of_cultists_inf:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4<&skull> &lKhalys, Leader of the Cultists &r&4<&skull>'
+  Display: '&4<&skull> &lKalith, Matriarch of the Cult &r&4<&skull>'
   Health: 3000
   Damage: 200
   Faction: q5_inf
   Group: q5_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Khalys - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Kalith - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -326,7 +326,7 @@ khalys_leader_of_cultists_inf:
 khalys_clone_inf:
   Type: ZOMBIE
   Disguise: WITCH
-  Display: '&4Khalys Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
+  Display: '&4Kalith Clone &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7]'
   Health: 300 # 10% of original
   Damage: 100 # 50% of original
   Faction: q5_inf

--- a/mobs/q6_blood.yml
+++ b/mobs/q6_blood.yml
@@ -93,7 +93,7 @@ death_knight_blood:
 
 mortis_death_knight_blood:
   Type: SKELETON
-  Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMortrix Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1500  # 5x300
   Faction: q6_blood
@@ -251,7 +251,7 @@ elite_skeleton_warrior_blood:
 
 murot_high_priest_blood:
   Type: SKELETON
-  Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMurond, High Priest of Mortrix &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000
   Damage: 1000
   Faction: q6_blood
@@ -287,14 +287,14 @@ murot_high_priest_blood:
 skeledragon_phase1_blood:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lBonewyrm &r&4<&skull>'
   Health: 50000
   Damage: 1500
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
+    Title: '&c<&skull> Bonewyrm - Phase 1 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -319,14 +319,14 @@ skeledragon_phase1_blood:
 skeledragon_phase2_blood:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix & Bonewyrm &r&4<&skull>'
   Health: 70000
   Damage: 2000
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
+    Title: '&c<&skull> Mortrix & Bonewyrm - Phase 2 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -352,14 +352,14 @@ skeledragon_phase2_blood:
 
 mortis_phase3_blood:
   Type: SKELETON
-  Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix, Unbound God of Death &r&4<&skull>'
   Health: 100000
   Damage: 2500
   Faction: q6_blood
   Group: q6_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis - Final Phase <&skull>'
+    Title: '&c<&skull> Mortrix - Final Phase <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q6_hell.yml
+++ b/mobs/q6_hell.yml
@@ -93,7 +93,7 @@ death_knight_hell:
 
 mortis_death_knight_hell:
   Type: SKELETON
-  Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMortrix Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 600   # 2x300
   Faction: q6_hell
@@ -251,7 +251,7 @@ elite_skeleton_warrior_hell:
 
 murot_high_priest_hell:
   Type: SKELETON
-  Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMurond, High Priest of Mortrix &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000
   Damage: 400
   Faction: q6_hell
@@ -287,14 +287,14 @@ murot_high_priest_hell:
 skeledragon_phase1_hell:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lBonewyrm &r&4<&skull>'
   Health: 15000
   Damage: 600
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
+    Title: '&c<&skull> Bonewyrm - Phase 1 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -319,14 +319,14 @@ skeledragon_phase1_hell:
 skeledragon_phase2_hell:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix & Bonewyrm &r&4<&skull>'
   Health: 21000
   Damage: 800
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
+    Title: '&c<&skull> Mortrix & Bonewyrm - Phase 2 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -352,14 +352,14 @@ skeledragon_phase2_hell:
 
 mortis_phase3_hell:
   Type: SKELETON
-  Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix, Unbound God of Death &r&4<&skull>'
   Health: 30000
   Damage: 1000
   Faction: q6_hell
   Group: q6_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis - Final Phase <&skull>'
+    Title: '&c<&skull> Mortrix - Final Phase <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q6_inf.yml
+++ b/mobs/q6_inf.yml
@@ -93,7 +93,7 @@ death_knight_inf:
 
 mortis_death_knight_inf:
   Type: SKELETON
-  Display: '&5&lMortis Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMortrix Death Knight &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 300
   Faction: q6_inf
@@ -251,7 +251,7 @@ elite_skeleton_warrior_inf:
 
 murot_high_priest_inf:
   Type: SKELETON
-  Display: '&5&lMurot, High Priest of Mortis &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lMurond, High Priest of Mortrix &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 200
   Faction: q6_inf
@@ -287,14 +287,14 @@ murot_high_priest_inf:
 skeledragon_phase1_inf:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lSkeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lBonewyrm &r&4<&skull>'
   Health: 5000
   Damage: 300
   Faction: q6_inf
   Group: q6_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Skeledragon - Phase 1 <&skull>'
+    Title: '&c<&skull> Bonewyrm - Phase 1 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -319,14 +319,14 @@ skeledragon_phase1_inf:
 skeledragon_phase2_inf:
   Type: Zombie
   Disguise: Horse
-  Display: '&4<&skull> &lMortis & Skeledragon &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix & Bonewyrm &r&4<&skull>'
   Health: 7000
   Damage: 400
   Faction: q6_inf
   Group: q6_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis & Skeledragon - Phase 2 <&skull>'
+    Title: '&c<&skull> Mortrix & Bonewyrm - Phase 2 <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:
@@ -352,14 +352,14 @@ skeledragon_phase2_inf:
 
 mortis_phase3_inf:
   Type: SKELETON
-  Display: '&4<&skull> &lMortis, Unchained God of Death &r&4<&skull>'
+  Display: '&4<&skull> &lMortrix, Unbound God of Death &r&4<&skull>'
   Health: 10000
   Damage: 500
   Faction: q6_inf
   Group: q6_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Mortis - Final Phase <&skull>'
+    Title: '&c<&skull> Mortrix - Final Phase <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q7_blood.yml
+++ b/mobs/q7_blood.yml
@@ -252,7 +252,7 @@ angry_flamespawn_blood:
 
 commander_embersword_blood:
   Type: ZOMBIE
-  Display: '&5&lCommander Embersword &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lCommander Emberblade &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1250   # 5x250
   Faction: q7_blood
@@ -286,14 +286,14 @@ commander_embersword_blood:
 # Mission 3 Boss
 herald_of_anderworld_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lHerald of the Anderworld &r&4<&skull>'
+  Display: '&4<&skull> &lHarbinger of the Anderrealm &r&4<&skull>'
   Health: 50000  # 10x5000
   Damage: 0      # Uses skills for damage
   Faction: q7_blood
   Group: q7_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Herald of the Anderworld - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Harbinger of the Anderrealm - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q7_hell.yml
+++ b/mobs/q7_hell.yml
@@ -252,7 +252,7 @@ angry_flamespawn_hell:
 
 commander_embersword_hell:
   Type: ZOMBIE
-  Display: '&5&lCommander Embersword &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lCommander Emberblade &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 500   # 2x250
   Faction: q7_hell
@@ -286,14 +286,14 @@ commander_embersword_hell:
 # Mission 3 Boss
 herald_of_anderworld_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lHerald of the Anderworld &r&4<&skull>'
+  Display: '&4<&skull> &lHarbinger of the Anderrealm &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 0      # Uses skills for damage
   Faction: q7_hell
   Group: q7_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Herald of the Anderworld - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Harbinger of the Anderrealm - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q7_inf.yml
+++ b/mobs/q7_inf.yml
@@ -252,7 +252,7 @@ angry_flamespawn_inf:
 
 commander_embersword_inf:
   Type: ZOMBIE
-  Display: '&5&lCommander Embersword &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lCommander Emberblade &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000
   Damage: 250
   Faction: q7_inf
@@ -286,14 +286,14 @@ commander_embersword_inf:
 # Mission 3 Boss
 herald_of_anderworld_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lHerald of the Anderworld &r&4<&skull>'
+  Display: '&4<&skull> &lHarbinger of the Anderrealm &r&4<&skull>'
   Health: 5000
   Damage: 0
   Faction: q7_inf
   Group: q7_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Herald of the Anderworld - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Harbinger of the Anderrealm - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q8_blood.yml
+++ b/mobs/q8_blood.yml
@@ -334,14 +334,14 @@ pale_enforcer_blood:
 
 sigrismarr_priest_of_fjalnir_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lSigrismarr, Twisted Priest of Fjalnir &r&4<&skull>'
+  Display: '&4<&skull> &lSigrosmar, Twisted Priest of Fjolnar &r&4<&skull>'
   Health: 50000
   Damage: 0
   Faction: q8_blood
   Group: q8_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Sigrismarr - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Sigrosmar - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q8_hell.yml
+++ b/mobs/q8_hell.yml
@@ -337,14 +337,14 @@ pale_enforcer_hell:
 # Mission 3 Boss
 sigrismarr_priest_of_fjalnir_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lSigrismarr, Twisted Priest of Fjalnir &r&4<&skull>'
+  Display: '&4<&skull> &lSigrosmar, Twisted Priest of Fjolnar &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 0      # Uses skills for damage
   Faction: q8_hell
   Group: q8_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Sigrismarr - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Sigrosmar - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q8_inf.yml
+++ b/mobs/q8_inf.yml
@@ -337,14 +337,14 @@ pale_enforcer_inf:
 # Mission 3 Boss
 sigrismarr_priest_of_fjalnir_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lSigrismarr, Twisted Priest of Fjalnir &r&4<&skull>'
+  Display: '&4<&skull> &lSigrosmar, Twisted Priest of Fjolnar &r&4<&skull>'
   Health: 5000
   Damage: 0  # Only uses skills for damage
   Faction: q8_inf
   Group: q8_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> Sigrismarr - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> Sigrosmar - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q9_blood.yml
+++ b/mobs/q9_blood.yml
@@ -122,7 +122,7 @@ stone_golem_blood:
 asterion_blood:
   Type: ZOMBIE
   Disguise: VINDICATOR
-  Display: '&5&lAsterion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAsteron &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1500   # 5x300
   Faction: q9_blood
@@ -276,7 +276,7 @@ minotaur_blood:
 
 ebicarus_blood:
   Type: ZOMBIE
-  Display: '&5&lEbicarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lEbidarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 30000  # 10x3000
   Damage: 1500   # 5x300
   Faction: q9_blood
@@ -308,14 +308,14 @@ ebicarus_blood:
 
 medusa_blood:
   Type: ZOMBIE
-  Display: '&4<&skull> &lM`Edusa &r&4<&skull>'
+  Display: '&4<&skull> &lM`Edara &r&4<&skull>'
   Health: 50000  # 10x5000
   Damage: 1000   # 5x200
   Faction: q9_blood
   Group: q9_blood
   BossBar:
     Enabled: true
-    Title: '&c<&skull> M`Edusa - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> M`Edara - <mob.hp{round=0}> <&skull>'
     Color: RED
     Style: SEGMENTED_12
   Options:

--- a/mobs/q9_hell.yml
+++ b/mobs/q9_hell.yml
@@ -122,7 +122,7 @@ stone_golem_hell:
 asterion_hell:
   Type: ZOMBIE
   Disguise: VINDICATOR
-  Display: '&5&lAsterion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAsteron &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 600   # 2x300
   Faction: q9_hell
@@ -276,7 +276,7 @@ minotaur_hell:
 
 ebicarus_hell:
   Type: ZOMBIE
-  Display: '&5&lEbicarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lEbidarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 9000  # 3x3000
   Damage: 600   # 2x300
   Faction: q9_hell
@@ -308,14 +308,14 @@ ebicarus_hell:
 
 medusa_hell:
   Type: ZOMBIE
-  Display: '&4<&skull> &lM`Edusa &r&4<&skull>'
+  Display: '&4<&skull> &lM`Edara &r&4<&skull>'
   Health: 15000  # 3x5000
   Damage: 400    # 2x200
   Faction: q9_hell
   Group: q9_hell
   BossBar:
     Enabled: true
-    Title: '&c<&skull> M`Edusa - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> M`Edara - <mob.hp{round=0}> <&skull>'
     Color: PURPLE
     Style: SEGMENTED_12
   Options:

--- a/mobs/q9_inf.yml
+++ b/mobs/q9_inf.yml
@@ -123,7 +123,7 @@ stone_golem_inf:
 asterion_inf:
   Type: ZOMBIE
   Disguise: VINDICATOR
-  Display: '&5&lAsterion &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lAsteron &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000  # Mini-boss HP
   Damage: 300   # High damage
   Faction: q9_inf
@@ -278,7 +278,7 @@ minotaur_inf:
 
 ebicarus_inf:
   Type: ZOMBIE
-  Display: '&5&lEbicarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Display: '&5&lEbidarus &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
   Health: 3000  # Mini-boss HP
   Damage: 300   # High damage
   Faction: q9_inf
@@ -311,14 +311,14 @@ ebicarus_inf:
 # Mission 3 Boss
 medusa_inf:
   Type: ZOMBIE
-  Display: '&4<&skull> &lM`Edusa &r&4<&skull>'
+  Display: '&4<&skull> &lM`Edara &r&4<&skull>'
   Health: 5000  # Boss HP
   Damage: 200   # Base damage
   Faction: q9_inf
   Group: q9_inf
   BossBar:
     Enabled: true
-    Title: '&c<&skull> M`Edusa - <mob.hp{round=0}> <&skull>'
+    Title: '&c<&skull> M`Edara - <mob.hp{round=0}> <&skull>'
     Color: BLUE
     Style: SEGMENTED_12
   Options:


### PR DESCRIPTION
## Summary
- align boss soul display names with the newly rethemed bosses from Grimmor through Gorgra
- update legendary crafting material display strings to reference the revised boss identities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d4a66884832a9cf74366db94afce