### PR TITLE
Add Bloodborne mobs and shared bleed skills

### DIFF
--- a/mobs/bloodborne.yml
+++ b/mobs/bloodborne.yml
@@ -1,0 +1,83 @@
+# =========================
+#  MOBS
+# =========================
+
+blood_sludge:
+  Type: SLIME
+  Display: '&4&lBlood Sludge &r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Health: 50000
+  Damage: 18
+  Options:
+    Size: 6
+    FollowRange: 18
+    ShowHealth: true
+    AlwaysShowName: true
+    PreventItemPickup: true
+    PreventOtherDrops: true
+    PreventRandomEquipment: true
+    PreventSunburn: true
+    PreventJockeyMounts: true
+    PreventTransformation: true
+    MovementSpeed: '0.06'     # ledwo się rusza
+  Faction: Bloodborne
+  Group: Bloodborne
+  # Atak nakłada krwawienie % HP celu; co jakiś czas strzela pociskiem ze spowolnieniem
+  Skills:
+    - skill{s=BleedMaxHP2p} @target ~onAttack
+    - skill{s=BloodSpit} @target ~onTimer:100 ?incombat
+    - setname{name="<caster.name>";delay=2} @self ~onDamaged
+    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  Drops:
+    - normal_mobs_drops
+
+blood_sludgeling:
+  Type: SLIME
+  Display: '&f&lBlood Sludgeling &r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Health: 6500
+  Damage: 8
+  Options:
+    Size: 2
+    FollowRange: 16
+    ShowHealth: true
+    AlwaysShowName: true
+    PreventItemPickup: true
+    PreventOtherDrops: true
+    PreventRandomEquipment: true
+    PreventSunburn: true
+    PreventJockeyMounts: true
+    PreventTransformation: true
+    MovementSpeed: '0.18'
+  Faction: Bloodborne
+  Group: Bloodborne
+  Skills:
+    - skill{s=BleedMaxHP1p} @target ~onAttack
+    - skill{s=BloodSpit} @target ~onTimer:160 ?incombat
+    - setname{name="<caster.name>";delay=2} @self ~onDamaged
+    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  Drops:
+    - normal_mobs_drops
+
+blood_leech:
+  Type: SILVERFISH
+  Display: '&f&lBlood Leech &r &r&r&7[&c<caster.hp{round=1}>&7/&c<caster.mhp>&7] &4<&heart>'
+  Health: 2200
+  Damage: 5
+  Options:
+    FollowRange: 20
+    ShowHealth: true
+    AlwaysShowName: true
+    PreventItemPickup: true
+    PreventOtherDrops: true
+    PreventRandomEquipment: true
+    PreventSunburn: true
+    PreventJockeyMounts: true
+    PreventTransformation: true
+    MovementSpeed: '0.23'
+  Faction: Bloodborne
+  Group: Bloodborne
+  Skills:
+    - skill{s=BleedMaxHP1p} @target ~onAttack
+    - setname{name="<caster.name>";delay=2} @self ~onDamaged
+    - setname{name="<caster.name>";delay=2} @self ~onTimer:10 ?incombat
+  Drops:
+    - normal_mobs_drops

--- a/skills/bloodborne.yml
+++ b/skills/bloodborne.yml
@@ -1,0 +1,31 @@
+# =========================
+#  SKILLE WSPÓLNE
+# =========================
+Skills:
+  BleedMaxHP2p: # Krwawienie: 5% max HP celu co 1s przez 5s
+    Skills:
+      - repeat{times=5;interval=20} @target
+      - damage{amount="<target.mhp>*0.05";ia=true} @target
+      - effect:particles{p=reddust;amount=10;speed=0.1;hS=0.2;vS=0.2} @target
+      - sound{s=entity.player.hurt;v=0.6;p=0.8} @target
+
+  BleedMaxHP1p: # Delikatniejsze krwawienie: 1% max HP celu co 1s przez 5s
+    Skills:
+      - repeat{times=5;interval=20} @target
+      - damage{amount="<target.mhp>*0.02";ia=true} @target
+      - effect:particles{p=reddust;amount=6;speed=0.05;hS=0.2;vS=0.2} @target
+
+  BloodSpit: # Pocisk: obrażenia + bardzo duże spowolnienie
+    Skills:
+      - projectile{v=18;i=1;hR=1;vR=1;hnp=true;onHit=BloodSpit_Hit;onTick=BloodSpit_Tick} @target
+
+  BloodSpit_Hit:
+    Skills:
+      - damage{amount=45} @target
+      - potion{type=SLOW;duration=160;level=7} @target   # bardzo duże spowolnienie (ok. Slowness VIII)
+      - effect:particles{p=block_crack;m=redstone_block;amount=24;speed=0.2;hS=0.3;vS=0.3} @target
+      - sound{s=entity.slime.attack;v=1.0;p=0.6} @target
+
+  BloodSpit_Tick:
+    Skills:
+      - effect:particles{p=reddust;amount=2;speed=0.01;hS=0.05;vS=0.05} @origin


### PR DESCRIPTION
## Summary
- add shared Bloodborne bleed and projectile skills for new enemies
- define Blood Sludge, Blood Sludgeling, and Blood Leech mobs with appropriate behaviors and drops

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69fe821f8832a8a681b18638f7ed7