### PR TITLE
Add luck wrappers for world rare drops

### DIFF
--- a/droptables/Catacombs_6-10_drops.yml
+++ b/droptables/Catacombs_6-10_drops.yml
@@ -2,19 +2,27 @@ arisen:
   Drops:
     # - experience 10
     - arisen_item_drops 1
+    - arisen_rare_drops 1
 arisen_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - rusty_greatsword 1 0.05
     - profane_helmet 1 0.05
+
+arisen_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - used_club 1 0.01
     - bulwark_of_power 1 0.005
+    - nothing 1 0.985
 
 nefertari_priest:
   Drops:
     # - experience 10
     - nefertari_priest_item_drops 1
+    - nefertari_priest_rare_drops 1
 nefertari_priest_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -22,19 +30,32 @@ nefertari_priest_item_drops:
     - rusty_greatsword 1 0.075
     - profane_helmet 1 0.075
     - used_club 1 0.03
+
+nefertari_priest_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - bulwark_of_power 1 0.015
     - steps_of_destiny 1 0.005
+    - nothing 1 0.98
 
 nefertari_snooper:
   Drops:
     # - experience 10
     - tousled_priest_robe 1 0.25
     - nefertari_snooper_item_drops 1
+    - nefertari_snooper_rare_drops 1
 nefertari_snooper_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - used_club 1 0.08
+
+nefertari_snooper_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - bulwark_of_power 1 0.025
     - steps_of_destiny 1 0.015
     - leggings_of_valor 1 0.005
+    - nothing 1 0.955

--- a/droptables/Eternal_watch_21-25_drops.yml
+++ b/droptables/Eternal_watch_21-25_drops.yml
@@ -3,24 +3,30 @@ norse_gnome:
     # - experience 10
     - norse_gnome_item_drops 1
 norse_gnome_item_drops:
-  MinItems: 0
-  MaxItems: 1
+  TotalItems: 1
+  BonusLuckItems: 0.15
   Drops:
     - iced_needle 1 0.01
     - frostbound_helm 1 0.005
     - frostbound_chestplate 1 0.005
     - frostbound_leggings 1 0.005
     - frostbound_boots 1 0.005
+    - nothing 1 0.97
 
 frost_catcher:
   Drops:
     # - experience 10
     - frost_catcher_item_drops 1
+    - frost_catcher_rare_drops 1
 frost_catcher_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - iced_needle 1 0.03
+frost_catcher_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - frostbound_helm 1 0.015
     - frostbound_chestplate 1 0.015
     - frostbound_leggings 1 0.015
@@ -28,17 +34,23 @@ frost_catcher_item_drops:
     - frostbite_blade 1 0.005
     - chestplate_of_snow_tempest 1 0.005
     - windrunner_boots 1 0.005
+    - nothing 1 0.925
 
 frost_paw:
   Drops:
     # - experience 10
     - chain_fragment 1 0.25
     - frost_paw_item_drops 1
+    - frost_paw_rare_drops 1
 frost_paw_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - iced_needle 1 0.08
+frost_paw_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - frostbound_helm 1 0.025
     - frostbound_chestplate 1 0.025
     - frostbound_leggings 1 0.025
@@ -48,3 +60,4 @@ frost_paw_item_drops:
     - windrunner_boots 1 0.015
     - ymirs_wrath 1 0.005
     - snowstorm_conq_leggings 1 0.005
+    - nothing 1 0.845

--- a/droptables/Mystra_26-30_drops.yml
+++ b/droptables/Mystra_26-30_drops.yml
@@ -3,8 +3,8 @@ satyr:
     # - experience 10
     - satyr_item_drops 1
 satyr_item_drops:
-  MinItems: 0
-  MaxItems: 1
+  TotalItems: 1
+  BonusLuckItems: 0.15
   Drops:
     - dune_wrap 1 0.01
     - desert_sandals 1 0.01
@@ -12,16 +12,22 @@ satyr_item_drops:
     - sunfire_chestplate 1 0.005
     - flamecaller_scimitar 1 0.005
     - inferno_dagger 1 0.005
+    - nothing 1 0.95
 
 cyclops:
   Drops:
     # - experience 10
     - cyclops_item_drops 1
+    - cyclops_rare_drops 1
 cyclops_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - dune_wrap 1 0.03
+cyclops_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - desert_sandals 1 0.003
     - sandstorm_leggings 1 0.015
     - sunfire_chestplate 1 0.015
@@ -29,18 +35,24 @@ cyclops_item_drops:
     - inferno_dagger 1 0.015
     - eternal_ember_chestplate 1 0.005
     - flamewarden_helm 1 0.005
+    - nothing 1 0.927
 
 satyr_general:
   Drops:
     # - experience 10
     - satyrs_horn 1 0.25
     - satyr_general_item_drops 1
+    - satyr_general_rare_drops 1
 satyr_general_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - dune_wrap 1 0.08
     - desert_sandals 1 0.08
+satyr_general_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sandstorm_leggings 1 0.025
     - sunfire_chestplate 1 0.025
     - flamecaller_scimitar 1 0.025
@@ -49,3 +61,4 @@ satyr_general_item_drops:
     - flamewarden_helm 1 0.015
     - scorchweaver_leggings 1 0.005
     - doomsday_scythe 1 0.005
+    - nothing 1 0.835

--- a/droptables/OceanBones_91-100_drops.yml
+++ b/droptables/OceanBones_91-100_drops.yml
@@ -11,28 +11,39 @@ oceanbones_drop_items:
 cold_death_knight:
   Drops:
     - cold_death_knight_items 1
+    - cold_death_knight_rare_drops 1
 
 cold_death_knight_items:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.1
+cold_death_knight_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - death_knight_helmet 1 0.01
     - death_knight_chestplate 1 0.01
     - death_knight_leggings 1 0.01
     - death_knight_boots 1 0.01
     - death_knight_blade 1 0.01
+    - nothing 1 0.95
 
 death_knight_of_the_watch:
   Drops:
     - Throphy_of_the_long_forgotten_bone_dragon 1 0.1
     - death_knight_of_the_watch_items 1
+    - death_knight_of_the_watch_rare_drops 1
 
 death_knight_of_the_watch_items:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.2
+death_knight_of_the_watch_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - death_knight_helmet 1 0.02
     - death_knight_chestplate 1 0.02
     - death_knight_leggings 1 0.02
@@ -46,3 +57,4 @@ death_knight_of_the_watch_items:
     - aegis_of_dark_souls 1 0.0075
     - belt_of_the_death_knight 1 0.0075
     - gauntlets_of_shadow_grasp 1 0.0075
+    - nothing 1 0.8475

--- a/droptables/Q10_drops.yml
+++ b/droptables/Q10_drops.yml
@@ -5,6 +5,7 @@ anderworld_jitterjelly_inf_drop:
   Drops:
     - ips 1 0.01
     - anderworld_jitterjelly_inf_drop_item_drops 1
+    - anderworld_jitterjelly_inf_drop_rare_drops 1
 anderworld_jitterjelly_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ anderworld_jitterjelly_inf_drop_item_drops:
     - charming_belt_infernal 1 0.01
     - rookie_jacket_infernal 1 0.01
     - abyssal_treasure_gloves_infernal 1 0.01
+
+anderworld_jitterjelly_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.0005
+    - nothing 1 0.9995
 
 anderworld_jabbax_inf_drop:
   Drops:
     - ips 1 0.01
     - anderworld_jabbax_inf_drop_item_drops 1
+    - anderworld_jabbax_inf_drop_rare_drops 1
 anderworld_jabbax_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ anderworld_jabbax_inf_drop_item_drops:
     - charming_belt_infernal 1 0.01
     - rookie_jacket_infernal 1 0.01
     - abyssal_treasure_gloves_infernal 1 0.01
+
+anderworld_jabbax_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.0005
+    - nothing 1 0.9995
 
 combat_ready_zorlobb_inf_drop:
   Drops:
     - ips 1 0.01
     - combat_ready_zorlobb_inf_drop_item_drops 1
+    - combat_ready_zorlobb_inf_drop_rare_drops 1
 combat_ready_zorlobb_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ combat_ready_zorlobb_inf_drop_item_drops:
     - charming_belt_infernal 1 0.01
     - rookie_jacket_infernal 1 0.01
     - abyssal_treasure_gloves_infernal 1 0.01
+
+combat_ready_zorlobb_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.0005
+    - nothing 1 0.9995
 
 armed_khaross_inf_drop:
   Drops:
     - ips 1 0.01
     - armed_khaross_inf_drop_item_drops 1
+    - armed_khaross_inf_drop_rare_drops 1
 armed_khaross_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ armed_khaross_inf_drop_item_drops:
     - charming_belt_infernal 1 0.01
     - rookie_jacket_infernal 1 0.01
     - abyssal_treasure_gloves_infernal 1 0.01
+
+armed_khaross_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.0005
+    - nothing 1 0.9995
 
 mordacious_khaross_inf_drop:
   Drops:
     - ips 1 0.01
     - mordacious_khaross_inf_drop_item_drops 1
+    - mordacious_khaross_inf_drop_rare_drops 1
 mordacious_khaross_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -64,12 +93,19 @@ mordacious_khaross_inf_drop_item_drops:
     - charming_belt_infernal 1 0.01
     - rookie_jacket_infernal 1 0.01
     - abyssal_treasure_gloves_infernal 1 0.01
+
+mordacious_khaross_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.0005
+    - nothing 1 0.9995
 
 scheming_gorgon_inf_drop:
   Drops:
     - ips 1 0.25
     - scheming_gorgon_inf_drop_item_drops 1
+    - scheming_gorgon_inf_drop_rare_drops 1
 scheming_gorgon_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -77,12 +113,19 @@ scheming_gorgon_inf_drop_item_drops:
     - charming_belt_infernal 1 0.25
     - rookie_jacket_infernal 1 0.25
     - abyssal_treasure_gloves_infernal 1 0.05
+
+scheming_gorgon_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.01
+    - nothing 1 0.99
 
 poisonous_jitterjelly_inf_drop:
   Drops:
     - ips 1 0.25
     - poisonous_jitterjelly_inf_drop_item_drops 1
+    - poisonous_jitterjelly_inf_drop_rare_drops 1
 poisonous_jitterjelly_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -90,12 +133,19 @@ poisonous_jitterjelly_inf_drop_item_drops:
     - charming_belt_infernal 1 0.25
     - rookie_jacket_infernal 1 0.25
     - abyssal_treasure_gloves_infernal 1 0.05
+
+poisonous_jitterjelly_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.01
+    - nothing 1 0.99
 
 patrolling_jabbax_inf_drop:
   Drops:
     - ips 1 0.25
     - patrolling_jabbax_inf_drop_item_drops 1
+    - patrolling_jabbax_inf_drop_rare_drops 1
 patrolling_jabbax_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -103,12 +153,19 @@ patrolling_jabbax_inf_drop_item_drops:
     - charming_belt_infernal 1 0.25
     - rookie_jacket_infernal 1 0.25
     - abyssal_treasure_gloves_infernal 1 0.05
+
+patrolling_jabbax_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.01
+    - nothing 1 0.99
 
 melas_inf_drop:
   Drops:
     - ips 1 0.5
     - melas_inf_drop_item_drops 1
+    - melas_inf_drop_rare_drops 1
 melas_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -116,12 +173,19 @@ melas_inf_drop_item_drops:
     - charming_belt_infernal 1 0.5
     - rookie_jacket_infernal 1 0.5
     - abyssal_treasure_gloves_infernal 1 0.1
+
+melas_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.04
+    - nothing 1 0.96
 
 akheilos_inf_drop:
   Drops:
     - ips 1 0.5
     - akheilos_inf_drop_item_drops 1
+    - akheilos_inf_drop_rare_drops 1
 akheilos_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -129,13 +193,20 @@ akheilos_inf_drop_item_drops:
     - charming_belt_infernal 1 0.5
     - rookie_jacket_infernal 1 0.5
     - abyssal_treasure_gloves_infernal 1 0.1
+
+akheilos_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.04
+    - nothing 1 0.96
 
 gorga_inf_drop:
   Drops:
     - gorga_frag_I 1 0.05
     - ips 1 1
     - gorga_inf_drop_item_drops 1
+    - gorga_inf_drop_rare_drops 1
 gorga_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -143,7 +214,13 @@ gorga_inf_drop_item_drops:
     - charming_belt_infernal 1 1
     - rookie_jacket_infernal 1 1
     - abyssal_treasure_gloves_infernal 1 0.25
+
+gorga_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -152,6 +229,7 @@ anderworld_jitterjelly_hell_drop:
   Drops:
     - ips 2 0.01
     - anderworld_jitterjelly_hell_drop_item_drops 1
+    - anderworld_jitterjelly_hell_drop_rare_drops 1
 anderworld_jitterjelly_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -159,12 +237,19 @@ anderworld_jitterjelly_hell_drop_item_drops:
     - charming_belt_hell 1 0.01
     - rookie_jacket_hell 1 0.01
     - abyssal_treasure_gloves_hell 1 0.02
+
+anderworld_jitterjelly_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.001
+    - nothing 1 0.999
 
 anderworld_jabbax_hell_drop:
   Drops:
     - ips 2 0.01
     - anderworld_jabbax_hell_drop_item_drops 1
+    - anderworld_jabbax_hell_drop_rare_drops 1
 anderworld_jabbax_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -172,12 +257,19 @@ anderworld_jabbax_hell_drop_item_drops:
     - charming_belt_hell 1 0.01
     - rookie_jacket_hell 1 0.01
     - abyssal_treasure_gloves_hell 1 0.02
+
+anderworld_jabbax_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.001
+    - nothing 1 0.999
 
 combat_ready_zorlobb_hell_drop:
   Drops:
     - ips 2 0.01
     - combat_ready_zorlobb_hell_drop_item_drops 1
+    - combat_ready_zorlobb_hell_drop_rare_drops 1
 combat_ready_zorlobb_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -185,12 +277,19 @@ combat_ready_zorlobb_hell_drop_item_drops:
     - charming_belt_hell 1 0.01
     - rookie_jacket_hell 1 0.01
     - abyssal_treasure_gloves_hell 1 0.02
+
+combat_ready_zorlobb_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.001
+    - nothing 1 0.999
 
 armed_khaross_hell_drop:
   Drops:
     - ips 2 0.01
     - armed_khaross_hell_drop_item_drops 1
+    - armed_khaross_hell_drop_rare_drops 1
 armed_khaross_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -198,12 +297,19 @@ armed_khaross_hell_drop_item_drops:
     - charming_belt_hell 1 0.01
     - rookie_jacket_hell 1 0.01
     - abyssal_treasure_gloves_hell 1 0.02
+
+armed_khaross_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.001
+    - nothing 1 0.999
 
 mordacious_khaross_hell_drop:
   Drops:
     - ips 2 0.01
     - mordacious_khaross_hell_drop_item_drops 1
+    - mordacious_khaross_hell_drop_rare_drops 1
 mordacious_khaross_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -211,12 +317,19 @@ mordacious_khaross_hell_drop_item_drops:
     - charming_belt_hell 1 0.01
     - rookie_jacket_hell 1 0.01
     - abyssal_treasure_gloves_hell 1 0.02
+
+mordacious_khaross_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.001
+    - nothing 1 0.999
 
 scheming_gorgon_hell_drop:
   Drops:
     - ips 2 0.25
     - scheming_gorgon_hell_drop_item_drops 1
+    - scheming_gorgon_hell_drop_rare_drops 1
 scheming_gorgon_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -224,12 +337,19 @@ scheming_gorgon_hell_drop_item_drops:
     - charming_belt_hell 1 0.025
     - rookie_jacket_hell 1 0.025
     - abyssal_treasure_gloves_hell 1 0.1
+
+scheming_gorgon_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.02
+    - nothing 1 0.98
 
 poisonous_jitterjelly_hell_drop:
   Drops:
     - ips 2 0.25
     - poisonous_jitterjelly_hell_drop_item_drops 1
+    - poisonous_jitterjelly_hell_drop_rare_drops 1
 poisonous_jitterjelly_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -237,12 +357,19 @@ poisonous_jitterjelly_hell_drop_item_drops:
     - charming_belt_hell 1 0.025
     - rookie_jacket_hell 1 0.025
     - abyssal_treasure_gloves_hell 1 0.1
+
+poisonous_jitterjelly_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.02
+    - nothing 1 0.98
 
 patrolling_jabbax_hell_drop:
   Drops:
     - ips 2 0.25
     - patrolling_jabbax_hell_drop_item_drops 1
+    - patrolling_jabbax_hell_drop_rare_drops 1
 patrolling_jabbax_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -250,41 +377,68 @@ patrolling_jabbax_hell_drop_item_drops:
     - charming_belt_hell 1 0.025
     - rookie_jacket_hell 1 0.025
     - abyssal_treasure_gloves_hell 1 0.1
+
+patrolling_jabbax_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_hell 1 0.02
+    - nothing 1 0.98
 
 melas_hell_drop:
   Drops:
     - ips 2 0.5
     - melas_hell_drop_item_drops 1
+    - melas_hell_drop_rare_drops 1
 melas_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - ring_of_renewal_hell 1 0.05
+
+melas_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_treasure_shield_hell 1 0.0125
+    - nothing 1 0.9875
 
 akheilos_hell_drop:
   Drops:
     - ips 2 0.5
     - akheilos_hell_drop_item_drops 1
+    - akheilos_hell_drop_rare_drops 1
 akheilos_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - ring_of_renewal_hell 1 0.05
+
+akheilos_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_treasure_shield_hell 1 0.0125
+    - nothing 1 0.9875
 
 gorga_hell_drop:
   Drops:
     - gorga_frag_II 1 0.05
     - ips 2 1
     - gorga_hell_drop_item_drops 1
+    - gorga_hell_drop_rare_drops 1
 gorga_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - ring_of_renewal_hell 1 0.125
+
+gorga_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_treasure_shield_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -293,6 +447,7 @@ anderworld_jitterjelly_blood_drop:
   Drops:
     - ips 3 0.01
     - anderworld_jitterjelly_blood_drop_item_drops 1
+    - anderworld_jitterjelly_blood_drop_rare_drops 1
 anderworld_jitterjelly_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -300,12 +455,19 @@ anderworld_jitterjelly_blood_drop_item_drops:
     - charming_belt_blood 1 0.01
     - rookie_jacket_blood 1 0.01
     - abyssal_treasure_gloves_blood 1 0.03
+
+anderworld_jitterjelly_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.005
+    - nothing 1 0.995
 
 anderworld_jabbax_blood_drop:
   Drops:
     - ips 3 0.01
     - anderworld_jabbax_blood_drop_item_drops 1
+    - anderworld_jabbax_blood_drop_rare_drops 1
 anderworld_jabbax_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -313,12 +475,19 @@ anderworld_jabbax_blood_drop_item_drops:
     - charming_belt_blood 1 0.01
     - rookie_jacket_blood 1 0.01
     - abyssal_treasure_gloves_blood 1 0.03
+
+anderworld_jabbax_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.005
+    - nothing 1 0.995
 
 combat_ready_zorlobb_blood_drop:
   Drops:
     - ips 3 0.01
     - combat_ready_zorlobb_blood_drop_item_drops 1
+    - combat_ready_zorlobb_blood_drop_rare_drops 1
 combat_ready_zorlobb_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -326,12 +495,19 @@ combat_ready_zorlobb_blood_drop_item_drops:
     - charming_belt_blood 1 0.01
     - rookie_jacket_blood 1 0.01
     - abyssal_treasure_gloves_blood 1 0.03
+
+combat_ready_zorlobb_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.005
+    - nothing 1 0.995
 
 armed_khaross_blood_drop:
   Drops:
     - ips 3 0.01
     - armed_khaross_blood_drop_item_drops 1
+    - armed_khaross_blood_drop_rare_drops 1
 armed_khaross_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -339,12 +515,19 @@ armed_khaross_blood_drop_item_drops:
     - charming_belt_blood 1 0.01
     - rookie_jacket_blood 1 0.01
     - abyssal_treasure_gloves_blood 1 0.03
+
+armed_khaross_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.005
+    - nothing 1 0.995
 
 mordacious_khaross_blood_drop:
   Drops:
     - ips 3 0.01
     - mordacious_khaross_blood_drop_item_drops 1
+    - mordacious_khaross_blood_drop_rare_drops 1
 mordacious_khaross_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -352,12 +535,19 @@ mordacious_khaross_blood_drop_item_drops:
     - charming_belt_blood 1 0.01
     - rookie_jacket_blood 1 0.01
     - abyssal_treasure_gloves_blood 1 0.03
+
+mordacious_khaross_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.005
+    - nothing 1 0.995
 
 scheming_gorgon_blood_drop:
   Drops:
     - ips 3 0.01
     - scheming_gorgon_blood_drop_item_drops 1
+    - scheming_gorgon_blood_drop_rare_drops 1
 scheming_gorgon_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -365,12 +555,19 @@ scheming_gorgon_blood_drop_item_drops:
     - charming_belt_blood 1 0.25
     - rookie_jacket_blood 1 0.025
     - abyssal_treasure_gloves_blood 1 0.2
+
+scheming_gorgon_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.03
+    - nothing 1 0.97
 
 poisonous_jitterjelly_blood_drop:
   Drops:
     - ips 3 0.01
     - poisonous_jitterjelly_blood_drop_item_drops 1
+    - poisonous_jitterjelly_blood_drop_rare_drops 1
 poisonous_jitterjelly_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -378,12 +575,19 @@ poisonous_jitterjelly_blood_drop_item_drops:
     - charming_belt_blood 1 0.25
     - rookie_jacket_blood 1 0.025
     - abyssal_treasure_gloves_blood 1 0.2
+
+poisonous_jitterjelly_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.03
+    - nothing 1 0.97
 
 patrolling_jabbax_blood_drop:
   Drops:
     - ips 3 0.01
     - patrolling_jabbax_blood_drop_item_drops 1
+    - patrolling_jabbax_blood_drop_rare_drops 1
 patrolling_jabbax_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -391,42 +595,77 @@ patrolling_jabbax_blood_drop_item_drops:
     - charming_belt_blood 1 0.25
     - rookie_jacket_blood 1 0.025
     - abyssal_treasure_gloves_blood 1 0.2
+
+patrolling_jabbax_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - ring_of_renewal_blood 1 0.03
+    - nothing 1 0.97
 
 melas_blood_drop:
   Drops:
     - ips 3 0.5
     - melas_blood_drop_item_drops 1
+    - melas_blood_drop_rare_drops 1
 melas_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - ring_of_renewal_blood 1 0.06
     - abyssal_treasure_shield_blood 1 0.025
+
+melas_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_treasure_helmet_blood 1 0.001
+    - nothing 1 0.999
 
 akheilos_blood_drop:
   Drops:
     - ips 3 0.5
     - akheilos_blood_drop_item_drops 1
+    - akheilos_blood_drop_rare_drops 1
 akheilos_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - ring_of_renewal_blood 1 0.06
     - abyssal_treasure_shield_blood 1 0.025
+
+akheilos_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_treasure_helmet_blood 1 0.001
+    - nothing 1 0.999
 
 gorga_blood_drop:
   Drops:
     - gorga_frag_III 1 0.05
     - ips 3 1
     - gorga_blood_drop_item_drops 1
-    - q10_soul 1 0.01
+    - gorga_blood_drop_rare_drops 1
+    - q10_soul_luck 1
 gorga_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - ring_of_renewal_blood 1 0.15
     - abyssal_treasure_shield_blood 1 0.05
+
+gorga_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_treasure_helmet_blood 1 0.01
+    - nothing 1 0.99
+
+
+q10_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q10_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q2_drops.yml
+++ b/droptables/Q2_drops.yml
@@ -5,6 +5,7 @@ gremlin_marauder_inf_drop:
   Drops:
     - ips 1 0.01
     - gremlin_marauder_inf_drop_item_drops 1
+    - gremlin_marauder_inf_drop_rare_drops 1
 gremlin_marauder_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ gremlin_marauder_inf_drop_item_drops:
     - spider_web_chestplate 1 0.01
     - poisonous_dagger 1 0.01
     - shroud_of_the_untouchables 1 0.01
+
+gremlin_marauder_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison 1 0.0005
+    - nothing 1 0.9995
 
 corrupted_root_creature_inf_drop:
   Drops:
     - ips 1 0.25
     - corrupted_root_creature_inf_drop_item_drops 1
+    - corrupted_root_creature_inf_drop_rare_drops 1
 corrupted_root_creature_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ corrupted_root_creature_inf_drop_item_drops:
     - spider_web_chestplate 1 0.25
     - poisonous_dagger 1 0.25
     - shroud_of_the_untouchables 1 0.05
+
+corrupted_root_creature_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison 1 0.01
+    - nothing 1 0.99
 
 xerib_the_hunchback_inf_drop:
   Drops:
     - ips 1 0.5
     - xerib_the_hunchback_inf_drop_item_drops 1
+    - xerib_the_hunchback_inf_drop_rare_drops 1
 xerib_the_hunchback_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -38,13 +53,20 @@ xerib_the_hunchback_inf_drop_item_drops:
     - spider_web_chestplate 1 0.5
     - poisonous_dagger 1 0.5
     - shroud_of_the_untouchables 1 0.1
+
+xerib_the_hunchback_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison 1 0.04
+    - nothing 1 0.96
 
 arachna_inf_drop:
   Drops:
     - arachna_frag_I 1 0.05
     - ips 1 1
     - arachna_inf_drop_item_drops 1
+    - arachna_inf_drop_rare_drops 1
 arachna_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -52,7 +74,13 @@ arachna_inf_drop_item_drops:
     - spider_web_chestplate 1 1
     - poisonous_dagger 1 1
     - shroud_of_the_untouchables 1 0.25
+
+arachna_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -61,6 +89,7 @@ gremlin_marauder_hell_drop:
   Drops:
     - ips 2 0.01
     - gremlin_marauder_hell_drop_item_drops 1
+    - gremlin_marauder_hell_drop_rare_drops 1
 gremlin_marauder_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -68,12 +97,19 @@ gremlin_marauder_hell_drop_item_drops:
     - spider_web_chestplate_hell 1 0.01
     - poisonous_dagger_hell 1 0.01
     - shroud_of_the_untouchables_hell 1 0.02
+
+gremlin_marauder_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison_hell 1 0.001
+    - nothing 1 0.999
 
 corrupted_root_creature_hell_drop:
   Drops:
     - ips 2 0.25
     - corrupted_root_creature_hell_drop_item_drops 1
+    - corrupted_root_creature_hell_drop_rare_drops 1
 corrupted_root_creature_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -81,30 +117,50 @@ corrupted_root_creature_hell_drop_item_drops:
     - spider_web_chestplate_hell 1 0.025
     - poisonous_dagger_hell 1 0.025
     - shroud_of_the_untouchables_hell 1 0.1
+
+corrupted_root_creature_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison_hell 1 0.02
+    - nothing 1 0.98
 
 xerib_the_hunchback_hell_drop:
   Drops:
     - ips 2 0.5
     - xerib_the_hunchback_hell_drop_item_drops 1
+    - xerib_the_hunchback_hell_drop_rare_drops 1
 xerib_the_hunchback_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - oceanus_ring_of_poison_hell 1 0.05
+
+xerib_the_hunchback_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - arachnas_venomous_revenge 1 0.0125
+    - nothing 1 0.9875
 
 arachna_hell_drop:
   Drops:
     - arachna_frag_II 1 0.05
     - ips 2 1
     - arachna_hell_drop_item_drops 1
+    - arachna_hell_drop_rare_drops 1
 arachna_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - oceanus_ring_of_poison_hell 1 0.125
+
+arachna_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - arachnas_venomous_revenge 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -113,6 +169,7 @@ gremlin_marauder_blood_drop:
   Drops:
     - ips 3 0.01
     - gremlin_marauder_blood_drop_item_drops 1
+    - gremlin_marauder_blood_drop_rare_drops 1
 gremlin_marauder_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -120,12 +177,19 @@ gremlin_marauder_blood_drop_item_drops:
     - spider_web_chestplate_bloodshed 1 0.01
     - poisonous_dagger_bloodshed 1 0.01
     - shroud_of_the_untouchables_bloodshed 1 0.03
+
+gremlin_marauder_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison_bloodshed 1 0.005
+    - nothing 1 0.995
 
 corrupted_root_creature_blood_drop:
   Drops:
     - ips 3 0.01
     - corrupted_root_creature_blood_drop_item_drops 1
+    - corrupted_root_creature_blood_drop_rare_drops 1
 corrupted_root_creature_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -133,30 +197,58 @@ corrupted_root_creature_blood_drop_item_drops:
     - spider_web_chestplate_bloodshed 1 0.25
     - poisonous_dagger_bloodshed 1 0.025
     - shroud_of_the_untouchables_bloodshed 1 0.2
+
+corrupted_root_creature_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_ring_of_poison_bloodshed 1 0.03
+    - nothing 1 0.97
 
 xerib_the_hunchback_blood_drop:
   Drops:
     - ips 3 0.5
     - xerib_the_hunchback_blood_drop_item_drops 1
+    - xerib_the_hunchback_blood_drop_rare_drops 1
 xerib_the_hunchback_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - oceanus_ring_of_poison_bloodshed 1 0.06
     - arachnas_venomous_revenge_blood 1 0.025
+
+xerib_the_hunchback_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - arachnas_vigor_of_the_spider 1 0.001
+    - nothing 1 0.999
 
 arachna_blood_drop:
   Drops:
     - arachna_frag_III 1 0.05
     - ips 3 1
     - arachna_blood_drop_item_drops 1
-    - q2_soul 1 0.01
+    - arachna_blood_drop_rare_drops 1
+    - q2_soul_luck 1
 arachna_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - oceanus_ring_of_poison_bloodshed 1 0.15
     - arachnas_venomous_revenge_blood 1 0.05
+
+arachna_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - arachnas_vigor_of_the_spider 1 0.01
+    - nothing 1 0.99
+
+
+q2_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q2_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q3_drops.yml
+++ b/droptables/Q3_drops.yml
@@ -5,6 +5,7 @@ cursed_farmer_inf_drop:
   Drops:
     - ips 1 0.01
     - cursed_farmer_inf_drop_item_drops 1
+    - cursed_farmer_inf_drop_rare_drops 1
 cursed_farmer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ cursed_farmer_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.01
     - glacial_boots_infernal 1 0.01
     - visage_of_the_untouchables_infernal 1 0.01
+
+cursed_farmer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.0005
+    - nothing 1 0.9995
 
 cursed_archer_inf_drop:
   Drops:
     - ips 1 0.01
     - cursed_archer_inf_drop_item_drops 1
+    - cursed_archer_inf_drop_rare_drops 1
 cursed_archer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ cursed_archer_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.01
     - glacial_boots_infernal 1 0.01
     - visage_of_the_untouchables_infernal 1 0.01
+
+cursed_archer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.0005
+    - nothing 1 0.9995
 
 slain_warrior_inf_drop:
   Drops:
     - ips 1 0.01
     - slain_warrior_inf_drop_item_drops 1
+    - slain_warrior_inf_drop_rare_drops 1
 slain_warrior_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ slain_warrior_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.01
     - glacial_boots_infernal 1 0.01
     - visage_of_the_untouchables_infernal 1 0.01
+
+slain_warrior_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.0005
+    - nothing 1 0.9995
 
 slain_archer_inf_drop:
   Drops:
     - ips 1 0.01
     - slain_archer_inf_drop_item_drops 1
+    - slain_archer_inf_drop_rare_drops 1
 slain_archer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ slain_archer_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.01
     - glacial_boots_infernal 1 0.01
     - visage_of_the_untouchables_infernal 1 0.01
+
+slain_archer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.0005
+    - nothing 1 0.9995
 
 cursed_troll_inf_drop:
   Drops:
     - ips 1 0.25
     - cursed_troll_inf_drop_item_drops 1
+    - cursed_troll_inf_drop_rare_drops 1
 cursed_troll_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -64,12 +93,19 @@ cursed_troll_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.25
     - glacial_boots_infernal 1 0.25
     - visage_of_the_untouchables_infernal 1 0.05
+
+cursed_troll_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.01
+    - nothing 1 0.99
 
 slain_assassin_inf_drop:
   Drops:
     - ips 1 0.25
     - slain_assassin_inf_drop_item_drops 1
+    - slain_assassin_inf_drop_rare_drops 1
 slain_assassin_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -77,12 +113,19 @@ slain_assassin_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.25
     - glacial_boots_infernal 1 0.25
     - visage_of_the_untouchables_infernal 1 0.05
+
+slain_assassin_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.01
+    - nothing 1 0.99
 
 parallel_world_evil_miller_inf_drop:
   Drops:
     - ips 1 0.5
     - parallel_world_evil_miller_inf_drop_item_drops 1
+    - parallel_world_evil_miller_inf_drop_rare_drops 1
 parallel_world_evil_miller_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -90,12 +133,19 @@ parallel_world_evil_miller_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.5
     - glacial_boots_infernal 1 0.5
     - visage_of_the_untouchables_infernal 1 0.1
+
+parallel_world_evil_miller_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.04
+    - nothing 1 0.96
 
 the_bloody_arrow_inf_drop:
   Drops:
     - ips 1 0.5
     - the_bloody_arrow_inf_drop_item_drops 1
+    - the_bloody_arrow_inf_drop_rare_drops 1
 the_bloody_arrow_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -103,13 +153,20 @@ the_bloody_arrow_inf_drop_item_drops:
     - undead_chestplate_infernal 1 0.5
     - glacial_boots_infernal 1 0.5
     - visage_of_the_untouchables_infernal 1 0.1
+
+the_bloody_arrow_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.04
+    - nothing 1 0.96
 
 king_heredur_inf_drop:
   Drops:
     - heredur_frag_I 1 0.05
     - ips 1 1
     - king_heredur_inf_drop_item_drops 1
+    - king_heredur_inf_drop_rare_drops 1
 king_heredur_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -117,7 +174,13 @@ king_heredur_inf_drop_item_drops:
     - undead_chestplate_infernal 1 1
     - glacial_boots_infernal 1 1
     - visage_of_the_untouchables_infernal 1 0.25
+
+king_heredur_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -126,6 +189,7 @@ cursed_farmer_hell_drop:
   Drops:
     - ips 2 0.01
     - cursed_farmer_hell_drop_item_drops 1
+    - cursed_farmer_hell_drop_rare_drops 1
 cursed_farmer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -133,12 +197,19 @@ cursed_farmer_hell_drop_item_drops:
     - undead_chestplate_hell 1 0.01
     - glacial_boots_hell 1 0.01
     - visage_of_the_untouchables_hell 1 0.02
+
+cursed_farmer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_hell 1 0.001
+    - nothing 1 0.999
 
 cursed_archer_hell_drop:
   Drops:
     - ips 2 0.01
     - cursed_archer_hell_drop_item_drops 1
+    - cursed_archer_hell_drop_rare_drops 1
 cursed_archer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -146,12 +217,19 @@ cursed_archer_hell_drop_item_drops:
     - undead_chestplate_hell 1 0.01
     - glacial_boots_hell 1 0.01
     - visage_of_the_untouchables_hell 1 0.02
+
+cursed_archer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_hell 1 0.001
+    - nothing 1 0.999
 
 slain_warrior_hell_drop:
   Drops:
     - ips 2 0.01
     - slain_warrior_hell_drop_item_drops 1
+    - slain_warrior_hell_drop_rare_drops 1
 slain_warrior_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -159,12 +237,19 @@ slain_warrior_hell_drop_item_drops:
     - undead_chestplate_hell 1 0.01
     - glacial_boots_hell 1 0.01
     - visage_of_the_untouchables_hell 1 0.02
+
+slain_warrior_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_hell 1 0.001
+    - nothing 1 0.999
 
 slain_archer_hell_drop:
   Drops:
     - ips 2 0.01
     - slain_archer_hell_drop_item_drops 1
+    - slain_archer_hell_drop_rare_drops 1
 slain_archer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -172,12 +257,19 @@ slain_archer_hell_drop_item_drops:
     - undead_chestplate_hell 1 0.01
     - glacial_boots_hell 1 0.01
     - visage_of_the_untouchables_hell 1 0.02
+
+slain_archer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_hell 1 0.001
+    - nothing 1 0.999
 
 cursed_troll_hell_drop:
   Drops:
     - ips 2 0.25
     - cursed_troll_hell_drop_item_drops 1
+    - cursed_troll_hell_drop_rare_drops 1
 cursed_troll_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -185,12 +277,19 @@ cursed_troll_hell_drop_item_drops:
     - undead_chestplate_hell 1 0.025
     - glacial_boots_hell 1 0.025
     - visage_of_the_untouchables_hell 1 0.1
+
+cursed_troll_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_hell 1 0.02
+    - nothing 1 0.98
 
 slain_assassin_hell_drop:
   Drops:
     - ips 2 0.25
     - slain_assassin_hell_drop_item_drops 1
+    - slain_assassin_hell_drop_rare_drops 1
 slain_assassin_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -198,41 +297,68 @@ slain_assassin_hell_drop_item_drops:
     - undead_chestplate_hell 1 0.025
     - glacial_boots_hell 1 0.025
     - visage_of_the_untouchables_hell 1 0.1
+
+slain_assassin_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_hell 1 0.02
+    - nothing 1 0.98
 
 parallel_world_evil_miller_hell_drop:
   Drops:
     - ips 2 0.5
     - parallel_world_evil_miller_hell_drop_item_drops 1
+    - parallel_world_evil_miller_hell_drop_rare_drops 1
 parallel_world_evil_miller_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - agathons_ring_of_order_hell 1 0.05
+
+parallel_world_evil_miller_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - heredurs_royal_power_hell 1 0.0125
+    - nothing 1 0.9875
 
 the_bloody_arrow_hell_drop:
   Drops:
     - ips 2 0.5
     - the_bloody_arrow_hell_drop_item_drops 1
+    - the_bloody_arrow_hell_drop_rare_drops 1
 the_bloody_arrow_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - agathons_ring_of_order_hell 1 0.05
+
+the_bloody_arrow_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - heredurs_royal_power_hell 1 0.0125
+    - nothing 1 0.9875
 
 king_heredur_hell_drop:
   Drops:
     - heredur_frag_II 1 0.05
     - ips 2 1
     - king_heredur_hell_drop_item_drops 1
+    - king_heredur_hell_drop_rare_drops 1
 king_heredur_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - agathons_ring_of_order_hell 1 0.125
+
+king_heredur_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - heredurs_royal_power_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -241,6 +367,7 @@ cursed_farmer_blood_drop:
   Drops:
     - ips 3 0.01
     - cursed_farmer_blood_drop_item_drops 1
+    - cursed_farmer_blood_drop_rare_drops 1
 cursed_farmer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -248,12 +375,19 @@ cursed_farmer_blood_drop_item_drops:
     - undead_chestplate_blood 1 0.01
     - glacial_boots_blood 1 0.01
     - visage_of_the_untouchables_blood 1 0.03
+
+cursed_farmer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_blood 1 0.005
+    - nothing 1 0.995
 
 cursed_archer_blood_drop:
   Drops:
     - ips 3 0.01
     - cursed_archer_blood_drop_item_drops 1
+    - cursed_archer_blood_drop_rare_drops 1
 cursed_archer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -261,12 +395,19 @@ cursed_archer_blood_drop_item_drops:
     - undead_chestplate_blood 1 0.01
     - glacial_boots_blood 1 0.01
     - visage_of_the_untouchables_blood 1 0.03
+
+cursed_archer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_blood 1 0.005
+    - nothing 1 0.995
 
 slain_warrior_blood_drop:
   Drops:
     - ips 3 0.01
     - slain_warrior_blood_drop_item_drops 1
+    - slain_warrior_blood_drop_rare_drops 1
 slain_warrior_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -274,12 +415,19 @@ slain_warrior_blood_drop_item_drops:
     - undead_chestplate_blood 1 0.01
     - glacial_boots_blood 1 0.01
     - visage_of_the_untouchables_blood 1 0.03
+
+slain_warrior_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_blood 1 0.005
+    - nothing 1 0.995
 
 slain_archer_blood_drop:
   Drops:
     - ips 3 0.01
     - slain_archer_blood_drop_item_drops 1
+    - slain_archer_blood_drop_rare_drops 1
 slain_archer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -287,12 +435,19 @@ slain_archer_blood_drop_item_drops:
     - undead_chestplate_blood 1 0.01
     - glacial_boots_blood 1 0.01
     - visage_of_the_untouchables_blood 1 0.03
+
+slain_archer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_blood 1 0.005
+    - nothing 1 0.995
 
 cursed_troll_blood_drop:
   Drops:
     - ips 3 0.01
     - cursed_troll_blood_drop_item_drops 1
+    - cursed_troll_blood_drop_rare_drops 1
 cursed_troll_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -300,12 +455,19 @@ cursed_troll_blood_drop_item_drops:
     - undead_chestplate_blood 1 0.25
     - glacial_boots_blood 1 0.025
     - visage_of_the_untouchables_blood 1 0.2
+
+cursed_troll_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_blood 1 0.03
+    - nothing 1 0.97
 
 slain_assassin_blood_drop:
   Drops:
     - ips 3 0.01
     - slain_assassin_blood_drop_item_drops 1
+    - slain_assassin_blood_drop_rare_drops 1
 slain_assassin_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -313,42 +475,77 @@ slain_assassin_blood_drop_item_drops:
     - undead_chestplate_blood 1 0.25
     - glacial_boots_blood 1 0.025
     - visage_of_the_untouchables_blood 1 0.2
+
+slain_assassin_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - agathons_ring_of_order_blood 1 0.03
+    - nothing 1 0.97
 
 parallel_world_evil_miller_blood_drop:
   Drops:
     - ips 3 0.5
     - parallel_world_evil_miller_blood_drop_item_drops 1
+    - parallel_world_evil_miller_blood_drop_rare_drops 1
 parallel_world_evil_miller_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - agathons_ring_of_order_blood 1 0.06
     - heredurs_royal_power_blood 1 0.025
+
+parallel_world_evil_miller_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - heredurs_royal_shield_blood 1 0.001
+    - nothing 1 0.999
 
 the_bloody_arrow_blood_drop:
   Drops:
     - ips 3 0.5
     - the_bloody_arrow_blood_drop_item_drops 1
+    - the_bloody_arrow_blood_drop_rare_drops 1
 the_bloody_arrow_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - agathons_ring_of_order_blood 1 0.06
     - heredurs_royal_power_blood 1 0.025
+
+the_bloody_arrow_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - heredurs_royal_shield_blood 1 0.001
+    - nothing 1 0.999
 
 king_heredur_blood_drop:
   Drops:
     - heredur_frag_III 1 0.05
     - ips 3 1
     - king_heredur_blood_drop_item_drops 1
-    - q3_soul 1 0.01
+    - king_heredur_blood_drop_rare_drops 1
+    - q3_soul_luck 1
 king_heredur_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - agathons_ring_of_order_blood 1 0.15
     - heredurs_royal_power_blood 1 0.05
+
+king_heredur_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - heredurs_royal_shield_blood 1 0.01
+    - nothing 1 0.99
+
+
+q3_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q3_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q4_drops.yml
+++ b/droptables/Q4_drops.yml
@@ -5,6 +5,7 @@ sanguine_clan_raging_guardian_inf_drop:
   Drops:
     - ips 1 0.01
     - sanguine_clan_raging_guardian_inf_drop_item_drops 1
+    - sanguine_clan_raging_guardian_inf_drop_rare_drops 1
 sanguine_clan_raging_guardian_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ sanguine_clan_raging_guardian_inf_drop_item_drops:
     - honey_charm_infernal 1 0.01
     - beekeeper_hat_infernal 1 0.01
     - strike_of_the_untouchables_infernal 1 0.01
+
+sanguine_clan_raging_guardian_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_infernal 1 0.0005
+    - nothing 1 0.9995
 
 raging_hunting_hound_inf_drop:
   Drops:
     - ips 1 0.01
     - raging_hunting_hound_inf_drop_item_drops 1
+    - raging_hunting_hound_inf_drop_rare_drops 1
 raging_hunting_hound_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ raging_hunting_hound_inf_drop_item_drops:
     - honey_charm_infernal 1 0.01
     - beekeeper_hat_infernal 1 0.01
     - strike_of_the_untouchables_infernal 1 0.01
+
+raging_hunting_hound_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_infernal 1 0.0005
+    - nothing 1 0.9995
 
 sanguine_clan_raging_snooper_inf_drop:
   Drops:
     - ips 1 0.25
     - sanguine_clan_raging_snooper_inf_drop_item_drops 1
+    - sanguine_clan_raging_snooper_inf_drop_rare_drops 1
 sanguine_clan_raging_snooper_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ sanguine_clan_raging_snooper_inf_drop_item_drops:
     - honey_charm_infernal 1 0.25
     - beekeeper_hat_infernal 1 0.25
     - strike_of_the_untouchables_infernal 1 0.05
+
+sanguine_clan_raging_snooper_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_infernal 1 0.01
+    - nothing 1 0.99
 
 sanguine_hunter_inf_drop:
   Drops:
     - ips 1 0.25
     - sanguine_hunter_inf_drop_item_drops 1
+    - sanguine_hunter_inf_drop_rare_drops 1
 sanguine_hunter_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ sanguine_hunter_inf_drop_item_drops:
     - honey_charm_infernal 1 0.25
     - beekeeper_hat_infernal 1 0.25
     - strike_of_the_untouchables_infernal 1 0.05
+
+sanguine_hunter_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_infernal 1 0.01
+    - nothing 1 0.99
 
 ancient_stag_inf_drop:
   Drops:
     - ips 1 0.5
     - ancient_stag_inf_drop_item_drops 1
+    - ancient_stag_inf_drop_rare_drops 1
 ancient_stag_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -64,13 +93,20 @@ ancient_stag_inf_drop_item_drops:
     - honey_charm_infernal 1 0.5
     - beekeeper_hat_infernal 1 0.5
     - strike_of_the_untouchables_infernal 1 0.1
+
+ancient_stag_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_infernal 1 0.04
+    - nothing 1 0.96
 
 bearach_inf_drop:
   Drops:
     - bearach_frag_I 1 0.05
     - ips 1 1
     - bearach_inf_drop_item_drops 1
+    - bearach_inf_drop_rare_drops 1
 bearach_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -78,7 +114,13 @@ bearach_inf_drop_item_drops:
     - honey_charm_infernal 1 1
     - beekeeper_hat_infernal 1 1
     - strike_of_the_untouchables_infernal 1 0.25
+
+bearach_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -87,6 +129,7 @@ sanguine_clan_raging_guardian_hell_drop:
   Drops:
     - ips 2 0.01
     - sanguine_clan_raging_guardian_hell_drop_item_drops 1
+    - sanguine_clan_raging_guardian_hell_drop_rare_drops 1
 sanguine_clan_raging_guardian_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -94,12 +137,19 @@ sanguine_clan_raging_guardian_hell_drop_item_drops:
     - honey_charm_hell 1 0.01
     - beekeeper_hat_hell 1 0.01
     - strike_of_the_untouchables_hell 1 0.02
+
+sanguine_clan_raging_guardian_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_hell 1 0.001
+    - nothing 1 0.999
 
 raging_hunting_hound_hell_drop:
   Drops:
     - ips 2 0.01
     - raging_hunting_hound_hell_drop_item_drops 1
+    - raging_hunting_hound_hell_drop_rare_drops 1
 raging_hunting_hound_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -107,12 +157,19 @@ raging_hunting_hound_hell_drop_item_drops:
     - honey_charm_hell 1 0.01
     - beekeeper_hat_hell 1 0.01
     - strike_of_the_untouchables_hell 1 0.02
+
+raging_hunting_hound_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_hell 1 0.001
+    - nothing 1 0.999
 
 sanguine_clan_raging_snooper_hell_drop:
   Drops:
     - ips 2 0.25
     - sanguine_clan_raging_snooper_hell_drop_item_drops 1
+    - sanguine_clan_raging_snooper_hell_drop_rare_drops 1
 sanguine_clan_raging_snooper_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -120,12 +177,19 @@ sanguine_clan_raging_snooper_hell_drop_item_drops:
     - honey_charm_hell 1 0.025
     - beekeeper_hat_hell 1 0.025
     - strike_of_the_untouchables_hell 1 0.1
+
+sanguine_clan_raging_snooper_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_hell 1 0.02
+    - nothing 1 0.98
 
 sanguine_hunter_hell_drop:
   Drops:
     - ips 2 0.25
     - sanguine_hunter_hell_drop_item_drops 1
+    - sanguine_hunter_hell_drop_rare_drops 1
 sanguine_hunter_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -133,30 +197,50 @@ sanguine_hunter_hell_drop_item_drops:
     - honey_charm_hell 1 0.025
     - beekeeper_hat_hell 1 0.025
     - strike_of_the_untouchables_hell 1 0.1
+
+sanguine_hunter_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_hell 1 0.02
+    - nothing 1 0.98
 
 ancient_stag_hell_drop:
   Drops:
     - ips 2 0.5
     - ancient_stag_hell_drop_item_drops 1
+    - ancient_stag_hell_drop_rare_drops 1
 ancient_stag_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - artayas_cape_of_life_hell 1 0.05
+
+ancient_stag_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_wild_care_hell 1 0.0125
+    - nothing 1 0.9875
 
 bearach_hell_drop:
   Drops:
     - bearach_frag_II 1 0.05
     - ips 2 1
     - bearach_hell_drop_item_drops 1
+    - bearach_hell_drop_rare_drops 1
 bearach_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - artayas_cape_of_life_hell 1 0.125
+
+bearach_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_wild_care_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -165,6 +249,7 @@ sanguine_clan_raging_guardian_blood_drop:
   Drops:
     - ips 3 0.01
     - sanguine_clan_raging_guardian_blood_drop_item_drops 1
+    - sanguine_clan_raging_guardian_blood_drop_rare_drops 1
 sanguine_clan_raging_guardian_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -172,12 +257,19 @@ sanguine_clan_raging_guardian_blood_drop_item_drops:
     - honey_charm_blood 1 0.01
     - beekeeper_hat_blood 1 0.01
     - strike_of_the_untouchables_blood 1 0.03
+
+sanguine_clan_raging_guardian_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_blood 1 0.005
+    - nothing 1 0.995
 
 raging_hunting_hound_blood_drop:
   Drops:
     - ips 3 0.01
     - raging_hunting_hound_blood_drop_item_drops 1
+    - raging_hunting_hound_blood_drop_rare_drops 1
 raging_hunting_hound_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -185,12 +277,19 @@ raging_hunting_hound_blood_drop_item_drops:
     - honey_charm_blood 1 0.01
     - beekeeper_hat_blood 1 0.01
     - strike_of_the_untouchables_blood 1 0.03
+
+raging_hunting_hound_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_blood 1 0.005
+    - nothing 1 0.995
 
 sanguine_clan_raging_snooper_blood_drop:
   Drops:
     - ips 3 0.01
     - sanguine_clan_raging_snooper_blood_drop_item_drops 1
+    - sanguine_clan_raging_snooper_blood_drop_rare_drops 1
 sanguine_clan_raging_snooper_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -198,12 +297,19 @@ sanguine_clan_raging_snooper_blood_drop_item_drops:
     - honey_charm_blood 1 0.25
     - beekeeper_hat_blood 1 0.025
     - strike_of_the_untouchables_blood 1 0.2
+
+sanguine_clan_raging_snooper_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_blood 1 0.03
+    - nothing 1 0.97
 
 sanguine_hunter_blood_drop:
   Drops:
     - ips 3 0.01
     - sanguine_hunter_blood_drop_item_drops 1
+    - sanguine_hunter_blood_drop_rare_drops 1
 sanguine_hunter_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -211,12 +317,19 @@ sanguine_hunter_blood_drop_item_drops:
     - honey_charm_blood 1 0.25
     - beekeeper_hat_blood 1 0.025
     - strike_of_the_untouchables_blood 1 0.2
+
+sanguine_hunter_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - artayas_cape_of_life_blood 1 0.03
+    - nothing 1 0.97
 
 ancient_stag_blood_drop:
   Drops:
     - ips 3 0.5
     - ancient_stag_blood_drop_item_drops 1
+    - ancient_stag_blood_drop_rare_drops 1
 ancient_stag_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -224,14 +337,21 @@ ancient_stag_blood_drop_item_drops:
     - artayas_cape_of_life_blood 1 0.06
     - artayas_wild_care_blood 1 0.025
     - bearachs_tormentor_blood 1 0.001
+
+ancient_stag_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - bearachs_instinct_blood 1 0.001
+    - nothing 1 0.999
 
 bearach_blood_drop:
   Drops:
     - bearach_frag_III 1 0.05
     - ips 3 1
     - bearach_blood_drop_item_drops 1
-    - q4_soul 1 0.01
+    - bearach_blood_drop_rare_drops 1
+    - q4_soul_luck 1
 bearach_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -239,4 +359,18 @@ bearach_blood_drop_item_drops:
     - artayas_cape_of_life_blood 1 0.15
     - artayas_wild_care_blood 1 0.05
     - bearachs_tormentor_blood 1 0.01
+
+bearach_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - bearachs_instinct_blood 1 0.01
+    - nothing 1 0.99
+
+
+q4_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q4_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q5_drops.yml
+++ b/droptables/Q5_drops.yml
@@ -5,6 +5,7 @@ furious_maggot_inf_drop:
   Drops:
     - ips 1 0.01
     - furious_maggot_inf_drop_item_drops 1
+    - furious_maggot_inf_drop_rare_drops 1
 furious_maggot_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ furious_maggot_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.01
     - void_axe_infernal 1 0.01
     - duty_of_the_untouchables_infernal 1 0.01
+
+furious_maggot_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.0005
+    - nothing 1 0.9995
 
 furious_flagrancy_inf_drop:
   Drops:
     - ips 1 0.01
     - furious_flagrancy_inf_drop_item_drops 1
+    - furious_flagrancy_inf_drop_rare_drops 1
 furious_flagrancy_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ furious_flagrancy_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.01
     - void_axe_infernal 1 0.01
     - duty_of_the_untouchables_infernal 1 0.01
+
+furious_flagrancy_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.0005
+    - nothing 1 0.9995
 
 living_andermagic_inf_drop:
   Drops:
     - ips 1 0.01
     - living_andermagic_inf_drop_item_drops 1
+    - living_andermagic_inf_drop_rare_drops 1
 living_andermagic_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ living_andermagic_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.01
     - void_axe_infernal 1 0.01
     - duty_of_the_untouchables_infernal 1 0.01
+
+living_andermagic_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.0005
+    - nothing 1 0.9995
 
 andermagic_guardian_inf_drop:
   Drops:
     - ips 1 0.01
     - andermagic_guardian_inf_drop_item_drops 1
+    - andermagic_guardian_inf_drop_rare_drops 1
 andermagic_guardian_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ andermagic_guardian_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.01
     - void_axe_infernal 1 0.01
     - duty_of_the_untouchables_infernal 1 0.01
+
+andermagic_guardian_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.0005
+    - nothing 1 0.9995
 
 furious_andermagic_inf_drop:
   Drops:
     - ips 1 0.25
     - furious_andermagic_inf_drop_item_drops 1
+    - furious_andermagic_inf_drop_rare_drops 1
 furious_andermagic_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -64,12 +93,19 @@ furious_andermagic_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.25
     - void_axe_infernal 1 0.25
     - duty_of_the_untouchables_infernal 1 0.05
+
+furious_andermagic_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.01
+    - nothing 1 0.99
 
 wailing_ghost_inf_drop:
   Drops:
     - ips 1 0.25
     - wailing_ghost_inf_drop_item_drops 1
+    - wailing_ghost_inf_drop_rare_drops 1
 wailing_ghost_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -77,12 +113,19 @@ wailing_ghost_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.25
     - void_axe_infernal 1 0.25
     - duty_of_the_untouchables_infernal 1 0.05
+
+wailing_ghost_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.01
+    - nothing 1 0.99
 
 andermagic_scoropitl_inf_drop:
   Drops:
     - ips 1 0.25
     - andermagic_scoropitl_inf_drop_item_drops 1
+    - andermagic_scoropitl_inf_drop_rare_drops 1
 andermagic_scoropitl_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -90,12 +133,19 @@ andermagic_scoropitl_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.25
     - void_axe_infernal 1 0.25
     - duty_of_the_untouchables_infernal 1 0.05
+
+andermagic_scoropitl_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.01
+    - nothing 1 0.99
 
 old_jabbax_shaman_inf_drop:
   Drops:
     - ips 1 0.5
     - old_jabbax_shaman_inf_drop_item_drops 1
+    - old_jabbax_shaman_inf_drop_rare_drops 1
 old_jabbax_shaman_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -103,12 +153,19 @@ old_jabbax_shaman_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.5
     - void_axe_infernal 1 0.5
     - duty_of_the_untouchables_infernal 1 0.1
+
+old_jabbax_shaman_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.04
+    - nothing 1 0.96
 
 wandering_experiment_inf_drop:
   Drops:
     - ips 1 0.5
     - wandering_experiment_inf_drop_item_drops 1
+    - wandering_experiment_inf_drop_rare_drops 1
 wandering_experiment_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -116,13 +173,20 @@ wandering_experiment_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 0.5
     - void_axe_infernal 1 0.5
     - duty_of_the_untouchables_infernal 1 0.1
+
+wandering_experiment_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.04
+    - nothing 1 0.96
 
 khalys_inf_drop:
   Drops:
     - khalys_frag_I 1 0.05
     - ips 1 1
     - khalys_inf_drop_item_drops 1
+    - khalys_inf_drop_rare_drops 1
 khalys_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -130,7 +194,13 @@ khalys_inf_drop_item_drops:
     - andermagic_neckel_infernal 1 1
     - void_axe_infernal 1 1
     - duty_of_the_untouchables_infernal 1 0.25
+
+khalys_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -139,6 +209,7 @@ furious_maggot_hell_drop:
   Drops:
     - ips 2 0.01
     - furious_maggot_hell_drop_item_drops 1
+    - furious_maggot_hell_drop_rare_drops 1
 furious_maggot_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -146,12 +217,19 @@ furious_maggot_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.01
     - void_axe_hell 1 0.01
     - duty_of_the_untouchables_hell 1 0.02
+
+furious_maggot_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.001
+    - nothing 1 0.999
 
 furious_flagrancy_hell_drop:
   Drops:
     - ips 2 0.01
     - furious_flagrancy_hell_drop_item_drops 1
+    - furious_flagrancy_hell_drop_rare_drops 1
 furious_flagrancy_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -159,12 +237,19 @@ furious_flagrancy_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.01
     - void_axe_hell 1 0.01
     - duty_of_the_untouchables_hell 1 0.02
+
+furious_flagrancy_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.001
+    - nothing 1 0.999
 
 living_andermagic_hell_drop:
   Drops:
     - ips 2 0.01
     - living_andermagic_hell_drop_item_drops 1
+    - living_andermagic_hell_drop_rare_drops 1
 living_andermagic_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -172,12 +257,19 @@ living_andermagic_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.01
     - void_axe_hell 1 0.01
     - duty_of_the_untouchables_hell 1 0.02
+
+living_andermagic_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.001
+    - nothing 1 0.999
 
 andermagic_guardian_hell_drop:
   Drops:
     - ips 2 0.01
     - andermagic_guardian_hell_drop_item_drops 1
+    - andermagic_guardian_hell_drop_rare_drops 1
 andermagic_guardian_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -185,12 +277,19 @@ andermagic_guardian_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.01
     - void_axe_hell 1 0.01
     - duty_of_the_untouchables_hell 1 0.02
+
+andermagic_guardian_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.001
+    - nothing 1 0.999
 
 furious_andermagic_hell_drop:
   Drops:
     - ips 2 0.25
     - furious_andermagic_hell_drop_item_drops 1
+    - furious_andermagic_hell_drop_rare_drops 1
 furious_andermagic_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -198,12 +297,19 @@ furious_andermagic_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.025
     - void_axe_hell 1 0.025
     - duty_of_the_untouchables_hell 1 0.1
+
+furious_andermagic_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.02
+    - nothing 1 0.98
 
 wailing_ghost_hell_drop:
   Drops:
     - ips 2 0.25
     - wailing_ghost_hell_drop_item_drops 1
+    - wailing_ghost_hell_drop_rare_drops 1
 wailing_ghost_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -211,12 +317,19 @@ wailing_ghost_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.025
     - void_axe_hell 1 0.025
     - duty_of_the_untouchables_hell 1 0.1
+
+wailing_ghost_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.02
+    - nothing 1 0.98
 
 andermagic_scoropitl_hell_drop:
   Drops:
     - ips 2 0.25
     - andermagic_scoropitl_hell_drop_item_drops 1
+    - andermagic_scoropitl_hell_drop_rare_drops 1
 andermagic_scoropitl_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -224,41 +337,68 @@ andermagic_scoropitl_hell_drop_item_drops:
     - andermagic_neckel_hell 1 0.025
     - void_axe_hell 1 0.025
     - duty_of_the_untouchables_hell 1 0.1
+
+andermagic_scoropitl_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_hell 1 0.02
+    - nothing 1 0.98
 
 old_jabbax_shaman_hell_drop:
   Drops:
     - ips 2 0.5
     - old_jabbax_shaman_hell_drop_item_drops 1
+    - old_jabbax_shaman_hell_drop_rare_drops 1
 old_jabbax_shaman_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - khalys_dark_gaze_hell 1 0.05
+
+old_jabbax_shaman_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_scheme_hell 1 0.0125
+    - nothing 1 0.9875
 
 wandering_experiment_hell_drop:
   Drops:
     - ips 2 0.5
     - wandering_experiment_hell_drop_item_drops 1
+    - wandering_experiment_hell_drop_rare_drops 1
 wandering_experiment_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - khalys_dark_gaze_hell 1 0.05
+
+wandering_experiment_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_scheme_hell 1 0.0125
+    - nothing 1 0.9875
 
 khalys_hell_drop:
   Drops:
     - khalys_frag_II 1 0.05
     - ips 2 1
     - khalys_hell_drop_item_drops 1
+    - khalys_hell_drop_rare_drops 1
 khalys_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - khalys_dark_gaze_hell 1 0.125
+
+khalys_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_scheme_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -267,6 +407,7 @@ furious_maggot_blood_drop:
   Drops:
     - ips 3 0.01
     - furious_maggot_blood_drop_item_drops 1
+    - furious_maggot_blood_drop_rare_drops 1
 furious_maggot_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -274,12 +415,19 @@ furious_maggot_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.01
     - void_axe_blood 1 0.01
     - duty_of_the_untouchables_blood 1 0.03
+
+furious_maggot_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.005
+    - nothing 1 0.995
 
 furious_flagrancy_blood_drop:
   Drops:
     - ips 3 0.01
     - furious_flagrancy_blood_drop_item_drops 1
+    - furious_flagrancy_blood_drop_rare_drops 1
 furious_flagrancy_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -287,12 +435,19 @@ furious_flagrancy_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.01
     - void_axe_blood 1 0.01
     - duty_of_the_untouchables_blood 1 0.03
+
+furious_flagrancy_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.005
+    - nothing 1 0.995
 
 living_andermagic_blood_drop:
   Drops:
     - ips 3 0.01
     - living_andermagic_blood_drop_item_drops 1
+    - living_andermagic_blood_drop_rare_drops 1
 living_andermagic_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -300,12 +455,19 @@ living_andermagic_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.01
     - void_axe_blood 1 0.01
     - duty_of_the_untouchables_blood 1 0.03
+
+living_andermagic_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.005
+    - nothing 1 0.995
 
 andermagic_guardian_blood_drop:
   Drops:
     - ips 3 0.01
     - andermagic_guardian_blood_drop_item_drops 1
+    - andermagic_guardian_blood_drop_rare_drops 1
 andermagic_guardian_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -313,12 +475,19 @@ andermagic_guardian_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.01
     - void_axe_blood 1 0.01
     - duty_of_the_untouchables_blood 1 0.03
+
+andermagic_guardian_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.005
+    - nothing 1 0.995
 
 furious_andermagic_blood_drop:
   Drops:
     - ips 3 0.01
     - furious_andermagic_blood_drop_item_drops 1
+    - furious_andermagic_blood_drop_rare_drops 1
 furious_andermagic_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -326,12 +495,19 @@ furious_andermagic_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.25
     - void_axe_blood 1 0.025
     - duty_of_the_untouchables_blood 1 0.2
+
+furious_andermagic_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.03
+    - nothing 1 0.97
 
 wailing_ghost_blood_drop:
   Drops:
     - ips 3 0.01
     - wailing_ghost_blood_drop_item_drops 1
+    - wailing_ghost_blood_drop_rare_drops 1
 wailing_ghost_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -339,12 +515,19 @@ wailing_ghost_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.25
     - void_axe_blood 1 0.025
     - duty_of_the_untouchables_blood 1 0.2
+
+wailing_ghost_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.03
+    - nothing 1 0.97
 
 andermagic_scoropitl_blood_drop:
   Drops:
     - ips 3 0.01
     - andermagic_scoropitl_blood_drop_item_drops 1
+    - andermagic_scoropitl_blood_drop_rare_drops 1
 andermagic_scoropitl_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -352,42 +535,77 @@ andermagic_scoropitl_blood_drop_item_drops:
     - andermagic_neckel_blood 1 0.25
     - void_axe_blood 1 0.025
     - duty_of_the_untouchables_blood 1 0.2
+
+andermagic_scoropitl_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - khalys_dark_gaze_blood 1 0.03
+    - nothing 1 0.97
 
 old_jabbax_shaman_blood_drop:
   Drops:
     - ips 3 0.5
     - old_jabbax_shaman_blood_drop_item_drops 1
+    - old_jabbax_shaman_blood_drop_rare_drops 1
 old_jabbax_shaman_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - khalys_dark_gaze_blood 1 0.06
     - khalys_dark_scheme_blood 1 0.025
+
+old_jabbax_shaman_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - balor_ring_of_chaos_blood 1 0.001
+    - nothing 1 0.999
 
 wandering_experiment_blood_drop:
   Drops:
     - ips 3 0.5
     - wandering_experiment_blood_drop_item_drops 1
+    - wandering_experiment_blood_drop_rare_drops 1
 wandering_experiment_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - khalys_dark_gaze_blood 1 0.06
     - khalys_dark_scheme_blood 1 0.025
+
+wandering_experiment_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - balor_ring_of_chaos_blood 1 0.001
+    - nothing 1 0.999
 
 khalys_blood_drop:
   Drops:
     - khalys_frag_III 1 0.05
     - ips 3 1
     - khalys_blood_drop_item_drops 1
-    - q5_soul 1 0.01
+    - khalys_blood_drop_rare_drops 1
+    - q5_soul_luck 1
 khalys_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - khalys_dark_gaze_blood 1 0.15
     - khalys_dark_scheme_blood 1 0.05
+
+khalys_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - balor_ring_of_chaos_blood 1 0.01
+    - nothing 1 0.99
+
+
+q5_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q5_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q6_drops.yml
+++ b/droptables/Q6_drops.yml
@@ -5,6 +5,7 @@ fallen_warrior_inf_drop:
   Drops:
     - ips 1 0.01
     - fallen_warrior_inf_drop_item_drops 1
+    - fallen_warrior_inf_drop_rare_drops 1
 fallen_warrior_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -14,12 +15,19 @@ fallen_warrior_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.005
+
+fallen_warrior_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.0005
+    - nothing 1 0.9995
 
 fallen_archer_inf_drop:
   Drops:
     - ips 1 0.01
     - fallen_archer_inf_drop_item_drops 1
+    - fallen_archer_inf_drop_rare_drops 1
 fallen_archer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -29,12 +37,19 @@ fallen_archer_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.005
+
+fallen_archer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.0005
+    - nothing 1 0.9995
 
 raging_soul_inf_drop:
   Drops:
     - ips 1 0.01
     - raging_soul_inf_drop_item_drops 1
+    - raging_soul_inf_drop_rare_drops 1
 raging_soul_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -44,12 +59,19 @@ raging_soul_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.005
+
+raging_soul_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.0005
+    - nothing 1 0.9995
 
 elite_skeleton_archer_inf_drop:
   Drops:
     - ips 1 0.25
     - elite_skeleton_archer_inf_drop_item_drops 1
+    - elite_skeleton_archer_inf_drop_rare_drops 1
 elite_skeleton_archer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -59,12 +81,19 @@ elite_skeleton_archer_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.01
+
+elite_skeleton_archer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.01
+    - nothing 1 0.99
 
 elite_skeleton_warrior_inf_drop:
   Drops:
     - ips 1 0.25
     - elite_skeleton_warrior_inf_drop_item_drops 1
+    - elite_skeleton_warrior_inf_drop_rare_drops 1
 elite_skeleton_warrior_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -74,12 +103,19 @@ elite_skeleton_warrior_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.01
+
+elite_skeleton_warrior_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.01
+    - nothing 1 0.99
 
 death_knight_inf_drop:
   Drops:
     - ips 1 0.25
     - death_knight_inf_drop_item_drops 1
+    - death_knight_inf_drop_rare_drops 1
 death_knight_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -89,12 +125,19 @@ death_knight_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.01
+
+death_knight_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.01
+    - nothing 1 0.99
 
 death_archer_inf_drop:
   Drops:
     - ips 1 0.25
     - death_archer_inf_drop_item_drops 1
+    - death_archer_inf_drop_rare_drops 1
 death_archer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -104,12 +147,19 @@ death_archer_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.01
     - dark_exile_boots_infernal 1 0.01
     - dark_exile_scythe_infernal 1 0.01
+
+death_archer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.01
+    - nothing 1 0.99
 
 mortis_death_knight_inf_drop:
   Drops:
     - ips 1 0.5
     - mortis_death_knight_inf_drop_item_drops 1
+    - mortis_death_knight_inf_drop_rare_drops 1
 mortis_death_knight_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -119,12 +169,19 @@ mortis_death_knight_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.04
     - dark_exile_boots_infernal 1 0.04
     - dark_exile_scythe_infernal 1 0.04
+
+mortis_death_knight_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.04
+    - nothing 1 0.96
 
 murot_priest_inf_drop:
   Drops:
     - ips 1 0.5
     - murot_priest_inf_drop_item_drops 1
+    - murot_priest_inf_drop_rare_drops 1
 murot_priest_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -134,13 +191,20 @@ murot_priest_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.04
     - dark_exile_boots_infernal 1 0.04
     - dark_exile_scythe_infernal 1 0.04
+
+murot_priest_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.04
+    - nothing 1 0.96
 
 mortis_inf_drop:
   Drops:
     - mortis_frag_I 1 0.05
     - ips 1 1
     - mortis_inf_drop_item_drops 1
+    - mortis_inf_drop_rare_drops 1
 mortis_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -150,7 +214,13 @@ mortis_inf_drop_item_drops:
     - dark_exile_leggings_infernal 1 0.1
     - dark_exile_boots_infernal 1 0.1
     - dark_exile_scythe_infernal 1 0.1
+
+mortis_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -159,6 +229,7 @@ fallen_warrior_hell_drop:
   Drops:
     - ips 2 0.01
     - fallen_warrior_hell_drop_item_drops 1
+    - fallen_warrior_hell_drop_rare_drops 1
 fallen_warrior_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -168,12 +239,19 @@ fallen_warrior_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.01
     - dark_exile_boots_hell 1 0.01
     - dark_exile_scythe_hell 1 0.01
+
+fallen_warrior_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.001
+    - nothing 1 0.999
 
 fallen_archer_hell_drop:
   Drops:
     - ips 2 0.01
     - fallen_archer_hell_drop_item_drops 1
+    - fallen_archer_hell_drop_rare_drops 1
 fallen_archer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -183,12 +261,19 @@ fallen_archer_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.01
     - dark_exile_boots_hell 1 0.01
     - dark_exile_scythe_hell 1 0.01
+
+fallen_archer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.001
+    - nothing 1 0.999
 
 raging_soul_hell_drop:
   Drops:
     - ips 2 0.01
     - raging_soul_hell_drop_item_drops 1
+    - raging_soul_hell_drop_rare_drops 1
 raging_soul_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -198,12 +283,19 @@ raging_soul_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.01
     - dark_exile_boots_hell 1 0.01
     - dark_exile_scythe_hell 1 0.01
+
+raging_soul_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.001
+    - nothing 1 0.999
 
 elite_skeleton_archer_hell_drop:
   Drops:
     - ips 2 0.25
     - elite_skeleton_archer_hell_drop_item_drops 1
+    - elite_skeleton_archer_hell_drop_rare_drops 1
 elite_skeleton_archer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -213,12 +305,19 @@ elite_skeleton_archer_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.025
     - dark_exile_boots_hell 1 0.025
     - dark_exile_scythe_hell 1 0.05
+
+elite_skeleton_archer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.02
+    - nothing 1 0.98
 
 elite_skeleton_warrior_hell_drop:
   Drops:
     - ips 2 0.25
     - elite_skeleton_warrior_hell_drop_item_drops 1
+    - elite_skeleton_warrior_hell_drop_rare_drops 1
 elite_skeleton_warrior_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -228,12 +327,19 @@ elite_skeleton_warrior_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.025
     - dark_exile_boots_hell 1 0.025
     - dark_exile_scythe_hell 1 0.05
+
+elite_skeleton_warrior_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.02
+    - nothing 1 0.98
 
 death_knight_hell_drop:
   Drops:
     - ips 2 0.25
     - death_knight_hell_drop_item_drops 1
+    - death_knight_hell_drop_rare_drops 1
 death_knight_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -243,12 +349,19 @@ death_knight_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.025
     - dark_exile_boots_hell 1 0.025
     - dark_exile_scythe_hell 1 0.05
+
+death_knight_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.02
+    - nothing 1 0.98
 
 death_archer_hell_drop:
   Drops:
     - ips 2 0.25
     - death_archer_hell_drop_item_drops 1
+    - death_archer_hell_drop_rare_drops 1
 death_archer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -258,12 +371,19 @@ death_archer_hell_drop_item_drops:
     - dark_exile_leggings_hell 1 0.025
     - dark_exile_boots_hell 1 0.025
     - dark_exile_scythe_hell 1 0.05
+
+death_archer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_hell 1 0.02
+    - nothing 1 0.98
 
 mortis_death_knight_hell_drop:
   Drops:
     - ips 2 0.5
     - mortis_death_knight_hell_drop_item_drops 1
+    - mortis_death_knight_hell_drop_rare_drops 1
 mortis_death_knight_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -274,12 +394,19 @@ mortis_death_knight_hell_drop_item_drops:
     - dark_exile_boots_hell 1 0.05
     - dark_exile_scythe_hell 1 0.05
     - mortis_ring_of_death_hell 1 0.05
+
+mortis_death_knight_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - seal_of_death_hell 1 0.0125
+    - nothing 1 0.9875
 
 murot_priest_hell_drop:
   Drops:
     - ips 2 0.5
     - murot_priest_hell_drop_item_drops 1
+    - murot_priest_hell_drop_rare_drops 1
 murot_priest_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -290,13 +417,20 @@ murot_priest_hell_drop_item_drops:
     - dark_exile_boots_hell 1 0.05
     - dark_exile_scythe_hell 1 0.05
     - mortis_ring_of_death_hell 1 0.05
+
+murot_priest_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - seal_of_death_hell 1 0.0125
+    - nothing 1 0.9875
 
 mortis_hell_drop:
   Drops:
     - mortis_frag_II 1 0.05
     - ips 2 1
     - mortis_hell_drop_item_drops 1
+    - mortis_hell_drop_rare_drops 1
 mortis_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -308,7 +442,13 @@ mortis_hell_drop_item_drops:
     - dark_exile_scythe_hell 1 0.125
     - dark_exile_scythe_hell 1 0.125
     - mortis_ring_of_death_hell 1 0.125
+
+mortis_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - seal_of_death_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -317,6 +457,7 @@ fallen_warrior_blood_drop:
   Drops:
     - ips 3 0.01
     - fallen_warrior_blood_drop_item_drops 1
+    - fallen_warrior_blood_drop_rare_drops 1
 fallen_warrior_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -326,12 +467,19 @@ fallen_warrior_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.01
     - dark_exile_boots_blood 1 0.01
     - dark_exile_scythe_blood 1 0.015
+
+fallen_warrior_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.005
+    - nothing 1 0.995
 
 fallen_archer_blood_drop:
   Drops:
     - ips 3 0.01
     - fallen_archer_blood_drop_item_drops 1
+    - fallen_archer_blood_drop_rare_drops 1
 fallen_archer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -341,12 +489,19 @@ fallen_archer_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.01
     - dark_exile_boots_blood 1 0.01
     - dark_exile_scythe_blood 1 0.015
+
+fallen_archer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.005
+    - nothing 1 0.995
 
 raging_soul_blood_drop:
   Drops:
     - ips 3 0.01
     - raging_soul_blood_drop_item_drops 1
+    - raging_soul_blood_drop_rare_drops 1
 raging_soul_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -356,12 +511,19 @@ raging_soul_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.01
     - dark_exile_boots_blood 1 0.01
     - dark_exile_scythe_blood 1 0.015
+
+raging_soul_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.005
+    - nothing 1 0.995
 
 elite_skeleton_archer_blood_drop:
   Drops:
     - ips 3 0.01
     - elite_skeleton_archer_blood_drop_item_drops 1
+    - elite_skeleton_archer_blood_drop_rare_drops 1
 elite_skeleton_archer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -371,12 +533,19 @@ elite_skeleton_archer_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.025
     - dark_exile_boots_blood 1 0.025
     - dark_exile_scythe_blood 1 0.075
+
+elite_skeleton_archer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.03
+    - nothing 1 0.97
 
 elite_skeleton_warrior_blood_drop:
   Drops:
     - ips 3 0.01
     - elite_skeleton_warrior_blood_drop_item_drops 1
+    - elite_skeleton_warrior_blood_drop_rare_drops 1
 elite_skeleton_warrior_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -386,12 +555,19 @@ elite_skeleton_warrior_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.025
     - dark_exile_boots_blood 1 0.025
     - dark_exile_scythe_blood 1 0.075
+
+elite_skeleton_warrior_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.03
+    - nothing 1 0.97
 
 death_knight_blood_drop:
   Drops:
     - ips 3 0.01
     - death_knight_blood_drop_item_drops 1
+    - death_knight_blood_drop_rare_drops 1
 death_knight_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -401,12 +577,19 @@ death_knight_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.05
     - dark_exile_boots_blood 1 0.05
     - dark_exile_scythe_blood 1 0.05
+
+death_knight_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.03
+    - nothing 1 0.97
 
 death_archer_blood_drop:
   Drops:
     - ips 3 0.01
     - death_archer_blood_drop_item_drops 1
+    - death_archer_blood_drop_rare_drops 1
 death_archer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -416,12 +599,19 @@ death_archer_blood_drop_item_drops:
     - dark_exile_leggings_blood 1 0.075
     - dark_exile_boots_blood 1 0.075
     - dark_exile_scythe_blood 1 0.075
+
+death_archer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - mortis_ring_of_death_blood 1 0.03
+    - nothing 1 0.97
 
 mortis_death_knight_blood_drop:
   Drops:
     - ips 3 0.5
     - mortis_death_knight_blood_drop_item_drops 1
+    - mortis_death_knight_blood_drop_rare_drops 1
 mortis_death_knight_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -434,12 +624,19 @@ mortis_death_knight_blood_drop_item_drops:
     - mortis_ring_of_death_blood 1 0.06
     - seal_of_death_blood 1 0.025
     - armor_of_unchained_death_god_blood 1 0.001
+
+mortis_death_knight_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - pants_of_unchained_death_god_blood 1 0.001
+    - nothing 1 0.999
 
 murot_priest_blood_drop:
   Drops:
     - ips 3 0.5
     - murot_priest_blood_drop_item_drops 1
+    - murot_priest_blood_drop_rare_drops 1
 murot_priest_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -452,14 +649,21 @@ murot_priest_blood_drop_item_drops:
     - mortis_ring_of_death_blood 1 0.06
     - seal_of_death_blood 1 0.025
     - armor_of_unchained_death_god_blood 1 0.001
+
+murot_priest_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - pants_of_unchained_death_god_blood 1 0.001
+    - nothing 1 0.999
 
 mortis_blood_drop:
   Drops:
     - mortis_frag_III 1 0.05
     - ips 3 1
     - mortis_blood_drop_item_drops 1
-    - q6_soul 1 0.01
+    - mortis_blood_drop_rare_drops 1
+    - q6_soul_luck 1
 mortis_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -472,4 +676,18 @@ mortis_blood_drop_item_drops:
     - mortis_ring_of_death_blood 1 0.15
     - seal_of_death_blood 1 0.05
     - armor_of_unchained_death_god_blood 1 0.01
+
+mortis_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - pants_of_unchained_death_god_blood 1 0.01
+    - nothing 1 0.99
+
+
+q6_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q6_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q7_drops.yml
+++ b/droptables/Q7_drops.yml
@@ -5,6 +5,7 @@ bone_warder_inf_drop:
   Drops:
     - ips 1 0.01
     - bone_warder_inf_drop_item_drops 1
+    - bone_warder_inf_drop_rare_drops 1
 bone_warder_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ bone_warder_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.01
     - fire_shroud_of_sun_infernal 1 0.01
     - resolve_of_the_alliance_infernal 1 0.01
+
+bone_warder_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.0005
+    - nothing 1 0.9995
 
 b1000_combat_mechanoid_inf_drop:
   Drops:
     - ips 1 0.01
     - b1000_combat_mechanoid_inf_drop_item_drops 1
+    - b1000_combat_mechanoid_inf_drop_rare_drops 1
 b1000_combat_mechanoid_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ b1000_combat_mechanoid_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.01
     - fire_shroud_of_sun_infernal 1 0.01
     - resolve_of_the_alliance_infernal 1 0.01
+
+b1000_combat_mechanoid_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.0005
+    - nothing 1 0.9995
 
 thundering_cyclops_inf_drop:
   Drops:
     - ips 1 0.25
     - thundering_cyclops_inf_drop_item_drops 1
+    - thundering_cyclops_inf_drop_rare_drops 1
 thundering_cyclops_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ thundering_cyclops_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.25
     - fire_shroud_of_sun_infernal 1 0.25
     - resolve_of_the_alliance_infernal 1 0.05
+
+thundering_cyclops_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.01
+    - nothing 1 0.99
 
 dark_sentinel_inf_drop:
   Drops:
     - ips 1 0.25
     - dark_sentinel_inf_drop_item_drops 1
+    - dark_sentinel_inf_drop_rare_drops 1
 dark_sentinel_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ dark_sentinel_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.25
     - fire_shroud_of_sun_infernal 1 0.25
     - resolve_of_the_alliance_infernal 1 0.05
+
+dark_sentinel_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.01
+    - nothing 1 0.99
 
 gate_guard_inf_drop:
   Drops:
     - ips 1 0.5
     - gate_guard_inf_drop_item_drops 1
+    - gate_guard_inf_drop_rare_drops 1
 gate_guard_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -64,13 +93,20 @@ gate_guard_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.5
     - fire_shroud_of_sun_infernal 1 0.5
     - resolve_of_the_alliance_infernal 1 0.1
+
+gate_guard_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.04
+    - nothing 1 0.96
 
 # Mission 2 Mobs
 razorclaw_inf_drop:
   Drops:
     - ips 1 0.01
     - razorclaw_inf_drop_item_drops 1
+    - razorclaw_inf_drop_rare_drops 1
 razorclaw_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -78,12 +114,19 @@ razorclaw_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.01
     - fire_shroud_of_sun_infernal 1 0.01
     - resolve_of_the_alliance_infernal 1 0.01
+
+razorclaw_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.0005
+    - nothing 1 0.9995
 
 flamescale_inf_drop:
   Drops:
     - ips 1 0.01
     - flamescale_inf_drop_item_drops 1
+    - flamescale_inf_drop_rare_drops 1
 flamescale_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -91,12 +134,19 @@ flamescale_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.01
     - fire_shroud_of_sun_infernal 1 0.01
     - resolve_of_the_alliance_infernal 1 0.01
+
+flamescale_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.0005
+    - nothing 1 0.9995
 
 fireclaw_inf_drop:
   Drops:
     - ips 1 0.25
     - fireclaw_inf_drop_item_drops 1
+    - fireclaw_inf_drop_rare_drops 1
 fireclaw_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -104,12 +154,19 @@ fireclaw_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.25
     - fire_shroud_of_sun_infernal 1 0.25
     - resolve_of_the_alliance_infernal 1 0.05
+
+fireclaw_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.01
+    - nothing 1 0.99
 
 flamespawn_inf_drop:
   Drops:
     - ips 1 0.01
     - flamespawn_inf_drop_item_drops 1
+    - flamespawn_inf_drop_rare_drops 1
 flamespawn_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -117,12 +174,19 @@ flamespawn_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.01
     - fire_shroud_of_sun_infernal 1 0.01
     - resolve_of_the_alliance_infernal 1 0.01
+
+flamespawn_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.0005
+    - nothing 1 0.9995
 
 commander_inf_drop:
   Drops:
     - ips 1 0.5
     - commander_inf_drop_item_drops 1
+    - commander_inf_drop_rare_drops 1
 commander_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -130,7 +194,13 @@ commander_inf_drop_item_drops:
     - blazing_shield_infernal 1 0.5
     - fire_shroud_of_sun_infernal 1 0.5
     - resolve_of_the_alliance_infernal 1 0.1
+
+commander_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.04
+    - nothing 1 0.96
 
 # Mission 3 Boss
 herald_inf_drop:
@@ -138,6 +208,7 @@ herald_inf_drop:
     - heralds_frag_I 1 0.05
     - ips 1 1
     - herald_inf_drop_item_drops 1
+    - herald_inf_drop_rare_drops 1
 herald_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -145,7 +216,13 @@ herald_inf_drop_item_drops:
     - blazing_shield_infernal 1 1
     - fire_shroud_of_sun_infernal 1 1
     - resolve_of_the_alliance_infernal 1 0.25
+
+herald_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -155,6 +232,7 @@ bone_warder_hell_drop:
   Drops:
     - ips 2 0.01
     - bone_warder_hell_drop_item_drops 1
+    - bone_warder_hell_drop_rare_drops 1
 bone_warder_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -162,12 +240,19 @@ bone_warder_hell_drop_item_drops:
     - blazing_shield_hell 1 0.01
     - fire_shroud_of_sun_hell 1 0.01
     - resolve_of_the_alliance_hell 1 0.02
+
+bone_warder_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.001
+    - nothing 1 0.999
 
 b1000_combat_mechanoid_hell_drop:
   Drops:
     - ips 2 0.01
     - b1000_combat_mechanoid_hell_drop_item_drops 1
+    - b1000_combat_mechanoid_hell_drop_rare_drops 1
 b1000_combat_mechanoid_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -175,12 +260,19 @@ b1000_combat_mechanoid_hell_drop_item_drops:
     - blazing_shield_hell 1 0.01
     - fire_shroud_of_sun_hell 1 0.01
     - resolve_of_the_alliance_hell 1 0.02
+
+b1000_combat_mechanoid_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.001
+    - nothing 1 0.999
 
 thundering_cyclops_hell_drop:
   Drops:
     - ips 2 0.25
     - thundering_cyclops_hell_drop_item_drops 1
+    - thundering_cyclops_hell_drop_rare_drops 1
 thundering_cyclops_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -188,12 +280,19 @@ thundering_cyclops_hell_drop_item_drops:
     - blazing_shield_hell 1 0.025
     - fire_shroud_of_sun_hell 1 0.025
     - resolve_of_the_alliance_hell 1 0.1
+
+thundering_cyclops_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.02
+    - nothing 1 0.98
 
 dark_sentinel_hell_drop:
   Drops:
     - ips 2 0.25
     - dark_sentinel_hell_drop_item_drops 1
+    - dark_sentinel_hell_drop_rare_drops 1
 dark_sentinel_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -201,24 +300,38 @@ dark_sentinel_hell_drop_item_drops:
     - blazing_shield_hell 1 0.025
     - fire_shroud_of_sun_hell 1 0.025
     - resolve_of_the_alliance_hell 1 0.1
+
+dark_sentinel_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.02
+    - nothing 1 0.98
 
 gate_guard_hell_drop:
   Drops:
     - ips 2 0.5
     - gate_guard_hell_drop_item_drops 1
+    - gate_guard_hell_drop_rare_drops 1
 gate_guard_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - fyrgons_fire_belt_hell 1 0.05
+
+gate_guard_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - the_heralds_burning_thunder_hell 1 0.0125
+    - nothing 1 0.9875
 
 # Mission 2 Mobs
 razorclaw_hell_drop:
   Drops:
     - ips 2 0.01
     - razorclaw_hell_drop_item_drops 1
+    - razorclaw_hell_drop_rare_drops 1
 razorclaw_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -226,12 +339,19 @@ razorclaw_hell_drop_item_drops:
     - blazing_shield_hell 1 0.01
     - fire_shroud_of_sun_hell 1 0.01
     - resolve_of_the_alliance_hell 1 0.02
+
+razorclaw_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.001
+    - nothing 1 0.999
 
 flamescale_hell_drop:
   Drops:
     - ips 2 0.01
     - flamescale_hell_drop_item_drops 1
+    - flamescale_hell_drop_rare_drops 1
 flamescale_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -239,12 +359,19 @@ flamescale_hell_drop_item_drops:
     - blazing_shield_hell 1 0.01
     - fire_shroud_of_sun_hell 1 0.01
     - resolve_of_the_alliance_hell 1 0.02
+
+flamescale_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.001
+    - nothing 1 0.999
 
 fireclaw_hell_drop:
   Drops:
     - ips 2 0.25
     - fireclaw_hell_drop_item_drops 1
+    - fireclaw_hell_drop_rare_drops 1
 fireclaw_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -252,12 +379,19 @@ fireclaw_hell_drop_item_drops:
     - blazing_shield_hell 1 0.025
     - fire_shroud_of_sun_hell 1 0.025
     - resolve_of_the_alliance_hell 1 0.1
+
+fireclaw_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.02
+    - nothing 1 0.98
 
 flamespawn_hell_drop:
   Drops:
     - ips 2 0.01
     - flamespawn_hell_drop_item_drops 1
+    - flamespawn_hell_drop_rare_drops 1
 flamespawn_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -265,18 +399,31 @@ flamespawn_hell_drop_item_drops:
     - blazing_shield_hell 1 0.01
     - fire_shroud_of_sun_hell 1 0.01
     - resolve_of_the_alliance_hell 1 0.02
+
+flamespawn_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_hell 1 0.001
+    - nothing 1 0.999
 
 commander_hell_drop:
   Drops:
     - ips 2 0.5
     - commander_hell_drop_item_drops 1
+    - commander_hell_drop_rare_drops 1
 commander_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - fyrgons_fire_belt_hell 1 0.05
+
+commander_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - the_heralds_burning_thunder_hell 1 0.0125
+    - nothing 1 0.9875
 
 # Mission 3 Boss
 herald_hell_drop:
@@ -284,12 +431,19 @@ herald_hell_drop:
     - heralds_frag_II 1 0.05
     - ips 2 1
     - herald_hell_drop_item_drops 1
+    - herald_hell_drop_rare_drops 1
 herald_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - fyrgons_fire_belt_hell 1 0.125
+
+herald_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - the_heralds_burning_thunder_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -298,6 +452,7 @@ bone_warder_blood_drop:
   Drops:
     - ips 3 0.01
     - bone_warder_blood_drop_item_drops 1
+    - bone_warder_blood_drop_rare_drops 1
 bone_warder_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -305,12 +460,19 @@ bone_warder_blood_drop_item_drops:
     - blazing_shield_blood 1 0.01
     - fire_shroud_of_sun_blood 1 0.01
     - resolve_of_the_alliance_blood 1 0.03
+
+bone_warder_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.005
+    - nothing 1 0.995
 
 b1000_combat_mechanoid_blood_drop:
   Drops:
     - ips 3 0.01
     - b1000_combat_mechanoid_blood_drop_item_drops 1
+    - b1000_combat_mechanoid_blood_drop_rare_drops 1
 b1000_combat_mechanoid_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -318,12 +480,19 @@ b1000_combat_mechanoid_blood_drop_item_drops:
     - blazing_shield_blood 1 0.01
     - fire_shroud_of_sun_blood 1 0.01
     - resolve_of_the_alliance_blood 1 0.03
+
+b1000_combat_mechanoid_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.005
+    - nothing 1 0.995
 
 thundering_cyclops_blood_drop:
   Drops:
     - ips 3 0.01
     - thundering_cyclops_blood_drop_item_drops 1
+    - thundering_cyclops_blood_drop_rare_drops 1
 thundering_cyclops_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -331,12 +500,19 @@ thundering_cyclops_blood_drop_item_drops:
     - blazing_shield_blood 1 0.25
     - fire_shroud_of_sun_blood 1 0.025
     - resolve_of_the_alliance_blood 1 0.2
+
+thundering_cyclops_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.03
+    - nothing 1 0.97
 
 dark_sentinel_blood_drop:
   Drops:
     - ips 3 0.01
     - dark_sentinel_blood_drop_item_drops 1
+    - dark_sentinel_blood_drop_rare_drops 1
 dark_sentinel_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -344,12 +520,19 @@ dark_sentinel_blood_drop_item_drops:
     - blazing_shield_blood 1 0.25
     - fire_shroud_of_sun_blood 1 0.025
     - resolve_of_the_alliance_blood 1 0.2
+
+dark_sentinel_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.03
+    - nothing 1 0.97
 
 gate_guard_blood_drop:
   Drops:
     - ips 3 0.5
     - gate_guard_blood_drop_item_drops 1
+    - gate_guard_blood_drop_rare_drops 1
 gate_guard_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -357,13 +540,20 @@ gate_guard_blood_drop_item_drops:
     - fyrgons_fire_belt_blood 1 0.06
     - the_heralds_burning_thunder_blood 1 0.025
     - the_heralds_blazing_onslaught_blood 1 0.001
+
+gate_guard_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - unbreakable_magma_blood 1 0.001
+    - nothing 1 0.999
 
 # Mission 2 Mobs
 razorclaw_blood_drop:
   Drops:
     - ips 3 0.01
     - razorclaw_blood_drop_item_drops 1
+    - razorclaw_blood_drop_rare_drops 1
 razorclaw_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -371,12 +561,19 @@ razorclaw_blood_drop_item_drops:
     - blazing_shield_blood 1 0.01
     - fire_shroud_of_sun_blood 1 0.01
     - resolve_of_the_alliance_blood 1 0.03
+
+razorclaw_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.005
+    - nothing 1 0.995
 
 flamescale_blood_drop:
   Drops:
     - ips 3 0.01
     - flamescale_blood_drop_item_drops 1
+    - flamescale_blood_drop_rare_drops 1
 flamescale_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -384,12 +581,19 @@ flamescale_blood_drop_item_drops:
     - blazing_shield_blood 1 0.01
     - fire_shroud_of_sun_blood 1 0.01
     - resolve_of_the_alliance_blood 1 0.03
+
+flamescale_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.005
+    - nothing 1 0.995
 
 fireclaw_blood_drop:
   Drops:
     - ips 3 0.01
     - fireclaw_blood_drop_item_drops 1
+    - fireclaw_blood_drop_rare_drops 1
 fireclaw_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -397,12 +601,19 @@ fireclaw_blood_drop_item_drops:
     - blazing_shield_blood 1 0.25
     - fire_shroud_of_sun_blood 1 0.025
     - resolve_of_the_alliance_blood 1 0.2
+
+fireclaw_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.03
+    - nothing 1 0.97
 
 flamespawn_blood_drop:
   Drops:
     - ips 3 0.01
     - flamespawn_blood_drop_item_drops 1
+    - flamespawn_blood_drop_rare_drops 1
 flamespawn_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -410,12 +621,19 @@ flamespawn_blood_drop_item_drops:
     - blazing_shield_blood 1 0.01
     - fire_shroud_of_sun_blood 1 0.01
     - resolve_of_the_alliance_blood 1 0.03
+
+flamespawn_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fyrgons_fire_belt_blood 1 0.005
+    - nothing 1 0.995
 
 commander_blood_drop:
   Drops:
     - ips 3 0.5
     - commander_blood_drop_item_drops 1
+    - commander_blood_drop_rare_drops 1
 commander_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -423,7 +641,13 @@ commander_blood_drop_item_drops:
     - fyrgons_fire_belt_blood 1 0.06
     - the_heralds_burning_thunder_blood 1 0.025
     - the_heralds_blazing_onslaught_blood 1 0.001
+
+commander_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - unbreakable_magma_blood 1 0.001
+    - nothing 1 0.999
 
 # Mission 3 Boss
 herald_blood_drop:
@@ -431,7 +655,8 @@ herald_blood_drop:
     - heralds_frag_III 1 0.05
     - ips 3 1
     - herald_blood_drop_item_drops 1
-    - q7_soul 1 0.01
+    - herald_blood_drop_rare_drops 1
+    - q7_soul_luck 1
 herald_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -439,4 +664,18 @@ herald_blood_drop_item_drops:
     - fyrgons_fire_belt_blood 1 0.15
     - the_heralds_burning_thunder_blood 1 0.05
     - the_heralds_blazing_onslaught_blood 1 0.01
+
+herald_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - unbreakable_magma_blood 1 0.01
+    - nothing 1 0.99
+
+
+q7_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q7_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q8_drops.yml
+++ b/droptables/Q8_drops.yml
@@ -5,6 +5,7 @@ electrified_ferocity_inf_drop:
   Drops:
     - ips 1 0.01
     - electrified_ferocity_inf_drop_item_drops 1
+    - electrified_ferocity_inf_drop_rare_drops 1
 electrified_ferocity_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ electrified_ferocity_inf_drop_item_drops:
     - frost_axe_infernal 1 0.01
     - frozen_mud_boots_infernal 1 0.01
     - unity_of_the_alliance_infernal 1 0.01
+
+electrified_ferocity_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.0005
+    - nothing 1 0.9995
 
 charged_drone_inf_drop:
   Drops:
     - ips 1 0.01
     - charged_drone_inf_drop_item_drops 1
+    - charged_drone_inf_drop_rare_drops 1
 charged_drone_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ charged_drone_inf_drop_item_drops:
     - frost_axe_infernal 1 0.01
     - frozen_mud_boots_infernal 1 0.01
     - unity_of_the_alliance_infernal 1 0.01
+
+charged_drone_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.0005
+    - nothing 1 0.9995
 
 big_heap_of_ice_inf_drop:
   Drops:
     - ips 1 0.25
     - big_heap_of_ice_inf_drop_item_drops 1
+    - big_heap_of_ice_inf_drop_rare_drops 1
 big_heap_of_ice_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ big_heap_of_ice_inf_drop_item_drops:
     - frost_axe_infernal 1 0.25
     - frozen_mud_boots_infernal 1 0.25
     - unity_of_the_alliance_infernal 1 0.05
+
+big_heap_of_ice_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.01
+    - nothing 1 0.99
 
 frostwolf_inf_drop:
   Drops:
     - ips 1 0.25
     - frostwolf_inf_drop_item_drops 1
+    - frostwolf_inf_drop_rare_drops 1
 frostwolf_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ frostwolf_inf_drop_item_drops:
     - frost_axe_infernal 1 0.25
     - frozen_mud_boots_infernal 1 0.25
     - unity_of_the_alliance_infernal 1 0.05
+
+frostwolf_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.01
+    - nothing 1 0.99
 
 shocking_forocity_inf_drop:
   Drops:
     - ips 1 0.5
     - shocking_forocity_inf_drop_item_drops 1
+    - shocking_forocity_inf_drop_rare_drops 1
 shocking_forocity_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -64,13 +93,20 @@ shocking_forocity_inf_drop_item_drops:
     - frost_axe_infernal 1 0.5
     - frozen_mud_boots_infernal 1 0.5
     - unity_of_the_alliance_infernal 1 0.1
+
+shocking_forocity_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.04
+    - nothing 1 0.96
 
 # Mission 2 Mobs
 pale_pillager_inf_drop:
   Drops:
     - ips 1 0.01
     - pale_pillager_inf_drop_item_drops 1
+    - pale_pillager_inf_drop_rare_drops 1
 pale_pillager_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -78,12 +114,19 @@ pale_pillager_inf_drop_item_drops:
     - frost_axe_infernal 1 0.01
     - frozen_mud_boots_infernal 1 0.01
     - unity_of_the_alliance_infernal 1 0.01
+
+pale_pillager_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.0005
+    - nothing 1 0.9995
 
 simple_troll_inf_drop:
   Drops:
     - ips 1 0.01
     - simple_troll_inf_drop_item_drops 1
+    - simple_troll_inf_drop_rare_drops 1
 simple_troll_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -91,12 +134,19 @@ simple_troll_inf_drop_item_drops:
     - frost_axe_infernal 1 0.01
     - frozen_mud_boots_infernal 1 0.01
     - unity_of_the_alliance_infernal 1 0.01
+
+simple_troll_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.0005
+    - nothing 1 0.9995
 
 frost_magician_inf_drop:
   Drops:
     - ips 1 0.25
     - frost_magician_inf_drop_item_drops 1
+    - frost_magician_inf_drop_rare_drops 1
 frost_magician_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -104,12 +154,19 @@ frost_magician_inf_drop_item_drops:
     - frost_axe_infernal 1 0.25
     - frozen_mud_boots_infernal 1 0.25
     - unity_of_the_alliance_infernal 1 0.05
+
+frost_magician_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.01
+    - nothing 1 0.99
 
 frost_bringer_inf_drop:
   Drops:
     - ips 1 0.25
     - frost_bringer_inf_drop_item_drops 1
+    - frost_bringer_inf_drop_rare_drops 1
 frost_bringer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -117,12 +174,19 @@ frost_bringer_inf_drop_item_drops:
     - frost_axe_infernal 1 0.25
     - frozen_mud_boots_infernal 1 0.25
     - unity_of_the_alliance_infernal 1 0.05
+
+frost_bringer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.01
+    - nothing 1 0.99
 
 pale_enforcer_inf_drop:
   Drops:
     - ips 1 0.5
     - pale_enforcer_inf_drop_item_drops 1
+    - pale_enforcer_inf_drop_rare_drops 1
 pale_enforcer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -130,7 +194,13 @@ pale_enforcer_inf_drop_item_drops:
     - frost_axe_infernal 1 0.5
     - frozen_mud_boots_infernal 1 0.5
     - unity_of_the_alliance_infernal 1 0.1
+
+pale_enforcer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.04
+    - nothing 1 0.96
 
 # Mission 3 Boss
 sigrismarr_inf_drop:
@@ -138,6 +208,7 @@ sigrismarr_inf_drop:
     - sigrismar_frag_I 1 0.05
     - ips 1 1
     - sigrismarr_inf_drop_item_drops 1
+    - sigrismarr_inf_drop_rare_drops 1
 sigrismarr_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -145,7 +216,13 @@ sigrismarr_inf_drop_item_drops:
     - frost_axe_infernal 1 1
     - frozen_mud_boots_infernal 1 1
     - unity_of_the_alliance_infernal 1 0.25
+
+sigrismarr_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -155,6 +232,7 @@ electrified_ferocity_hell_drop:
   Drops:
     - ips 2 0.01
     - electrified_ferocity_hell_drop_item_drops 1
+    - electrified_ferocity_hell_drop_rare_drops 1
 electrified_ferocity_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -162,12 +240,19 @@ electrified_ferocity_hell_drop_item_drops:
     - frost_axe_hell 1 0.01
     - frozen_mud_boots_hell 1 0.01
     - unity_of_the_alliance_hell 1 0.02
+
+electrified_ferocity_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.001
+    - nothing 1 0.999
 
 charged_drone_hell_drop:
   Drops:
     - ips 2 0.01
     - charged_drone_hell_drop_item_drops 1
+    - charged_drone_hell_drop_rare_drops 1
 charged_drone_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -175,12 +260,19 @@ charged_drone_hell_drop_item_drops:
     - frost_axe_hell 1 0.01
     - frozen_mud_boots_hell 1 0.01
     - unity_of_the_alliance_hell 1 0.02
+
+charged_drone_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.001
+    - nothing 1 0.999
 
 big_heap_hell_drop:
   Drops:
     - ips 2 0.25
     - big_heap_hell_drop_item_drops 1
+    - big_heap_hell_drop_rare_drops 1
 big_heap_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -188,12 +280,19 @@ big_heap_hell_drop_item_drops:
     - frost_axe_hell 1 0.025
     - frozen_mud_boots_hell 1 0.025
     - unity_of_the_alliance_hell 1 0.1
+
+big_heap_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.02
+    - nothing 1 0.98
 
 frostwolf_hell_drop:
   Drops:
     - ips 2 0.25
     - frostwolf_hell_drop_item_drops 1
+    - frostwolf_hell_drop_rare_drops 1
 frostwolf_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -201,24 +300,38 @@ frostwolf_hell_drop_item_drops:
     - frost_axe_hell 1 0.025
     - frozen_mud_boots_hell 1 0.025
     - unity_of_the_alliance_hell 1 0.1
+
+frostwolf_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.02
+    - nothing 1 0.98
 
 shocking_forocity_hell_drop:
   Drops:
     - ips 2 0.5
     - shocking_forocity_hell_drop_item_drops 1
+    - shocking_forocity_hell_drop_rare_drops 1
 shocking_forocity_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - fjalnirs_ring_of_frost_hell 1 0.05
+
+shocking_forocity_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sigrismarrs_eternal_ward_hell 1 0.0125
+    - nothing 1 0.9875
 
 # Mission 2 Mobs
 pale_pillager_hell_drop:
   Drops:
     - ips 2 0.01
     - pale_pillager_hell_drop_item_drops 1
+    - pale_pillager_hell_drop_rare_drops 1
 pale_pillager_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -226,12 +339,19 @@ pale_pillager_hell_drop_item_drops:
     - frost_axe_hell 1 0.01
     - frozen_mud_boots_hell 1 0.01
     - unity_of_the_alliance_hell 1 0.02
+
+pale_pillager_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.001
+    - nothing 1 0.999
 
 simple_troll_hell_drop:
   Drops:
     - ips 2 0.01
     - simple_troll_hell_drop_item_drops 1
+    - simple_troll_hell_drop_rare_drops 1
 simple_troll_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -239,12 +359,19 @@ simple_troll_hell_drop_item_drops:
     - frost_axe_hell 1 0.01
     - frozen_mud_boots_hell 1 0.01
     - unity_of_the_alliance_hell 1 0.02
+
+simple_troll_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.001
+    - nothing 1 0.999
 
 frost_magician_hell_drop:
   Drops:
     - ips 2 0.25
     - frost_magician_hell_drop_item_drops 1
+    - frost_magician_hell_drop_rare_drops 1
 frost_magician_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -252,12 +379,19 @@ frost_magician_hell_drop_item_drops:
     - frost_axe_hell 1 0.025
     - frozen_mud_boots_hell 1 0.025
     - unity_of_the_alliance_hell 1 0.1
+
+frost_magician_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.02
+    - nothing 1 0.98
 
 frost_bringer_hell_drop:
   Drops:
     - ips 2 0.25
     - frost_bringer_hell_drop_item_drops 1
+    - frost_bringer_hell_drop_rare_drops 1
 frost_bringer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -265,18 +399,31 @@ frost_bringer_hell_drop_item_drops:
     - frost_axe_hell 1 0.025
     - frozen_mud_boots_hell 1 0.025
     - unity_of_the_alliance_hell 1 0.1
+
+frost_bringer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_hell 1 0.02
+    - nothing 1 0.98
 
 pale_enforcer_hell_drop:
   Drops:
     - ips 2 0.5
     - pale_enforcer_hell_drop_item_drops 1
+    - pale_enforcer_hell_drop_rare_drops 1
 pale_enforcer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - fjalnirs_ring_of_frost_hell 1 0.05
+
+pale_enforcer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sigrismarrs_eternal_ward_hell 1 0.0125
+    - nothing 1 0.9875
 
 # Mission 3 Boss
 sigrismarr_hell_drop:
@@ -284,12 +431,19 @@ sigrismarr_hell_drop:
     - sigrismar_frag_II 1 0.05
     - ips 2 1
     - sigrismarr_hell_drop_item_drops 1
+    - sigrismarr_hell_drop_rare_drops 1
 sigrismarr_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - fjalnirs_ring_of_frost_hell 1 0.125
+
+sigrismarr_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sigrismarrs_eternal_ward_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -298,6 +452,7 @@ electrified_ferocity_blood_drop:
   Drops:
     - ips 3 0.01
     - electrified_ferocity_blood_drop_item_drops 1
+    - electrified_ferocity_blood_drop_rare_drops 1
 electrified_ferocity_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -305,12 +460,19 @@ electrified_ferocity_blood_drop_item_drops:
     - frost_axe_blood 1 0.01
     - frozen_mud_boots_blood 1 0.01
     - unity_of_the_alliance_blood 1 0.03
+
+electrified_ferocity_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.005
+    - nothing 1 0.995
 
 charged_drone_blood_drop:
   Drops:
     - ips 3 0.01
     - charged_drone_blood_drop_item_drops 1
+    - charged_drone_blood_drop_rare_drops 1
 charged_drone_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -318,12 +480,19 @@ charged_drone_blood_drop_item_drops:
     - frost_axe_blood 1 0.01
     - frozen_mud_boots_blood 1 0.01
     - unity_of_the_alliance_blood 1 0.03
+
+charged_drone_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.005
+    - nothing 1 0.995
 
 big_heap_blood_drop:
   Drops:
     - ips 3 0.01
     - big_heap_blood_drop_item_drops 1
+    - big_heap_blood_drop_rare_drops 1
 big_heap_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -331,12 +500,19 @@ big_heap_blood_drop_item_drops:
     - frost_axe_blood 1 0.25
     - frozen_mud_boots_blood 1 0.025
     - unity_of_the_alliance_blood 1 0.2
+
+big_heap_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.03
+    - nothing 1 0.97
 
 frostwolf_blood_drop:
   Drops:
     - ips 3 0.01
     - frostwolf_blood_drop_item_drops 1
+    - frostwolf_blood_drop_rare_drops 1
 frostwolf_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -344,25 +520,39 @@ frostwolf_blood_drop_item_drops:
     - frost_axe_blood 1 0.25
     - frozen_mud_boots_blood 1 0.025
     - unity_of_the_alliance_blood 1 0.2
+
+frostwolf_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.03
+    - nothing 1 0.97
 
 shocking_forocity_blood_drop:
   Drops:
     - ips 3 0.5
     - shocking_forocity_blood_drop_item_drops 1
+    - shocking_forocity_blood_drop_rare_drops 1
 shocking_forocity_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - fjalnirs_ring_of_frost_blood 1 0.06
     - sigrismarrs_eternal_ward_blood 1 0.025
+
+shocking_forocity_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sigrismarrs_eternal_grasp_blood 1 0.001
+    - nothing 1 0.999
 
 # Mission 2 Mobs
 pale_pillager_blood_drop:
   Drops:
     - ips 3 0.01
     - pale_pillager_blood_drop_item_drops 1
+    - pale_pillager_blood_drop_rare_drops 1
 pale_pillager_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -370,12 +560,19 @@ pale_pillager_blood_drop_item_drops:
     - frost_axe_blood 1 0.01
     - frozen_mud_boots_blood 1 0.01
     - unity_of_the_alliance_blood 1 0.03
+
+pale_pillager_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.005
+    - nothing 1 0.995
 
 simple_troll_blood_drop:
   Drops:
     - ips 3 0.01
     - simple_troll_blood_drop_item_drops 1
+    - simple_troll_blood_drop_rare_drops 1
 simple_troll_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -383,12 +580,19 @@ simple_troll_blood_drop_item_drops:
     - frost_axe_blood 1 0.01
     - frozen_mud_boots_blood 1 0.01
     - unity_of_the_alliance_blood 1 0.03
+
+simple_troll_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.005
+    - nothing 1 0.995
 
 frost_magician_blood_drop:
   Drops:
     - ips 3 0.01
     - frost_magician_blood_drop_item_drops 1
+    - frost_magician_blood_drop_rare_drops 1
 frost_magician_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -396,12 +600,19 @@ frost_magician_blood_drop_item_drops:
     - frost_axe_blood 1 0.25
     - frozen_mud_boots_blood 1 0.025
     - unity_of_the_alliance_blood 1 0.2
+
+frost_magician_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.03
+    - nothing 1 0.97
 
 frost_bringer_blood_drop:
   Drops:
     - ips 3 0.01
     - frost_bringer_blood_drop_item_drops 1
+    - frost_bringer_blood_drop_rare_drops 1
 frost_bringer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -409,19 +620,32 @@ frost_bringer_blood_drop_item_drops:
     - frost_axe_blood 1 0.25
     - frozen_mud_boots_blood 1 0.025
     - unity_of_the_alliance_blood 1 0.2
+
+frost_bringer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - fjalnirs_ring_of_frost_blood 1 0.03
+    - nothing 1 0.97
 
 pale_enforcer_blood_drop:
   Drops:
     - ips 3 0.5
     - pale_enforcer_blood_drop_item_drops 1
+    - pale_enforcer_blood_drop_rare_drops 1
 pale_enforcer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - fjalnirs_ring_of_frost_blood 1 0.06
     - sigrismarrs_eternal_ward_blood 1 0.025
+
+pale_enforcer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sigrismarrs_eternal_grasp_blood 1 0.001
+    - nothing 1 0.999
 
 # Mission 3 Boss
 sigrismarr_blood_drop:
@@ -429,11 +653,26 @@ sigrismarr_blood_drop:
     - sigrismar_frag_III 1 0.05
     - ips 3 1
     - sigrismarr_blood_drop_item_drops 1
-    - q8_soul 1 0.01
+    - sigrismarr_blood_drop_rare_drops 1
+    - q8_soul_luck 1
 sigrismarr_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - fjalnirs_ring_of_frost_blood 1 0.15
     - sigrismarrs_eternal_ward_blood 1 0.05
+
+sigrismarr_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - sigrismarrs_eternal_grasp_blood 1 0.01
+    - nothing 1 0.99
+
+
+q8_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q8_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Q9_drops.yml
+++ b/droptables/Q9_drops.yml
@@ -5,6 +5,7 @@ agile_satyr_warrior_inf_drop:
   Drops:
     - ips 1 0.01
     - agile_satyr_warrior_inf_drop_item_drops 1
+    - agile_satyr_warrior_inf_drop_rare_drops 1
 agile_satyr_warrior_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -12,12 +13,19 @@ agile_satyr_warrior_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.01
     - pure_chunk_of_meat_infernal 1 0.01
     - swiftness_of_the_alliance_infernal 1 0.01
+
+agile_satyr_warrior_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.0005
+    - nothing 1 0.9995
 
 perfidious_satyr_archer_inf_drop:
   Drops:
     - ips 1 0.01
     - perfidious_satyr_archer_inf_drop_item_drops 1
+    - perfidious_satyr_archer_inf_drop_rare_drops 1
 perfidious_satyr_archer_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -25,12 +33,19 @@ perfidious_satyr_archer_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.01
     - pure_chunk_of_meat_infernal 1 0.01
     - swiftness_of_the_alliance_infernal 1 0.01
+
+perfidious_satyr_archer_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.0005
+    - nothing 1 0.9995
 
 cohort_swordsman_inf_drop:
   Drops:
     - ips 1 0.25
     - cohort_swordsman_inf_drop_item_drops 1
+    - cohort_swordsman_inf_drop_rare_drops 1
 cohort_swordsman_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -38,12 +53,19 @@ cohort_swordsman_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.25
     - pure_chunk_of_meat_infernal 1 0.25
     - swiftness_of_the_alliance_infernal 1 0.05
+
+cohort_swordsman_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.01
+    - nothing 1 0.99
 
 stone_golem_inf_drop:
   Drops:
     - ips 1 0.25
     - stone_golem_inf_drop_item_drops 1
+    - stone_golem_inf_drop_rare_drops 1
 stone_golem_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,12 +73,19 @@ stone_golem_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.25
     - pure_chunk_of_meat_infernal 1 0.25
     - swiftness_of_the_alliance_infernal 1 0.05
+
+stone_golem_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.01
+    - nothing 1 0.99
 
 asterion_inf_drop:
   Drops:
     - ips 1 0.5
     - asterion_inf_drop_item_drops 1
+    - asterion_inf_drop_rare_drops 1
 asterion_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -64,13 +93,20 @@ asterion_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.5
     - pure_chunk_of_meat_infernal 1 0.5
     - swiftness_of_the_alliance_infernal 1 0.1
+
+asterion_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.04
+    - nothing 1 0.96
 
 # Mission 2 Mobs
 jabbax_inf_drop:
   Drops:
     - ips 1 0.01
     - jabbax_inf_drop_item_drops 1
+    - jabbax_inf_drop_rare_drops 1
 jabbax_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -78,12 +114,19 @@ jabbax_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.01
     - pure_chunk_of_meat_infernal 1 0.01
     - swiftness_of_the_alliance_infernal 1 0.01
+
+jabbax_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.0005
+    - nothing 1 0.9995
 
 zorlobb_warrior_inf_drop:
   Drops:
     - ips 1 0.25
     - zorlobb_warrior_inf_drop_item_drops 1
+    - zorlobb_warrior_inf_drop_rare_drops 1
 zorlobb_warrior_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -91,12 +134,19 @@ zorlobb_warrior_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.25
     - pure_chunk_of_meat_infernal 1 0.25
     - swiftness_of_the_alliance_infernal 1 0.05
+
+zorlobb_warrior_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.01
+    - nothing 1 0.99
 
 gorgon_acolyte_inf_drop:
   Drops:
     - ips 1 0.01
     - gorgon_acolyte_inf_drop_item_drops 1
+    - gorgon_acolyte_inf_drop_rare_drops 1
 gorgon_acolyte_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -104,12 +154,19 @@ gorgon_acolyte_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.01
     - pure_chunk_of_meat_infernal 1 0.01
     - swiftness_of_the_alliance_infernal 1 0.01
+
+gorgon_acolyte_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.0005
+    - nothing 1 0.9995
 
 minotaur_inf_drop:
   Drops:
     - ips 1 0.25
     - minotaur_inf_drop_item_drops 1
+    - minotaur_inf_drop_rare_drops 1
 minotaur_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -117,12 +174,19 @@ minotaur_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.25
     - pure_chunk_of_meat_infernal 1 0.25
     - swiftness_of_the_alliance_infernal 1 0.05
+
+minotaur_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.01
+    - nothing 1 0.99
 
 ebicarus_inf_drop:
   Drops:
     - ips 1 0.5
     - ebicarus_inf_drop_item_drops 1
+    - ebicarus_inf_drop_rare_drops 1
 ebicarus_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 2
@@ -130,7 +194,13 @@ ebicarus_inf_drop_item_drops:
     - ancient_hands_infernal 1 0.5
     - pure_chunk_of_meat_infernal 1 0.5
     - swiftness_of_the_alliance_infernal 1 0.1
+
+ebicarus_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.04
+    - nothing 1 0.96
 
 # Mission 3 Boss
 medusa_inf_drop:
@@ -138,6 +208,7 @@ medusa_inf_drop:
     - medusa_frag_I 1 0.05
     - ips 1 1
     - medusa_inf_drop_item_drops 1
+    - medusa_inf_drop_rare_drops 1
 medusa_inf_drop_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -145,7 +216,13 @@ medusa_inf_drop_item_drops:
     - ancient_hands_infernal 1 1
     - pure_chunk_of_meat_infernal 1 1
     - swiftness_of_the_alliance_infernal 1 0.25
+
+medusa_inf_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_infernal 1 0.1
+    - nothing 1 0.9
 
 # HELL HELL HELL
 # HELL HELL HELL
@@ -155,6 +232,7 @@ agile_satyr_warrior_hell_drop:
   Drops:
     - ips 2 0.01
     - agile_satyr_warrior_hell_drop_item_drops 1
+    - agile_satyr_warrior_hell_drop_rare_drops 1
 agile_satyr_warrior_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -162,12 +240,19 @@ agile_satyr_warrior_hell_drop_item_drops:
     - ancient_hands_hell 1 0.01
     - pure_chunk_of_meat_hell 1 0.01
     - swiftness_of_the_alliance_hell 1 0.02
+
+agile_satyr_warrior_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.001
+    - nothing 1 0.999
 
 perfidious_satyr_archer_hell_drop:
   Drops:
     - ips 2 0.01
     - perfidious_satyr_archer_hell_drop_item_drops 1
+    - perfidious_satyr_archer_hell_drop_rare_drops 1
 perfidious_satyr_archer_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -175,12 +260,19 @@ perfidious_satyr_archer_hell_drop_item_drops:
     - ancient_hands_hell 1 0.01
     - pure_chunk_of_meat_hell 1 0.01
     - swiftness_of_the_alliance_hell 1 0.02
+
+perfidious_satyr_archer_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.001
+    - nothing 1 0.999
 
 cohort_swordsman_hell_drop:
   Drops:
     - ips 2 0.25
     - cohort_swordsman_hell_drop_item_drops 1
+    - cohort_swordsman_hell_drop_rare_drops 1
 cohort_swordsman_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -188,12 +280,19 @@ cohort_swordsman_hell_drop_item_drops:
     - ancient_hands_hell 1 0.025
     - pure_chunk_of_meat_hell 1 0.025
     - swiftness_of_the_alliance_hell 1 0.1
+
+cohort_swordsman_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.02
+    - nothing 1 0.98
 
 stone_golem_hell_drop:
   Drops:
     - ips 2 0.25
     - stone_golem_hell_drop_item_drops 1
+    - stone_golem_hell_drop_rare_drops 1
 stone_golem_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -201,24 +300,38 @@ stone_golem_hell_drop_item_drops:
     - ancient_hands_hell 1 0.025
     - pure_chunk_of_meat_hell 1 0.025
     - swiftness_of_the_alliance_hell 1 0.1
+
+stone_golem_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.02
+    - nothing 1 0.98
 
 asterion_hell_drop:
   Drops:
     - ips 2 0.5
     - asterion_hell_drop_item_drops 1
+    - asterion_hell_drop_rare_drops 1
 asterion_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - oceanus_poison_crown_hell 1 0.05
+
+asterion_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - amulet_of_the_kraken_hell 1 0.0125
+    - nothing 1 0.9875
 
 # Mission 2 Mobs
 jabbax_hell_drop:
   Drops:
     - ips 2 0.01
     - jabbax_hell_drop_item_drops 1
+    - jabbax_hell_drop_rare_drops 1
 jabbax_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -226,12 +339,19 @@ jabbax_hell_drop_item_drops:
     - ancient_hands_hell 1 0.01
     - pure_chunk_of_meat_hell 1 0.01
     - swiftness_of_the_alliance_hell 1 0.02
+
+jabbax_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.001
+    - nothing 1 0.999
 
 zorlobb_warrior_hell_drop:
   Drops:
     - ips 2 0.25
     - zorlobb_warrior_hell_drop_item_drops 1
+    - zorlobb_warrior_hell_drop_rare_drops 1
 zorlobb_warrior_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -239,12 +359,19 @@ zorlobb_warrior_hell_drop_item_drops:
     - ancient_hands_hell 1 0.025
     - pure_chunk_of_meat_hell 1 0.025
     - swiftness_of_the_alliance_hell 1 0.1
+
+zorlobb_warrior_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.02
+    - nothing 1 0.98
 
 gorgon_acolyte_hell_drop:
   Drops:
     - ips 2 0.01
     - gorgon_acolyte_hell_drop_item_drops 1
+    - gorgon_acolyte_hell_drop_rare_drops 1
 gorgon_acolyte_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -252,12 +379,19 @@ gorgon_acolyte_hell_drop_item_drops:
     - ancient_hands_hell 1 0.01
     - pure_chunk_of_meat_hell 1 0.01
     - swiftness_of_the_alliance_hell 1 0.02
+
+gorgon_acolyte_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.001
+    - nothing 1 0.999
 
 minotaur_hell_drop:
   Drops:
     - ips 2 0.25
     - minotaur_hell_drop_item_drops 1
+    - minotaur_hell_drop_rare_drops 1
 minotaur_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -265,18 +399,31 @@ minotaur_hell_drop_item_drops:
     - ancient_hands_hell 1 0.025
     - pure_chunk_of_meat_hell 1 0.025
     - swiftness_of_the_alliance_hell 1 0.1
+
+minotaur_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_hell 1 0.02
+    - nothing 1 0.98
 
 ebicarus_hell_drop:
   Drops:
     - ips 2 0.5
     - ebicarus_hell_drop_item_drops 1
+    - ebicarus_hell_drop_rare_drops 1
 ebicarus_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - oceanus_poison_crown_hell 1 0.05
+
+ebicarus_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - amulet_of_the_kraken_hell 1 0.0125
+    - nothing 1 0.9875
 
 # Mission 3 Boss
 medusa_hell_drop:
@@ -284,12 +431,19 @@ medusa_hell_drop:
     - medusa_frag_II 1 0.05
     - ips 2 1
     - medusa_hell_drop_item_drops 1
+    - medusa_hell_drop_rare_drops 1
 medusa_hell_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - oceanus_poison_crown_hell 1 0.125
+
+medusa_hell_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - amulet_of_the_kraken_hell 1 0.025
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -298,6 +452,7 @@ agile_satyr_warrior_blood_drop:
   Drops:
     - ips 3 0.01
     - agile_satyr_warrior_blood_drop_item_drops 1
+    - agile_satyr_warrior_blood_drop_rare_drops 1
 agile_satyr_warrior_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -305,12 +460,19 @@ agile_satyr_warrior_blood_drop_item_drops:
     - ancient_hands_blood 1 0.01
     - pure_chunk_of_meat_blood 1 0.01
     - swiftness_of_the_alliance_blood 1 0.03
+
+agile_satyr_warrior_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.005
+    - nothing 1 0.995
 
 perfidious_satyr_archer_blood_drop:
   Drops:
     - ips 3 0.01
     - perfidious_satyr_archer_blood_drop_item_drops 1
+    - perfidious_satyr_archer_blood_drop_rare_drops 1
 perfidious_satyr_archer_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -318,12 +480,19 @@ perfidious_satyr_archer_blood_drop_item_drops:
     - ancient_hands_blood 1 0.01
     - pure_chunk_of_meat_blood 1 0.01
     - swiftness_of_the_alliance_blood 1 0.03
+
+perfidious_satyr_archer_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.005
+    - nothing 1 0.995
 
 cohort_swordsman_blood_drop:
   Drops:
     - ips 3 0.01
     - cohort_swordsman_blood_drop_item_drops 1
+    - cohort_swordsman_blood_drop_rare_drops 1
 cohort_swordsman_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -331,12 +500,19 @@ cohort_swordsman_blood_drop_item_drops:
     - ancient_hands_blood 1 0.25
     - pure_chunk_of_meat_blood 1 0.025
     - swiftness_of_the_alliance_blood 1 0.2
+
+cohort_swordsman_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.03
+    - nothing 1 0.97
 
 stone_golem_blood_drop:
   Drops:
     - ips 3 0.01
     - stone_golem_blood_drop_item_drops 1
+    - stone_golem_blood_drop_rare_drops 1
 stone_golem_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -344,25 +520,39 @@ stone_golem_blood_drop_item_drops:
     - ancient_hands_blood 1 0.25
     - pure_chunk_of_meat_blood 1 0.025
     - swiftness_of_the_alliance_blood 1 0.2
+
+stone_golem_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.03
+    - nothing 1 0.97
 
 asterion_blood_drop:
   Drops:
     - ips 3 0.5
     - asterion_blood_drop_item_drops 1
+    - asterion_blood_drop_rare_drops 1
 asterion_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - oceanus_poison_crown_blood 1 0.06
     - amulet_of_the_kraken_blood 1 0.025
+
+asterion_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - gorgonskin_leather_boots_blood 1 0.001
+    - nothing 1 0.999
 
 # Mission 2 Mobs
 jabbax_blood_drop:
   Drops:
     - ips 3 0.01
     - jabbax_blood_drop_item_drops 1
+    - jabbax_blood_drop_rare_drops 1
 jabbax_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -370,12 +560,19 @@ jabbax_blood_drop_item_drops:
     - ancient_hands_blood 1 0.01
     - pure_chunk_of_meat_blood 1 0.01
     - swiftness_of_the_alliance_blood 1 0.03
+
+jabbax_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.005
+    - nothing 1 0.995
 
 zorlobb_warrior_blood_drop:
   Drops:
     - ips 3 0.01
     - zorlobb_warrior_blood_drop_item_drops 1
+    - zorlobb_warrior_blood_drop_rare_drops 1
 zorlobb_warrior_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -383,12 +580,19 @@ zorlobb_warrior_blood_drop_item_drops:
     - ancient_hands_blood 1 0.25
     - pure_chunk_of_meat_blood 1 0.025
     - swiftness_of_the_alliance_blood 1 0.2
+
+zorlobb_warrior_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.03
+    - nothing 1 0.97
 
 gorgon_acolyte_blood_drop:
   Drops:
     - ips 3 0.01
     - gorgon_acolyte_blood_drop_item_drops 1
+    - gorgon_acolyte_blood_drop_rare_drops 1
 gorgon_acolyte_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -396,12 +600,19 @@ gorgon_acolyte_blood_drop_item_drops:
     - ancient_hands_blood 1 0.01
     - pure_chunk_of_meat_blood 1 0.01
     - swiftness_of_the_alliance_blood 1 0.03
+
+gorgon_acolyte_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.005
+    - nothing 1 0.995
 
 minotaur_blood_drop:
   Drops:
     - ips 3 0.01
     - minotaur_blood_drop_item_drops 1
+    - minotaur_blood_drop_rare_drops 1
 minotaur_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -409,19 +620,32 @@ minotaur_blood_drop_item_drops:
     - ancient_hands_blood 1 0.25
     - pure_chunk_of_meat_blood 1 0.025
     - swiftness_of_the_alliance_blood 1 0.2
+
+minotaur_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - oceanus_poison_crown_blood 1 0.03
+    - nothing 1 0.97
 
 ebicarus_blood_drop:
   Drops:
     - ips 3 0.5
     - ebicarus_blood_drop_item_drops 1
+    - ebicarus_blood_drop_rare_drops 1
 ebicarus_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 2
   Drops:
     - oceanus_poison_crown_blood 1 0.06
     - amulet_of_the_kraken_blood 1 0.025
+
+ebicarus_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - gorgonskin_leather_boots_blood 1 0.001
+    - nothing 1 0.999
 
 # Mission 3 Boss
 medusa_blood_drop:
@@ -429,11 +653,26 @@ medusa_blood_drop:
     - medusa_frag_III 1 0.05
     - ips 3 1
     - medusa_blood_drop_item_drops 1
-    - q9_soul 1 0.01
+    - medusa_blood_drop_rare_drops 1
+    - q9_soul_luck 1
 medusa_blood_drop_item_drops:
   MinItems: 0
   MaxItems: 3
   Drops:
     - oceanus_poison_crown_blood 1 0.15
     - amulet_of_the_kraken_blood 1 0.05
+
+medusa_blood_drop_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - gorgonskin_leather_boots_blood 1 0.01
+    - nothing 1 0.99
+
+
+q9_soul_luck:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - q9_soul 1 0.01
+    - nothing 1 0.99

--- a/droptables/Silfmoor_11-15_drops.yml
+++ b/droptables/Silfmoor_11-15_drops.yml
@@ -2,20 +2,28 @@ black_fur:
   Drops:
     # - experience 10
     - black_fur_item_drops 1
+    - black_fur_rare_drops 1
 black_fur_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - old_armor 1 0.05
     - simple_slacks 1 0.05
+
+black_fur_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - rafined_helmet 1 0.01
     - beast_hunter_sword 1 0.005
     - slimed_pants 1 0.005
+    - nothing 1 0.98
 
 bog_beast:
   Drops:
     # - experience 10
     - bog_beast_item_drops 1
+    - bog_beast_rare_drops 1
 bog_beast_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -23,20 +31,34 @@ bog_beast_item_drops:
     - old_armor 1 0.075
     - simple_slacks 1 0.075
     - rafined_helmet 1 0.03
+
+bog_beast_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - beast_hunter_sword 1 0.015
     - slimed_pants 1 0.015
     - black_fur_hunter_spear 1 0.005
+    - nothing 1 0.965
 
 talking:
   Drops:
     - fur_black 1 0.25
     - talking_item_drops 1
+    - talking_rare_drops 1
 talking_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - rafined_helmet 1 0.08
+
+talking_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - beast_hunter_sword 1 0.025
     - slimed_pants 1 0.025
     - black_fur_hunter_spear 1 0.015
     - talking_skeleton_skull 1 0.005
+    - nothing 1 0.93
+

--- a/droptables/Stalgard_36-40_drops.yml
+++ b/droptables/Stalgard_36-40_drops.yml
@@ -3,40 +3,53 @@ saw:
     # - experience 10
     - saw_item_drops 1
 saw_item_drops:
-  MinItems: 0
-  MaxItems: 1
+  TotalItems: 1
+  BonusLuckItems: 0.15
   Drops:
     - gearforged_helm 1 0.01
     - steelwalker_boots 1 0.01
     - steamforged_axe 1 0.005
     - automaton_blade 1 0.005
+    - nothing 1 0.97
 
 technik:
   Drops:
     # - experience 10
     - technik_item_drops 1
+    - technik_rare_drops 1
 technik_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - gearforged_helm 1 0.03
+technik_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - steelwalker_boots 1 0.003
     - steamforged_axe 1 0.015
     - automaton_blade 1 0.015
     - ironclad_chestplate 1 0.005
+    - nothing 1 0.962
 
 high_priest_danzo:
   Drops:
     # - experience 10
     - dragon_gold 1 0.25
     - high_priest_danzo_item_drops 1
+    - high_priest_danzo_rare_drops 1
 high_priest_danzo_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - gearforged_helm 1 0.08
     - steelwalker_boots 1 0.08
+high_priest_danzo_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - steamforged_axe 1 0.025
     - automaton_blade 1 0.025
     - ironclad_chestplate 1 0.015
     - clockwork_greaves 1 0.005
+    - nothing 1 0.93

--- a/droptables/Swerdfield_1-5_drops.yml
+++ b/droptables/Swerdfield_1-5_drops.yml
@@ -3,19 +3,27 @@ undead_villager_drops:
    # - experience 10
    # - money 10
     - undead_villager_item_drops 1
+    - undead_villager_rare_drops 1
 undead_villager_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - worn_chainmail 1 0.05
     - torn_leggings 1 0.05
+
+undead_villager_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - decent_blade 1 0.01
     - tabi_boots 1 0.005
+    - nothing 1 0.985
 
 undead_knight_drops:
   Drops:
     - broken_armor_piece 1 0.25
     - undead_knight_item_drops 1
+    - undead_knight_rare_drops 1
 undead_knight_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -23,5 +31,11 @@ undead_knight_item_drops:
     - worn_chainmail 1 0.075
     - torn_leggings 1 0.075
     - decent_blade 1 0.03
+
+undead_knight_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - tabi_boots 1 0.015
     - bobs_helmet 1 0.005
+    - nothing 1 0.98

--- a/droptables/Teganswall_16-20_drops.yml
+++ b/droptables/Teganswall_16-20_drops.yml
@@ -2,6 +2,7 @@ soulless:
   Drops:
     # - experience 10
     - soulless_item_drops 1
+    - soulless_rare_drops 1
 soulless_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -10,14 +11,21 @@ soulless_item_drops:
     - diamond_greaves 1 0.05
     - diamond_cuirass 1 0.05
     - diamond_shoes 1 0.05
+
+soulless_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - rafined_sabre 1 0.01
     - burning_pants 1 0.005
     - burning_boots 1 0.005
+    - nothing 1 0.98
 
 dragons:
   Drops:
     # - experience 10
     - dragons_item_drops 1
+    - dragons_rare_drops 1
 dragons_item_drops:
   MinItems: 0
   MaxItems: 1
@@ -27,24 +35,38 @@ dragons_item_drops:
     - diamond_cuirass 1 0.075
     - diamond_shoes 1 0.075
     - rafined_sabre 1 0.03
+
+dragons_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - burning_pants 1 0.015
     - burning_boots 1 0.015
     - fire-hardened_armor 1 0.005
     - blazing_crown 1 0.005
+    - nothing 1 0.96
 
 commander:
   Drops:
     - dragon_scale 1 0.25
     # - experience 10
     - commander_item_drops 1
+    - commander_rare_drops 1
 commander_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - rafined_sabre 1 0.08
+
+commander_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - burning_pants 1 0.025
     - burning_boots 1 0.025
     - fire-hardened_armor 1 0.015
     - blazing_crown 1 0.015
     - imperial_chestarmor 1 0.005
     - sword_of_the_dragon_god 1 0.005
+    - nothing 1 0.91
+

--- a/droptables/Tywil_81-90_drops.yml
+++ b/droptables/Tywil_81-90_drops.yml
@@ -11,29 +11,41 @@ leechbeast_drop_items:
 twisted_roots:
   Drops:
     - twisted_roots_items 1
+    - twisted_roots_rare_drops 1
 
 twisted_roots_items:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.1
+twisted_roots_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - corrupted_roots_helmet 1 0.025
     - twisted_bark_chestplate 1 0.025
     - woodland_wraith_blade 1 0.025
+    - nothing 1 0.925
 
 thunder_beech:
   Drops:
     -shadow_rose 1 0.15
     -thunder_beech_items 1
+    -thunder_beech_rare_drops 1
 
 thunder_beech_items:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.2
+thunder_beech_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - corrupted_roots_helmet 1 0.05
     - twisted_bark_chestplate 1 0.05
     - woodland_wraith_blade 1 0.05
     - ancient_forest_belt 1 0.02
     - corrupted_heartwood_ring 1 0.02
     - twisted_vine_ornament 1 0.0075
+    - nothing 1 0.8525

--- a/droptables/brigavik_51-60_drops.yml
+++ b/droptables/brigavik_51-60_drops.yml
@@ -12,29 +12,41 @@ ShadowNorseman:
   Drops:
     # - experience 10
     - ShadowNorseman_item_drops 1
+    - ShadowNorseman_rare_drops 1
 ShadowNorseman_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.1
+ShadowNorseman_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - researcher_boots 1 0.025
     - greaves_of_void_shadow 1 0.025
     - ring_of_eternal_agony 1 0.025
     - blade_of_the_fallen_souls 1 0.025
+    - nothing 1 0.9
 
 DemonWarden:
   Drops:
     # - experience 10
     - demon_blood 1 0.2
     - DemonWarden_item_drops 1
+    - DemonWarden_rare_drops 1
 DemonWarden_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.2
+DemonWarden_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - researcher_boots 1 0.05
     - greaves_of_void_shadow 1 0.05
     - ring_of_eternal_agony 1 0.05
     - blade_of_the_fallen_souls 1 0.05
     - pendant_of_the_demonic_soul 1 0.002
     - scythe_of_shadows_doom 1 0.002
+    - nothing 1 0.796

--- a/droptables/great_desert_46-50_drops.yml
+++ b/droptables/great_desert_46-50_drops.yml
@@ -3,39 +3,52 @@ serpent_fighter:
     # - experience 10
     - serpent_fighter_item_drops 1
 serpent_fighter_item_drops:
-  MinItems: 0
-  MaxItems: 1
+  TotalItems: 1
+  BonusLuckItems: 0.15
   Drops:
     - serpent_gaze 1 0.01
     - viper_coils 1 0.01
     - scarab_helm 1 0.005
+    - nothing 1 0.975
 
 serpent_spitter:
   Drops:
     # - experience 10
     - serpent_spitter_item_drops 1
+    - serpent_spitter_rare_drops 1
 serpent_spitter_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - serpent_gaze 1 0.03
+serpent_spitter_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - viper_coils 1 0.003
     - scarab_helm 1 0.015
     - scales_of_the_serpent 1 0.005
     - scorpion_sting 1 0.005
+    - nothing 1 0.972
 
 scarab_knephre:
   Drops:
     - deaddd_bush 1 0.25
     # - experience 10
     - scarab_knephre_item_drops 1
+    - scarab_knephre_rare_drops 1
 scarab_knephre_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - serpent_gaze 1 0.08
     - viper_coils 1 0.08
+scarab_knephre_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - scarab_helm 1 0.025
     - scales_of_the_serpent 1 0.015
     - scorpion_sting 1 0.015
     - nefrit_blade 1 0.005
+    - nothing 1 0.94

--- a/droptables/mitology.yml
+++ b/droptables/mitology.yml
@@ -15,34 +15,49 @@ mobs_t1_t2_item_drops:
 t1_normal_elite_drops:
   Drops:
     - t1_normal_elite_items_drops 1
+    - t1_normal_elite_rare_drops 1
 t1_normal_elite_items_drops:
-    MinItems: 0
-    MaxItems: 1
-    Drops:
-      - ring_of_apollo_t1 1 0.01 # leg item
-      - necklace_of_athena_t1 1 0.01 # leg item
-      - adornment_of_demeter_t1 1 0.05 # extor item
-      - shield_of_dionysus_t1 1 0.05 # extor item
-      - team_relic_of_ares_t1 1 0.005 # team relict
+  MinItems: 0
+  MaxItems: 1
+  Drops:
+    - ring_of_apollo_t1 1 0.01 # leg item
+    - necklace_of_athena_t1 1 0.01 # leg item
+    - adornment_of_demeter_t1 1 0.05 # extor item
+    - shield_of_dionysus_t1 1 0.05 # extor item
+
+t1_normal_elite_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - team_relic_of_ares_t1 1 0.005 # team relict
+    - nothing 1 0.995
 
 t1_mini_boss_boss_drops:
   Drops:
     - t1_mini_boss_boss_items_drops 1
+    - t1_mini_boss_boss_rare_drops 1
 t1_mini_boss_boss_items_drops:
-    MinItems: 0
-    MaxItems: 1
-    Drops:
-      - ring_of_apollo_t1 1 0.1 # leg item
-      - necklace_of_athena_t1 1 0.1 # leg item
-      - team_relic_of_ares_t1 1 0.025 # team relict
-      - boss_heart_of_zeus_t1 1 0.01 # serce bosa
-      - hermes_boots_t1 1 0.01 # item setowy
-      - hermes_helmet_t1 1 0.01 # item setowy
+  MinItems: 0
+  MaxItems: 1
+  Drops:
+    - ring_of_apollo_t1 1 0.1 # leg item
+    - necklace_of_athena_t1 1 0.1 # leg item
+    - hermes_boots_t1 1 0.01 # item setowy
+    - hermes_helmet_t1 1 0.01 # item setowy
+
+t1_mini_boss_boss_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - team_relic_of_ares_t1 1 0.025 # team relict
+    - boss_heart_of_zeus_t1 1 0.01 # serce bosa
+    - nothing 1 0.965
 
 # T2 DROPS
 t2_normal_elite_drops:
   Drops:
     - t2_normal_elite_items_drops 1
+    - t2_normal_elite_rare_drops 1
 t2_normal_elite_items_drops:
   MinItems: 0
   MaxItems: 1
@@ -51,27 +66,41 @@ t2_normal_elite_items_drops:
     - gloves_of_hephaestus_t2 1 0.01 # leg item
     - cloak_of_helios_t2 1 0.05 # extor item
     - ring_of_artemis_t2 1 0.05 # extor item
+
+t2_normal_elite_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - team_relic_of_athena_t2 1 0.005 # team relict
+    - nothing 1 0.995
 
 t2_mini_boss_boss_drops:
   Drops:
     - t2_mini_boss_boss_items_drops 1
+    - t2_mini_boss_boss_rare_drops 1
 t2_mini_boss_boss_items_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - sword_of_ares_t2 1 0.1 # leg item
     - gloves_of_hephaestus_t2 1 0.1 # leg item
-    - team_relic_of_athena_t2 1 0.025 # team relict
-    - heart_of_poseidon_t2 1 0.01 # serce bosa
     - olympian_ring_of_power_t2 1 0.01 # item setowy
     - olympian_ring_of_vitality_t2 1 0.01 # item setowy
     - olympian_belt_of_fortune_t2 1 0.01 # item setowy
+
+t2_mini_boss_boss_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - team_relic_of_athena_t2 1 0.025 # team relict
+    - heart_of_poseidon_t2 1 0.01 # serce bosa
+    - nothing 1 0.965
 
 # T3 DROPS
 t3_normal_elite_drops:
   Drops:
     - t3_normal_elite_items_drops 1
+    - t3_normal_elite_rare_drops 1
 t3_normal_elite_items_drops:
   MinItems: 0
   MaxItems: 1
@@ -80,28 +109,42 @@ t3_normal_elite_items_drops:
     - belt_of_titans_t3 1 0.01 # leg item
     - boots_of_iris_t3 1 0.05 # extor item
     - necklace_of_hecate_t3 1 0.05 # extor item
+
+t3_normal_elite_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - team_relic_of_apollo_t3 1 0.005 # team relict
+    - nothing 1 0.995
 
 t3_mini_boss_boss_drops:
   Drops:
     - t3_mini_boss_boss_items_drops 1
+    - t3_mini_boss_boss_rare_drops 1
 t3_mini_boss_boss_items_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - leggings_of_hermes_t3 1 0.1 # leg item
     - belt_of_titans_t3 1 0.1 # leg item
-    - team_relic_of_apollo_t3 1 0.025 # team relict
-    - heart_of_hades_t3 1 0.01 # serce bosa
     - divine_chestplate_of_olympus_t3 1 0.01 # item setowy
     - divine_gloves_of_olympus_t3 1 0.01 # item setowy
     - divine_leggings_of_olympus_t3 1 0.01 # item setowy
     - divine_necklace_of_olympus_t3 1 0.01 # item setowy
 
+t3_mini_boss_boss_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - team_relic_of_apollo_t3 1 0.025 # team relict
+    - heart_of_hades_t3 1 0.01 # serce bosa
+    - nothing 1 0.965
+
 # T4 DROPS
 t4_normal_elite_drops:
   Drops:
     - t4_normal_elite_items_drops 1
+    - t4_normal_elite_rare_drops 1
 t4_normal_elite_items_drops:
   MinItems: 0
   MaxItems: 1
@@ -110,25 +153,39 @@ t4_normal_elite_items_drops:
     - ring_of_divine_power_t4 1 0.01 # leg item
     - helm_of_medusa_t4 1 0.05 # extor item
     - belt_of_prometheus_t4 1 0.05 # extor item
+
+t4_normal_elite_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - team_relic_of_hermes_t4 1 0.005 # team relict
+    - nothing 1 0.995
 
 t4_mini_boss_boss_drops:
   Drops:
     - t4_mini_boss_boss_items_drops 1
+    - t4_mini_boss_boss_rare_drops 1
 t4_mini_boss_boss_items_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - chestplate_of_ares_t4 1 0.1 # leg item
     - ring_of_divine_power_t4 1 0.1 # leg item
+    - aegis_shield_of_zeus_t4 1 0.01 # item setowy
+
+t4_mini_boss_boss_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - team_relic_of_hermes_t4 1 0.025 # team relict
     - heart_of_kronos_t4 1 0.01 # serce bosa
-    - aegis_shield_of_zeus_t4 1 0.01 # item setowy
+    - nothing 1 0.965
 
 # T5 DROPS
 t5_normal_elite_drops:
   Drops:
     - t5_normal_elite_items_drops 1
+    - t5_normal_elite_rare_drops 1
 t5_normal_elite_items_drops:
   MinItems: 0
   MaxItems: 1
@@ -137,24 +194,37 @@ t5_normal_elite_items_drops:
     - golden_sword_of_apollo_t5 1 0.01 # leg item
     - necklace_of_orion_t5 1 0.05 # extor item
     - gloves_of_atlas_t5 1 0.05 # extor item
+
+t5_normal_elite_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - team_relic_of_zeus_t5 1 0.005 # team relict
+    - nothing 1 0.995
 
 t5_mini_boss_boss_drops:
   Drops:
     - t5_mini_boss_boss_items_drops 1
+    - t5_mini_boss_boss_rare_drops 1
 t5_mini_boss_boss_items_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - cloak_of_heracles_t5 1 0.1 # leg item
     - golden_sword_of_apollo_t5 1 0.1 # leg item
-    - team_relic_of_zeus_t5 1 0.025 # team relict
-    - heart_of_olympus_t5 1 0.01 # serce bosa
     - titan_ring_of_destruction_t5 1 0.01 # item setowy
     - titan_ring_of_vitality_t5 1 0.01 # item setowy
     - titan_necklace_of_supremacy_t5 1 0.01 # item setowy
     - titan_gloves_of_fortress_t5 1 0.01 # item setowy
     - titan_weapon_adornment_t5 1 0.01 # item setowy
+
+t5_mini_boss_boss_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
+    - team_relic_of_zeus_t5 1 0.025 # team relict
+    - heart_of_olympus_t5 1 0.01 # serce bosa
+    - nothing 1 0.965
 
 mobs_t3_t4_drops:
   Drops:

--- a/droptables/nahuatlan_41-45_drops.yml
+++ b/droptables/nahuatlan_41-45_drops.yml
@@ -3,40 +3,53 @@ mummy:
     # - experience 10
     - mummy_item_drops 1
 mummy_item_drops:
-  MinItems: 0
-  MaxItems: 1
+  TotalItems: 1
+  BonusLuckItems: 0.15
   Drops:
     - entangled_trausers 1 0.01
     - twilight_chestplate 1 0.01
     - rotten_fang 1 0.005
     - helm_of_the_lost 1 0.005
+    - nothing 1 0.97
 
 crushing:
   Drops:
     # - experience 10
     - crushing_item_drops 1
+    - crushing_rare_drops 1
 crushing_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - entangled_trausers 1 0.03
+crushing_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - twilight_chestplate 1 0.003
     - rotten_fang 1 0.015
     - helm_of_the_lost 1 0.015
     - wraith_stalkers 1 0.005
+    - nothing 1 0.962
 
 protector:
   Drops:
     - protectors_heart 1 0.25
     # - experience 10
     - protector_item_drops 1
+    - protector_rare_drops 1
 protector_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - entangled_trausers 1 0.08
     - twilight_chestplate 1 0.08
+protector_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - rotten_fang 1 0.025
     - helm_of_the_lost 1 0.025
     - wraith_stalkers 1 0.015
     - dark_whisper 1 0.005
+    - nothing 1 0.93

--- a/droptables/telepolos_71-80_drops.yml
+++ b/droptables/telepolos_71-80_drops.yml
@@ -13,25 +13,38 @@ soul_collector_telepolos:
     - soul_of_an_acient_spartan 1 0.15
     # - experience 10
     - soul_collector_telepolos_item_drops 1
+    - soul_collector_telepolos_rare_drops 1
 soul_collector_telepolos_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.2
+soul_collector_telepolos_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - aegis_striders 1 0.05
     - phalanx_blade 1 0.05
     - dory_gauntlet 1 0.05
     - sandal_blade 1 0.02
     - hoplon_reaver 1 0.02
+    - nothing 1 0.8
 
 elite_telepolos:
   drops:
     -elite_telepolos_item_drops 1
+    -elite_telepolos_rare_drops 1
 elite_telepolos_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.1
+elite_telepolos_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - aegis_striders 1 0.025
     - phalanx_blade 1 0.025
     - dory_gauntlet 1 0.025
+    - nothing 1 0.925
+

--- a/droptables/temple_sector_31-35_drops.yml
+++ b/droptables/temple_sector_31-35_drops.yml
@@ -3,43 +3,56 @@ gorgon:
     # - experience 10
     - gorgon_item_drops 1
 gorgon_item_drops:
-  MinItems: 0
-  MaxItems: 1
+  TotalItems: 1
+  BonusLuckItems: 0.15
   Drops:
     - mermans_boots 1 0.01
     - nautilus_helm 1 0.01
     - abyssal_leggings 1 0.005
     - trident_blade 1 0.005
+    - nothing 1 0.97
 
 gorgon_heretic:
   Drops:
     # - experience 10
     - gorgon_heretic_item_drops 1
+    - gorgon_heretic_rare_drops 1
 gorgon_heretic_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - mermans_boots 1 0.03
+gorgon_heretic_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - nautilus_helm 1 0.003
     - abyssal_leggings 1 0.015
     - trident_blade 1 0.015
     - coral_guardian_chestplate 1 0.005
     - tidal_crown 1 0.005
+    - nothing 1 0.957
 
 high_priest_baran:
   Drops:
     # - experience 10
     - gorgons_poison 1 0.25
     - high_priest_baran_item_drops 1
+    - high_priest_baran_rare_drops 1
 high_priest_baran_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - mermans_boots 1 0.08
     - nautilus_helm 1 0.08
+high_priest_baran_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - abyssal_leggings 1 0.025
     - trident_blade 1 0.025
     - coral_guardian_chestplate 1 0.015
     - tidal_crown 1 0.015
     - ancient_fury 1 0.005
     - sea_emperor_greaves 1 0.005
+    - nothing 1 0.91

--- a/droptables/tetanocetl_61-70.yml
+++ b/droptables/tetanocetl_61-70.yml
@@ -12,29 +12,41 @@ teta_shaman:
   Drops:
     # - experience 10
     - teta_shaman_item_drops 1
+    - teta_shaman_rare_drops 1
 teta_shaman_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.1
+teta_shaman_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - armor_of_elder_tree 1 0.025
     - steps_of_elder_deity 1 0.025
     - cloak_of_spirit_hunter 1 0.025
     - spear_of_sacred_oak 1 0.025
+    - nothing 1 0.9
 
 orbax:
   Drops:
     - sticky_mucus 1 0.2
     # - experience 10
     - orbax_item_drops 1
+    - orbax_rare_drops 1
 orbax_item_drops:
   MinItems: 0
   MaxItems: 1
   Drops:
     - ips 1 0.2
+orbax_rare_drops:
+  TotalItems: 1
+  BonusLuckItems: 0.15
+  Drops:
     - armor_of_elder_tree 1 0.05
     - steps_of_elder_deity 1 0.05
     - cloak_of_spirit_hunter 1 0.05
     - spear_of_sacred_oak 1 0.05
     - ring_of_eternal_grove 1 0.02
     - mask_of_the_ancient_watcher 1 0.02
+    - nothing 1 0.76


### PR DESCRIPTION
## Summary
- add BonusLuckItems: 0.15 rare-drop wrappers to world tier loot tables so Luck scales unique and mythic items without inflating common rewards
- convert single-pool rare tables to TotalItems-based luck rolls with nothing fillers to preserve baseline drop rates

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68d64dac0e30832aa49e161341f4a763