### PR TITLE
Adjust unique and mythic drop odds across Q1-Q10

### DIFF
--- a/droptables/Q10_drops.yml
+++ b/droptables/Q10_drops.yml
@@ -242,8 +242,7 @@ anderworld_jitterjelly_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 anderworld_jabbax_hell_drop:
   Drops:
@@ -262,8 +261,7 @@ anderworld_jabbax_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 combat_ready_zorlobb_hell_drop:
   Drops:
@@ -282,8 +280,7 @@ combat_ready_zorlobb_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 armed_khaross_hell_drop:
   Drops:
@@ -302,8 +299,7 @@ armed_khaross_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 mordacious_khaross_hell_drop:
   Drops:
@@ -322,8 +318,7 @@ mordacious_khaross_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 scheming_gorgon_hell_drop:
   Drops:
@@ -342,8 +337,7 @@ scheming_gorgon_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 poisonous_jitterjelly_hell_drop:
   Drops:
@@ -362,8 +356,7 @@ poisonous_jitterjelly_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 patrolling_jabbax_hell_drop:
   Drops:
@@ -382,8 +375,7 @@ patrolling_jabbax_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 melas_hell_drop:
   Drops:
@@ -460,8 +452,7 @@ anderworld_jitterjelly_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 anderworld_jabbax_blood_drop:
   Drops:
@@ -480,8 +471,7 @@ anderworld_jabbax_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 combat_ready_zorlobb_blood_drop:
   Drops:
@@ -500,8 +490,7 @@ combat_ready_zorlobb_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 armed_khaross_blood_drop:
   Drops:
@@ -520,8 +509,7 @@ armed_khaross_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 mordacious_khaross_blood_drop:
   Drops:
@@ -540,8 +528,7 @@ mordacious_khaross_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 scheming_gorgon_blood_drop:
   Drops:
@@ -560,8 +547,7 @@ scheming_gorgon_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 poisonous_jitterjelly_blood_drop:
   Drops:
@@ -580,8 +566,7 @@ poisonous_jitterjelly_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 patrolling_jabbax_blood_drop:
   Drops:
@@ -600,8 +585,7 @@ patrolling_jabbax_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - ring_of_renewal_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 melas_blood_drop:
   Drops:

--- a/droptables/Q1_drops.yml
+++ b/droptables/Q1_drops.yml
@@ -61,7 +61,6 @@ grimmag_inf:
     - ips 1 1
     - grimmag_inf_item_drops 1
     - grimmag_inf_rare_drops 1
-    - q1_soul_luck 1
 grimmag_inf_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -95,10 +94,7 @@ flamecult_servant_hell_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_hell 1 0.002
-   # - grimmags_flaming_wrath 1 0.00075
-    #- fiery_tracks_of_grimmag 1 0.00075
-    - nothing 1 0.9965
+    - nothing 1 1
 
 flamecult_worshipper_hell:
   Drops:
@@ -116,10 +112,7 @@ flamecult_worshipper_hell_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_hell 1 0.012
-    #- grimmags_flaming_wrath 1 0.003
-   # - fiery_tracks_of_grimmag 1 0.003
-    - nothing 1 0.982
+    - nothing 1 1
 
 raazghul_the_corruptor_hell:
   Drops:
@@ -137,10 +130,9 @@ raazghul_the_corruptor_hell_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_hell 1 0.03
-    - grimmags_flaming_wrath 1 0.007
-    - fiery_tracks_of_grimmag 1 0.007
-    - nothing 1 0.956
+    - grimmags_flaming_wrath 1 0.00625
+    - fiery_tracks_of_grimmag 1 0.00625
+    - nothing 1 0.9875
 
 grimmag_hell:
   Drops:
@@ -148,7 +140,6 @@ grimmag_hell:
     - ips 2 1
     - grimmag_hell_item_drops 1
     - grimmag_hell_rare_drops 1
-    - q1_soul_luck 1
 grimmag_hell_item_drops:
   MinItems: 0
   MaxItems: 3
@@ -160,10 +151,9 @@ grimmag_hell_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_hell 1 0.05
-    - grimmags_flaming_wrath 1 0.02
-    - fiery_tracks_of_grimmag 1 0.02
-    - nothing 1 0.91
+    - grimmags_flaming_wrath 1 0.0125
+    - fiery_tracks_of_grimmag 1 0.0125
+    - nothing 1 0.975
 
 # BLOOD BLOOD BLOOD
 # BLOOD BLOOD BLOOD
@@ -184,11 +174,7 @@ flamecult_servant_blood_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_bloodshed 1 0.004
-    #- grimmags_flaming_wrath_bloodshed 1 0.001
-    #- fiery_tracks_of_grimmag_bloodshed 1 0.001
-   # - fyrgons_ring_of_fire 1 0.0005
-    - nothing 1 0.9935
+    - nothing 1 1
 
 flamecult_worshipper_blood:
   Drops:
@@ -206,11 +192,7 @@ flamecult_worshipper_blood_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_bloodshed 1 0.015
-    #- grimmags_flaming_wrath_bloodshed 1 0.004
-    # fiery_tracks_of_grimmag_bloodshed 1 0.004
-    #- fyrgons_ring_of_fire 1 0.001
-    - nothing 1 0.976
+    - nothing 1 1
 
 raazghul_the_corruptor_blood:
   Drops:
@@ -228,11 +210,10 @@ raazghul_the_corruptor_blood_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_bloodshed 1 0.04
-    - grimmags_flaming_wrath_bloodshed 1 0.01
-    - fiery_tracks_of_grimmag_bloodshed 1 0.01
-    - fyrgons_ring_of_fire 1 0.002
-    - nothing 1 0.938
+    - grimmags_flaming_wrath_bloodshed 1 0.0125
+    - fiery_tracks_of_grimmag_bloodshed 1 0.0125
+    - fyrgons_ring_of_fire 1 0.001
+    - nothing 1 0.974
 
 grimmag_blood:
   Drops:
@@ -252,11 +233,10 @@ grimmag_blood_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - cuchulains_battle_armor_bloodshed 1 0.08
-    - grimmags_flaming_wrath_bloodshed 1 0.03
-    - fiery_tracks_of_grimmag_bloodshed 1 0.03
+    - grimmags_flaming_wrath_bloodshed 1 0.025
+    - fiery_tracks_of_grimmag_bloodshed 1 0.025
     - fyrgons_ring_of_fire 1 0.01
-    - nothing 1 0.85
+    - nothing 1 0.94
 
 q1_soul_luck:
   TotalItems: 1

--- a/droptables/Q2_drops.yml
+++ b/droptables/Q2_drops.yml
@@ -102,8 +102,7 @@ gremlin_marauder_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_ring_of_poison_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 corrupted_root_creature_hell_drop:
   Drops:
@@ -122,8 +121,7 @@ corrupted_root_creature_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_ring_of_poison_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 xerib_the_hunchback_hell_drop:
   Drops:
@@ -182,8 +180,7 @@ gremlin_marauder_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_ring_of_poison_bloodshed 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 corrupted_root_creature_blood_drop:
   Drops:
@@ -202,8 +199,7 @@ corrupted_root_creature_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_ring_of_poison_bloodshed 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 xerib_the_hunchback_blood_drop:
   Drops:

--- a/droptables/Q3_drops.yml
+++ b/droptables/Q3_drops.yml
@@ -202,8 +202,7 @@ cursed_farmer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 cursed_archer_hell_drop:
   Drops:
@@ -222,8 +221,7 @@ cursed_archer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 slain_warrior_hell_drop:
   Drops:
@@ -242,8 +240,7 @@ slain_warrior_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 slain_archer_hell_drop:
   Drops:
@@ -262,8 +259,7 @@ slain_archer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 cursed_troll_hell_drop:
   Drops:
@@ -282,8 +278,7 @@ cursed_troll_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 slain_assassin_hell_drop:
   Drops:
@@ -302,8 +297,7 @@ slain_assassin_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 parallel_world_evil_miller_hell_drop:
   Drops:
@@ -380,8 +374,7 @@ cursed_farmer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 cursed_archer_blood_drop:
   Drops:
@@ -400,8 +393,7 @@ cursed_archer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 slain_warrior_blood_drop:
   Drops:
@@ -420,8 +412,7 @@ slain_warrior_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 slain_archer_blood_drop:
   Drops:
@@ -440,8 +431,7 @@ slain_archer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 cursed_troll_blood_drop:
   Drops:
@@ -460,8 +450,7 @@ cursed_troll_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 slain_assassin_blood_drop:
   Drops:
@@ -480,8 +469,7 @@ slain_assassin_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - agathons_ring_of_order_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 parallel_world_evil_miller_blood_drop:
   Drops:

--- a/droptables/Q4_drops.yml
+++ b/droptables/Q4_drops.yml
@@ -142,8 +142,7 @@ sanguine_clan_raging_guardian_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 raging_hunting_hound_hell_drop:
   Drops:
@@ -162,8 +161,7 @@ raging_hunting_hound_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 sanguine_clan_raging_snooper_hell_drop:
   Drops:
@@ -182,8 +180,7 @@ sanguine_clan_raging_snooper_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 sanguine_hunter_hell_drop:
   Drops:
@@ -202,8 +199,7 @@ sanguine_hunter_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 ancient_stag_hell_drop:
   Drops:
@@ -262,8 +258,7 @@ sanguine_clan_raging_guardian_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 raging_hunting_hound_blood_drop:
   Drops:
@@ -282,8 +277,7 @@ raging_hunting_hound_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 sanguine_clan_raging_snooper_blood_drop:
   Drops:
@@ -302,8 +296,7 @@ sanguine_clan_raging_snooper_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 sanguine_hunter_blood_drop:
   Drops:
@@ -322,8 +315,7 @@ sanguine_hunter_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - artayas_cape_of_life_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 ancient_stag_blood_drop:
   Drops:

--- a/droptables/Q5_drops.yml
+++ b/droptables/Q5_drops.yml
@@ -222,8 +222,7 @@ furious_maggot_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 furious_flagrancy_hell_drop:
   Drops:
@@ -242,8 +241,7 @@ furious_flagrancy_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 living_andermagic_hell_drop:
   Drops:
@@ -262,8 +260,7 @@ living_andermagic_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 andermagic_guardian_hell_drop:
   Drops:
@@ -282,8 +279,7 @@ andermagic_guardian_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 furious_andermagic_hell_drop:
   Drops:
@@ -302,8 +298,7 @@ furious_andermagic_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 wailing_ghost_hell_drop:
   Drops:
@@ -322,8 +317,7 @@ wailing_ghost_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 andermagic_scoropitl_hell_drop:
   Drops:
@@ -342,8 +336,7 @@ andermagic_scoropitl_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 old_jabbax_shaman_hell_drop:
   Drops:
@@ -420,8 +413,7 @@ furious_maggot_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 furious_flagrancy_blood_drop:
   Drops:
@@ -440,8 +432,7 @@ furious_flagrancy_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 living_andermagic_blood_drop:
   Drops:
@@ -460,8 +451,7 @@ living_andermagic_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 andermagic_guardian_blood_drop:
   Drops:
@@ -480,8 +470,7 @@ andermagic_guardian_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 furious_andermagic_blood_drop:
   Drops:
@@ -500,8 +489,7 @@ furious_andermagic_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 wailing_ghost_blood_drop:
   Drops:
@@ -520,8 +508,7 @@ wailing_ghost_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 andermagic_scoropitl_blood_drop:
   Drops:
@@ -540,8 +527,7 @@ andermagic_scoropitl_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - khalys_dark_gaze_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 old_jabbax_shaman_blood_drop:
   Drops:

--- a/droptables/Q6_drops.yml
+++ b/droptables/Q6_drops.yml
@@ -244,8 +244,7 @@ fallen_warrior_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 fallen_archer_hell_drop:
   Drops:
@@ -266,8 +265,7 @@ fallen_archer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 raging_soul_hell_drop:
   Drops:
@@ -288,8 +286,7 @@ raging_soul_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 elite_skeleton_archer_hell_drop:
   Drops:
@@ -310,8 +307,7 @@ elite_skeleton_archer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 elite_skeleton_warrior_hell_drop:
   Drops:
@@ -332,8 +328,7 @@ elite_skeleton_warrior_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 death_knight_hell_drop:
   Drops:
@@ -354,8 +349,7 @@ death_knight_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 death_archer_hell_drop:
   Drops:
@@ -376,8 +370,7 @@ death_archer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 mortis_death_knight_hell_drop:
   Drops:
@@ -472,8 +465,7 @@ fallen_warrior_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 fallen_archer_blood_drop:
   Drops:
@@ -494,8 +486,7 @@ fallen_archer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 raging_soul_blood_drop:
   Drops:
@@ -516,8 +507,7 @@ raging_soul_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 elite_skeleton_archer_blood_drop:
   Drops:
@@ -538,8 +528,7 @@ elite_skeleton_archer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 elite_skeleton_warrior_blood_drop:
   Drops:
@@ -560,8 +549,7 @@ elite_skeleton_warrior_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 death_knight_blood_drop:
   Drops:
@@ -582,8 +570,7 @@ death_knight_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 death_archer_blood_drop:
   Drops:
@@ -604,8 +591,7 @@ death_archer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - mortis_ring_of_death_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 mortis_death_knight_blood_drop:
   Drops:

--- a/droptables/Q7_drops.yml
+++ b/droptables/Q7_drops.yml
@@ -245,8 +245,7 @@ bone_warder_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 b1000_combat_mechanoid_hell_drop:
   Drops:
@@ -265,8 +264,7 @@ b1000_combat_mechanoid_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 thundering_cyclops_hell_drop:
   Drops:
@@ -285,8 +283,7 @@ thundering_cyclops_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 dark_sentinel_hell_drop:
   Drops:
@@ -305,8 +302,7 @@ dark_sentinel_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 gate_guard_hell_drop:
   Drops:
@@ -344,8 +340,7 @@ razorclaw_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 flamescale_hell_drop:
   Drops:
@@ -364,8 +359,7 @@ flamescale_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 fireclaw_hell_drop:
   Drops:
@@ -384,8 +378,7 @@ fireclaw_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 flamespawn_hell_drop:
   Drops:
@@ -404,8 +397,7 @@ flamespawn_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 commander_hell_drop:
   Drops:
@@ -465,8 +457,7 @@ bone_warder_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 b1000_combat_mechanoid_blood_drop:
   Drops:
@@ -485,8 +476,7 @@ b1000_combat_mechanoid_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 thundering_cyclops_blood_drop:
   Drops:
@@ -566,8 +556,7 @@ razorclaw_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 flamescale_blood_drop:
   Drops:
@@ -586,8 +575,7 @@ flamescale_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 fireclaw_blood_drop:
   Drops:
@@ -606,8 +594,7 @@ fireclaw_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 flamespawn_blood_drop:
   Drops:
@@ -626,8 +613,7 @@ flamespawn_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fyrgons_fire_belt_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 commander_blood_drop:
   Drops:

--- a/droptables/Q8_drops.yml
+++ b/droptables/Q8_drops.yml
@@ -245,8 +245,7 @@ electrified_ferocity_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 charged_drone_hell_drop:
   Drops:
@@ -265,8 +264,7 @@ charged_drone_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 big_heap_hell_drop:
   Drops:
@@ -285,8 +283,7 @@ big_heap_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 frostwolf_hell_drop:
   Drops:
@@ -305,8 +302,7 @@ frostwolf_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 shocking_forocity_hell_drop:
   Drops:
@@ -344,8 +340,7 @@ pale_pillager_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 simple_troll_hell_drop:
   Drops:
@@ -364,8 +359,7 @@ simple_troll_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 frost_magician_hell_drop:
   Drops:
@@ -384,8 +378,7 @@ frost_magician_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 frost_bringer_hell_drop:
   Drops:
@@ -404,8 +397,7 @@ frost_bringer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 pale_enforcer_hell_drop:
   Drops:
@@ -465,8 +457,7 @@ electrified_ferocity_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 charged_drone_blood_drop:
   Drops:
@@ -485,8 +476,7 @@ charged_drone_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 big_heap_blood_drop:
   Drops:
@@ -565,8 +555,7 @@ pale_pillager_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 simple_troll_blood_drop:
   Drops:
@@ -585,8 +574,7 @@ simple_troll_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 frost_magician_blood_drop:
   Drops:
@@ -605,8 +593,7 @@ frost_magician_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 frost_bringer_blood_drop:
   Drops:
@@ -625,8 +612,7 @@ frost_bringer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - fjalnirs_ring_of_frost_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 pale_enforcer_blood_drop:
   Drops:

--- a/droptables/Q9_drops.yml
+++ b/droptables/Q9_drops.yml
@@ -245,8 +245,7 @@ agile_satyr_warrior_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 perfidious_satyr_archer_hell_drop:
   Drops:
@@ -265,8 +264,7 @@ perfidious_satyr_archer_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 cohort_swordsman_hell_drop:
   Drops:
@@ -285,8 +283,7 @@ cohort_swordsman_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 stone_golem_hell_drop:
   Drops:
@@ -305,8 +302,7 @@ stone_golem_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 asterion_hell_drop:
   Drops:
@@ -344,8 +340,7 @@ jabbax_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 zorlobb_warrior_hell_drop:
   Drops:
@@ -364,8 +359,7 @@ zorlobb_warrior_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 gorgon_acolyte_hell_drop:
   Drops:
@@ -384,8 +378,7 @@ gorgon_acolyte_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.001
-    - nothing 1 0.999
+    - nothing 1 1
 
 minotaur_hell_drop:
   Drops:
@@ -404,8 +397,7 @@ minotaur_hell_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_hell 1 0.02
-    - nothing 1 0.98
+    - nothing 1 1
 
 ebicarus_hell_drop:
   Drops:
@@ -465,8 +457,7 @@ agile_satyr_warrior_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 perfidious_satyr_archer_blood_drop:
   Drops:
@@ -485,8 +476,7 @@ perfidious_satyr_archer_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 cohort_swordsman_blood_drop:
   Drops:
@@ -565,8 +555,7 @@ jabbax_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 zorlobb_warrior_blood_drop:
   Drops:
@@ -585,8 +574,7 @@ zorlobb_warrior_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 gorgon_acolyte_blood_drop:
   Drops:
@@ -605,8 +593,7 @@ gorgon_acolyte_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_blood 1 0.005
-    - nothing 1 0.995
+    - nothing 1 1
 
 minotaur_blood_drop:
   Drops:
@@ -625,8 +612,7 @@ minotaur_blood_drop_rare_drops:
   TotalItems: 1
   BonusLuckItems: 0.15
   Drops:
-    - oceanus_poison_crown_blood 1 0.03
-    - nothing 1 0.97
+    - nothing 1 1
 
 ebicarus_blood_drop:
   Drops:


### PR DESCRIPTION
## Summary
- Align Q1 hell and blood rare drops so only bosses and mini-bosses can award unique or mythic items at the requested rates
- Strip legendary loot from Q2–Q10 rare drop tables so standard mobs now only roll "nothing" while preserving the intended unique/mythic chances on elites and bosses
- Ensure boss soul rolls remain exclusive to blood bosses at the 1% drop rate

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69839c868832abb0eacd59ae7de2e